### PR TITLE
feat: AWSエンリッチメント機能を実装

### DIFF
--- a/__tests__/enrichers/aws.test.ts
+++ b/__tests__/enrichers/aws.test.ts
@@ -1,0 +1,223 @@
+/**
+ * AWSEnricher テスト
+ */
+
+import { AWSEnricher } from '../../lib/enrichers/aws';
+
+describe('AWSEnricher', () => {
+  let enricher: AWSEnricher;
+
+  beforeEach(() => {
+    enricher = new AWSEnricher();
+  });
+
+  describe('canHandle', () => {
+    it('AWSのURLを正しく判定できること', () => {
+      expect(enricher.canHandle('https://aws.amazon.com/blogs/compute/new-feature')).toBe(true);
+      expect(enricher.canHandle('https://aws.amazon.com/jp/blogs/news/article')).toBe(true);
+      expect(enricher.canHandle('https://aws.amazon.com/about-aws/whats-new/2025/01/feature')).toBe(true);
+    });
+
+    it('AWS以外のURLを拒否すること', () => {
+      expect(enricher.canHandle('https://cloud.google.com/blog/article')).toBe(false);
+      expect(enricher.canHandle('https://azure.microsoft.com/blog')).toBe(false);
+      expect(enricher.canHandle('https://example.com/article')).toBe(false);
+    });
+  });
+
+  describe('enrich', () => {
+    // fetchをモック化するためのヘルパー
+    const mockFetch = (html: string, status = 200) => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: status === 200,
+        status,
+        text: jest.fn().mockResolvedValue(html),
+      } as any);
+    };
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('AWS Blogの記事から正しくコンテンツを抽出できること', () => {
+      const mockHtml = `
+        <html>
+          <head>
+            <title>AWS Blog Post</title>
+            <meta property="og:image" content="https://aws.amazon.com/image.jpg" />
+          </head>
+          <body>
+            <header>Navigation</header>
+            <main>
+              <article>
+                <div class="blog-post-content">
+                  <p>This is a comprehensive AWS blog post about new features in Amazon EC2.</p>
+                  <p>Amazon Web Services (AWS) continues to innovate and provide new capabilities for developers and organizations worldwide.</p>
+                  <p>Today, we're excited to announce several new features that will help you build more scalable and resilient applications.</p>
+                  <p>The new EC2 instance types offer improved performance and cost efficiency. These instances are optimized for compute-intensive workloads.</p>
+                  <p>With enhanced networking capabilities, you can achieve up to 100 Gbps of network performance, enabling faster data transfer between instances.</p>
+                  <p>Additionally, the new instances support the latest generation of Intel and AMD processors, providing better performance per dollar.</p>
+                  <p>We've also improved the Auto Scaling service with predictive scaling capabilities that use machine learning to forecast traffic patterns.</p>
+                  <p>This feature helps you maintain optimal performance while minimizing costs by automatically adjusting capacity based on predicted demand.</p>
+                  <p>Security enhancements include improved encryption options and integration with AWS Key Management Service for better key rotation.</p>
+                  <p>The new features are available in all AWS regions starting today. You can start using them immediately through the AWS Management Console.</p>
+                </div>
+              </article>
+            </main>
+            <footer>AWS Footer</footer>
+          </body>
+        </html>
+      `;
+
+      mockFetch(mockHtml);
+
+      return enricher.enrich('https://aws.amazon.com/blogs/compute/test-article').then(result => {
+        expect(result).not.toBeNull();
+        expect(result!.content).not.toBeNull();
+        expect(result!.content!.length).toBeGreaterThan(500);
+        expect(result!.content).toContain('AWS blog post');
+        expect(result!.content).toContain('Amazon EC2');
+        expect(result!.content).not.toContain('Navigation');
+        expect(result!.content).not.toContain('AWS Footer');
+        expect(result!.thumbnail).toBe('https://aws.amazon.com/image.jpg');
+      });
+    });
+
+    it('What\'s Newの記事から正しくコンテンツを抽出できること', () => {
+      const mockHtml = `
+        <html>
+          <body>
+            <div class="whatsnew-content">
+              <p>AWS announces a new feature for Amazon RDS that enables automated database backups with point-in-time recovery.</p>
+              <p>This feature provides continuous backups of your database, allowing you to restore to any point within your retention period.</p>
+              <p>The automated backups are stored in Amazon S3 and are encrypted using AWS Key Management Service (KMS) keys.</p>
+              <p>You can configure the backup retention period from 1 to 35 days, depending on your compliance and recovery requirements.</p>
+              <p>The feature supports all RDS database engines including MySQL, PostgreSQL, MariaDB, Oracle, and SQL Server.</p>
+              <p>Point-in-time recovery allows you to restore your database to any second during your retention period, up to the last 5 minutes.</p>
+              <p>This capability is essential for disaster recovery and helps meet regulatory compliance requirements for data retention.</p>
+              <p>The feature is now available in all commercial AWS regions at no additional charge for backup storage up to the size of your database.</p>
+            </div>
+          </body>
+        </html>
+      `;
+
+      mockFetch(mockHtml);
+
+      return enricher.enrich('https://aws.amazon.com/about-aws/whats-new/test').then(result => {
+        expect(result).not.toBeNull();
+        expect(result!.content).not.toBeNull();
+        expect(result!.content!.length).toBeGreaterThan(500);
+        expect(result!.content).toContain('Amazon RDS');
+        expect(result!.content).toContain('automated database backups');
+      });
+    });
+
+    it('複数のセレクタを試して段落を収集できること', () => {
+      const mockHtml = `
+        <html>
+          <body>
+            <div class="some-other-container">
+              <p>Amazon Web Services introduces new capabilities for serverless computing with AWS Lambda.</p>
+              <p>The new features include improved cold start performance and support for container images up to 10 GB.</p>
+              <p>Lambda now supports provisioned concurrency, which keeps functions initialized and ready to respond immediately.</p>
+              <p>This eliminates cold start latency for critical applications that require consistent performance.</p>
+              <p>The container image support allows developers to package and deploy Lambda functions as container images.</p>
+              <p>This makes it easier to use existing container tooling and workflows with serverless applications.</p>
+              <p>Additionally, Lambda now integrates with Amazon EFS, enabling functions to access shared file systems.</p>
+              <p>These enhancements make Lambda more suitable for a wider range of workloads including ML inference and data processing.</p>
+              <p>The new features are available in all regions where Lambda is supported, with pricing based on usage.</p>
+              <p>To get started, visit the Lambda console or use the AWS CLI to create functions with these new capabilities.</p>
+            </div>
+          </body>
+        </html>
+      `;
+
+      mockFetch(mockHtml);
+
+      return enricher.enrich('https://aws.amazon.com/blogs/test-fallback').then(result => {
+        expect(result).not.toBeNull();
+        expect(result!.content).not.toBeNull();
+        expect(result!.content!.length).toBeGreaterThan(500);
+        expect(result!.content).toContain('AWS Lambda');
+        expect(result!.content).toContain('serverless computing');
+      });
+    });
+
+    it('コンテンツが不足している場合はnullを返すこと', () => {
+      const shortHtml = `
+        <html>
+          <body>
+            <div class="blog-post-content">
+              <p>Short content.</p>
+            </div>
+          </body>
+        </html>
+      `;
+
+      mockFetch(shortHtml);
+
+      return enricher.enrich('https://aws.amazon.com/blogs/short-article').then(result => {
+        expect(result).toBeNull();
+      });
+    });
+
+    it('HTTPエラー時はnullを返すこと', () => {
+      mockFetch('', 404);
+
+      return enricher.enrich('https://aws.amazon.com/blogs/not-found').then(result => {
+        expect(result).toBeNull();
+      });
+    });
+
+    it('フェッチエラー時はnullを返すこと', () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+
+      return enricher.enrich('https://aws.amazon.com/blogs/error-article').then(result => {
+        expect(result).toBeNull();
+      });
+    });
+
+    it('画像URLを正しく正規化できること', () => {
+      const mockHtml = `
+        <html>
+          <head>
+            <meta property="og:image" content="/static/images/blog-image.jpg" />
+          </head>
+          <body>
+            <div class="blog-post-content">
+              <p>Amazon Web Services (AWS) is the world's most comprehensive and broadly adopted cloud platform.</p>
+              <p>AWS offers over 200 fully featured services from data centers globally, serving millions of customers.</p>
+              <p>From startups to large enterprises and government agencies, organizations trust AWS to power their infrastructure.</p>
+              <p>The platform provides computing power, database storage, content delivery, and other functionality.</p>
+              <p>AWS helps businesses scale and grow by providing on-demand access to computing resources and services.</p>
+              <p>With pay-as-you-go pricing, organizations can avoid upfront capital expenses and scale as needed.</p>
+              <p>The global infrastructure includes multiple regions and availability zones for high availability.</p>
+              <p>AWS continues to innovate with new services and features being added regularly to meet customer needs.</p>
+            </div>
+          </body>
+        </html>
+      `;
+
+      mockFetch(mockHtml);
+
+      return enricher.enrich('https://aws.amazon.com/blogs/test-image').then(result => {
+        expect(result).not.toBeNull();
+        expect(result!.thumbnail).toBe('https://aws.amazon.com/static/images/blog-image.jpg');
+      });
+    });
+  });
+
+  describe('getRateLimit', () => {
+    it('レート制限が1500ミリ秒であること', () => {
+      const rateLimit = (enricher as any).getRateLimit();
+      expect(rateLimit).toBe(1500);
+    });
+  });
+
+  describe('getMinContentLength', () => {
+    it('最小コンテンツ長が500文字であること', () => {
+      const minLength = (enricher as any).getMinContentLength();
+      expect(minLength).toBe(500);
+    });
+  });
+});

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { AlertCircle } from 'lucide-react';
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen px-4">
+      <div className="text-center">
+        <AlertCircle className="mx-auto h-16 w-16 text-gray-400 mb-4" />
+        <h1 className="text-4xl font-bold text-gray-900 mb-2">404</h1>
+        <h2 className="text-2xl font-semibold text-gray-700 mb-4">
+          ページが見つかりません
+        </h2>
+        <p className="text-gray-600 mb-8 max-w-md mx-auto">
+          お探しのページは存在しないか、移動した可能性があります。
+        </p>
+        <Link
+          href="/"
+          className="inline-flex items-center px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors"
+        >
+          ホームに戻る
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/lib/enrichers/aws.ts
+++ b/lib/enrichers/aws.ts
@@ -1,0 +1,192 @@
+import { BaseContentEnricher } from './base';
+import * as cheerio from 'cheerio';
+
+/**
+ * AWS Blog Content Enricher
+ * AWSブログ記事の完全なコンテンツを取得
+ */
+export class AWSEnricher extends BaseContentEnricher {
+  /**
+   * AWSブログのURLかどうかを判定
+   */
+  canHandle(url: string): boolean {
+    return url.includes('aws.amazon.com');
+  }
+
+  /**
+   * AWSブログの記事を詳細に取得してエンリッチ
+   */
+  async enrich(url: string): Promise<{ content: string | null; thumbnail?: string | null } | null> {
+    try {
+      // console.log(`[AWS Enricher] Fetching content from: ${url}`);
+      
+      const response = await fetch(url, {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; TechTrend/1.0)',
+          'Accept': 'text/html,application/xhtml+xml',
+          'Accept-Language': 'en-US,en;q=0.9,ja;q=0.8',
+        },
+      });
+
+      if (!response.ok) {
+        console.error(`[AWS Enricher] Failed to fetch: ${response.status}`);
+        return null;
+      }
+
+      const html = await response.text();
+      const $ = cheerio.load(html);
+      
+      // コンテンツの抽出（AWSブログの構造に基づく）
+      let content = '';
+      let thumbnail: string | null = null;
+      
+      // メインコンテンツエリアを探す（複数のセレクタを試す）
+      const contentSelectors = [
+        // AWS Blog specific selectors
+        '.blog-post-content',
+        '.blog-content',
+        'article .content',
+        '.entry-content',
+        'main article',
+        '[itemprop="articleBody"]',
+        '.post-content',
+        '#aws-page-content',
+        '.aws-text-box',
+        // What's New specific selectors
+        '.whatsnew-content',
+        '.whats-new-content',
+        // Generic fallbacks
+        'article',
+        'main',
+        '.content',
+      ];
+      
+      for (const selector of contentSelectors) {
+        const element = $(selector);
+        if (element.length > 0) {
+          // 不要な要素を削除
+          element.find('script, style, noscript, iframe, nav, header, footer').remove();
+          element.find('.social-share, .related-posts, .comments').remove();
+          
+          content = element.text().trim();
+          
+          // コンテンツが十分な長さがあるかチェック（500文字以上）
+          if (content.length > 500) {
+            // console.log(`[AWS Enricher] Found content with selector: ${selector} (${content.length} chars)`);
+            break;
+          }
+        }
+      }
+      
+      // コンテンツが短すぎる場合は、段落を個別に収集
+      if (content.length < 500) {
+        const paragraphs: string[] = [];
+        $('p').each((_, elem) => {
+          const text = $(elem).text().trim();
+          if (text.length > 50) { // 短い段落は除外
+            paragraphs.push(text);
+          }
+        });
+        
+        if (paragraphs.length > 0) {
+          content = paragraphs.join('\n\n');
+          // console.log(`[AWS Enricher] Collected paragraphs: ${paragraphs.length} (${content.length} chars)`);
+        }
+      }
+      
+      // サムネイル画像の抽出
+      const thumbnailSelectors = [
+        'meta[property="og:image"]',
+        'meta[name="twitter:image"]',
+        '.blog-post-image img',
+        'article img',
+        '.featured-image img',
+      ];
+      
+      for (const selector of thumbnailSelectors) {
+        if (selector.startsWith('meta')) {
+          const metaContent = $(selector).attr('content');
+          if (metaContent) {
+            thumbnail = this.normalizeImageUrl(metaContent, url);
+            break;
+          }
+        } else {
+          const imgSrc = $(selector).first().attr('src');
+          if (imgSrc) {
+            thumbnail = this.normalizeImageUrl(imgSrc, url);
+            break;
+          }
+        }
+      }
+      
+      // コンテンツが取得できなかった場合
+      if (!content || content.length < 200) {
+        console.error(`[AWS Enricher] Insufficient content found (${content.length} chars)`);
+        return null;
+      }
+      
+      // console.log(`[AWS Enricher] Successfully enriched: ${content.length} chars, thumbnail: ${thumbnail ? 'yes' : 'no'}`);
+      
+      return { 
+        content: content || null, 
+        thumbnail: thumbnail || null 
+      };
+    } catch (error) {
+      console.error('[AWS Enricher] Error during enrichment:', error);
+      return null;
+    }
+  }
+  
+  /**
+   * 画像URLを正規化
+   */
+  private normalizeImageUrl(imageUrl: string, baseUrl: string): string {
+    if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
+      return imageUrl;
+    }
+    
+    if (imageUrl.startsWith('//')) {
+      return 'https:' + imageUrl;
+    }
+    
+    if (imageUrl.startsWith('/')) {
+      const url = new URL(baseUrl);
+      return `${url.protocol}//${url.host}${imageUrl}`;
+    }
+    
+    // 相対パス
+    const url = new URL(baseUrl);
+    const basePath = url.pathname.substring(0, url.pathname.lastIndexOf('/'));
+    return `${url.protocol}//${url.host}${basePath}/${imageUrl}`;
+  }
+  
+  /**
+   * レート制限の設定（1.5秒）
+   */
+  protected getRateLimit(): number {
+    return 1500;
+  }
+  
+  /**
+   * コンテンツセレクタの取得
+   */
+  protected getContentSelectors(): string[] {
+    return [
+      '.blog-post-content',
+      '.blog-content',
+      'article .content',
+      '.entry-content',
+      '#aws-page-content',
+      '.aws-text-box',
+      'article',
+      'main',
+    ];
+  }
+  
+  /**
+   * 最小コンテンツ長の取得
+   */
+  protected getMinContentLength(): number {
+    return 500; // AWS記事は比較的長いので500文字以上
+  }
+}

--- a/lib/enrichers/index.ts
+++ b/lib/enrichers/index.ts
@@ -26,6 +26,7 @@ import { CloudflareBlogEnricher } from './cloudflare-blog';
 import { MozillaHacksEnricher } from './mozilla-hacks';
 import { HackerNewsEnricher } from './hacker-news';
 import { MediumEngineeringEnricher } from './medium-engineering';
+import { AWSEnricher } from './aws';
 
 export { BaseContentEnricher } from './base';
 export type { IContentEnricher, EnrichedContent, EnrichmentResult } from './base';
@@ -51,6 +52,7 @@ export { CloudflareBlogEnricher } from './cloudflare-blog';
 export { MozillaHacksEnricher } from './mozilla-hacks';
 export { HackerNewsEnricher } from './hacker-news';
 export { MediumEngineeringEnricher } from './medium-engineering';
+export { AWSEnricher } from './aws';
 
 /**
  * エンリッチャーファクトリークラス
@@ -86,6 +88,8 @@ export class ContentEnricherFactory {
       new MozillaHacksEnricher(),
       new HackerNewsEnricher(),
       new MediumEngineeringEnricher(),
+      // 新規追加（2025年9月2日）AWSソース
+      new AWSEnricher(),
       new HatenaContentEnricher(),  // 最後（すべてのURLに対応するため）
       // 将来的に他の企業のエンリッチャーを追加
       // new CookpadContentEnricher(),

--- a/scripts/fix/enrich-aws-articles.ts
+++ b/scripts/fix/enrich-aws-articles.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+/**
+ * AWS記事のエンリッチメント実行スクリプト
+ * 既存のAWS記事を取得し、エンリッチメントを実行してコンテンツを更新する
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { ContentEnricherFactory } from '../../lib/enrichers';
+import * as dotenv from 'dotenv';
+
+// 環境変数の読み込み
+dotenv.config();
+
+const prisma = new PrismaClient();
+
+// プログレスバーの表示用
+function showProgress(current: number, total: number, message: string = '') {
+  const percentage = Math.round((current / total) * 100);
+  const barLength = 40;
+  const filled = Math.round((current / total) * barLength);
+  const bar = '█'.repeat(filled) + '░'.repeat(barLength - filled);
+  
+  process.stdout.write(`\r[${bar}] ${percentage}% (${current}/${total}) ${message}`);
+  
+  if (current === total) {
+    process.stdout.write('\n');
+  }
+}
+
+async function enrichAwsArticles() {
+  console.log('AWS記事エンリッチメント処理を開始します...\n');
+  
+  try {
+    // AWSソースのIDを取得
+    const awsSource = await prisma.source.findFirst({
+      where: { name: 'AWS' }
+    });
+    
+    if (!awsSource) {
+      console.error('AWSソースが見つかりません');
+      return;
+    }
+    
+    // AWS記事を取得
+    const articles = await prisma.article.findMany({
+      where: { sourceId: awsSource.id },
+      orderBy: { createdAt: 'desc' }
+    });
+    
+    console.log(`対象記事数: ${articles.length}件\n`);
+    
+    // ドライラン確認
+    const isDryRun = process.argv.includes('--dry-run');
+    if (isDryRun) {
+      console.log('🔍 ドライランモード: 実際の更新は行いません\n');
+    }
+    
+    // エンリッチャーファクトリーの初期化
+    const enricherFactory = new ContentEnricherFactory();
+    
+    let successCount = 0;
+    let failCount = 0;
+    let skipCount = 0;
+    const errors: { url: string; error: string }[] = [];
+    
+    // 各記事に対してエンリッチメントを実行
+    for (let i = 0; i < articles.length; i++) {
+      const article = articles[i];
+      const currentIndex = i + 1;
+      
+      try {
+        // 既に十分なコンテンツがある場合はスキップ（5000文字以上）
+        if (article.content && article.content.length > 5000) {
+          skipCount++;
+          showProgress(currentIndex, articles.length, `スキップ: ${article.title?.substring(0, 30)}...`);
+          continue;
+        }
+        
+        // エンリッチャーを取得
+        const enricher = enricherFactory.getEnricher(article.url);
+        
+        if (!enricher) {
+          failCount++;
+          errors.push({ url: article.url, error: 'エンリッチャーが見つかりません' });
+          showProgress(currentIndex, articles.length, `失敗: エンリッチャーなし`);
+          continue;
+        }
+        
+        showProgress(currentIndex, articles.length, `処理中: ${article.title?.substring(0, 30)}...`);
+        
+        // エンリッチメント実行
+        const enrichedContent = await enricher.enrich(article.url);
+        
+        if (!enrichedContent || !enrichedContent.content) {
+          failCount++;
+          errors.push({ url: article.url, error: 'コンテンツの取得に失敗' });
+          continue;
+        }
+        
+        // データベース更新（ドライランの場合はスキップ）
+        if (!isDryRun) {
+          await prisma.article.update({
+            where: { id: article.id },
+            data: {
+              content: enrichedContent.content,
+              thumbnail: enrichedContent.thumbnail || article.thumbnail,
+              updatedAt: new Date()
+            }
+          });
+        }
+        
+        successCount++;
+        
+        // 元のコンテンツ長と新しいコンテンツ長を記録
+        console.log(`\n✅ ${article.title?.substring(0, 50)}...`);
+        console.log(`   元: ${article.content?.length || 0}文字 → 新: ${enrichedContent.content.length}文字`);
+        
+        // レート制限（1.5秒待機）
+        await new Promise(resolve => setTimeout(resolve, 1500));
+        
+      } catch (error) {
+        failCount++;
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        errors.push({ url: article.url, error: errorMessage });
+        showProgress(currentIndex, articles.length, `エラー: ${errorMessage.substring(0, 30)}...`);
+      }
+    }
+    
+    // 結果サマリー
+    console.log('\n\n========================================');
+    console.log('エンリッチメント処理完了');
+    console.log('========================================');
+    console.log(`✅ 成功: ${successCount}件`);
+    console.log(`⏭️  スキップ: ${skipCount}件（既に十分なコンテンツ）`);
+    console.log(`❌ 失敗: ${failCount}件`);
+    
+    // エラー詳細
+    if (errors.length > 0) {
+      console.log('\n❌ エラー詳細:');
+      errors.slice(0, 10).forEach(({ url, error }) => {
+        console.log(`  - ${url}: ${error}`);
+      });
+      
+      if (errors.length > 10) {
+        console.log(`  ... 他 ${errors.length - 10}件のエラー`);
+      }
+    }
+    
+    // 統計情報
+    if (successCount > 0 && !isDryRun) {
+      const updatedArticles = await prisma.article.findMany({
+        where: { sourceId: awsSource.id },
+        select: { content: true }
+      });
+      
+      const contentLengths = updatedArticles.map(a => a.content?.length || 0);
+      const avgLength = Math.round(contentLengths.reduce((a, b) => a + b, 0) / contentLengths.length);
+      const maxLength = Math.max(...contentLengths);
+      const minLength = Math.min(...contentLengths.filter(l => l > 0));
+      
+      console.log('\n📊 統計情報:');
+      console.log(`  平均コンテンツ長: ${avgLength}文字`);
+      console.log(`  最大コンテンツ長: ${maxLength}文字`);
+      console.log(`  最小コンテンツ長: ${minLength}文字`);
+    }
+    
+  } catch (error) {
+    console.error('\n❌ エラーが発生しました:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// メイン処理の実行
+enrichAwsArticles().catch(error => {
+  console.error('予期しないエラー:', error);
+  process.exit(1);
+});

--- a/scripts/maintenance/enrich-aws-content.ts
+++ b/scripts/maintenance/enrich-aws-content.ts
@@ -1,0 +1,159 @@
+/**
+ * AWS Content Enrichment Script for Scheduler
+ * AWS記事のコンテンツを自動的にエンリッチメント
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { AWSEnricher } from '../../lib/enrichers/aws';
+
+const prisma = new PrismaClient();
+const enricher = new AWSEnricher();
+
+async function enrichAWSContent() {
+  console.error('=== AWS Content Enrichment ===');
+  
+  try {
+    // 最近追加されたAWS記事を取得（2時間以内）
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    
+    // テストモード: 引数に --test が含まれる場合は24時間以内の記事を対象
+    const isTestMode = process.argv.includes('--test');
+    const timeThreshold = isTestMode 
+      ? new Date(Date.now() - 24 * 60 * 60 * 1000)  // テスト時: 24時間
+      : twoHoursAgo;  // 通常時: 2時間
+    
+    const articles = await prisma.article.findMany({
+      where: {
+        source: {
+          name: 'AWS'
+        },
+        createdAt: {
+          gte: timeThreshold
+        }
+      },
+      include: {
+        source: true
+      },
+      orderBy: {
+        publishedAt: 'desc'
+      }
+    });
+    
+    if (articles.length === 0) {
+      console.error('No new AWS articles to enrich');
+      return;
+    }
+    
+    console.error(`Found ${articles.length} new AWS articles to process`);
+    
+    let enrichedCount = 0;
+    let failedCount = 0;
+    let skippedCount = 0;
+    
+    for (const article of articles) {
+      try {
+        // コンテンツが既に十分な長さがある場合はスキップ（5000文字以上）
+        if (article.content && article.content.length > 5000) {
+          console.error(`[SKIP] Already enriched (${article.content.length} chars): ${article.title?.substring(0, 50)}...`);
+          skippedCount++;
+          continue;
+        }
+        
+        // What's Newなど短い記事は元々短いことが想定される
+        const isWhatsNew = article.url.includes('/whats-new/');
+        const minContentLength = isWhatsNew ? 1000 : 2000;
+        
+        // 既に最小限のコンテンツがある場合
+        if (article.content && article.content.length > minContentLength) {
+          console.error(`[SKIP] Has sufficient content (${article.content.length} chars): ${article.title?.substring(0, 50)}...`);
+          skippedCount++;
+          continue;
+        }
+        
+        console.error(`\nEnriching: ${article.title?.substring(0, 80)}...`);
+        console.error(`Current content: ${article.content?.length || 0} chars`);
+        
+        // エンリッチメント実行
+        const enrichedData = await enricher.enrich(article.url);
+        
+        if (enrichedData && enrichedData.content) {
+          const currentLength = article.content?.length || 0;
+          const newLength = enrichedData.content.length;
+          
+          // 内容が20%以上改善されている場合のみ更新
+          if (newLength > currentLength * 1.2 || currentLength < 500) {
+            await prisma.article.update({
+              where: { id: article.id },
+              data: {
+                content: enrichedData.content,
+                ...(enrichedData.thumbnail && { thumbnail: enrichedData.thumbnail })
+              }
+            });
+            
+            console.error(`✅ Enriched: ${currentLength} -> ${newLength} chars (+${Math.round((newLength - currentLength) / currentLength * 100)}%)`);
+            enrichedCount++;
+          } else {
+            console.error(`[SKIP] Minimal improvement (${currentLength} -> ${newLength} chars)`);
+            skippedCount++;
+          }
+        } else {
+          console.error(`❌ Failed to enrich content`);
+          failedCount++;
+        }
+        
+        // AWSのレート制限対策（1.5秒）
+        await new Promise(resolve => setTimeout(resolve, 1500));
+        
+      } catch (error) {
+        console.error(`❌ Error processing article: ${error instanceof Error ? error.message : String(error)}`);
+        failedCount++;
+      }
+    }
+    
+    // 結果サマリー
+    console.error('\n=== Enrichment Summary ===');
+    console.error(`✅ Enriched: ${enrichedCount} articles`);
+    console.error(`⏭️  Skipped: ${skippedCount} articles`);
+    console.error(`❌ Failed: ${failedCount} articles`);
+    
+    // 全体の統計情報を出力（デバッグ用）
+    if (enrichedCount > 0) {
+      console.error('\n📊 AWS Articles Statistics:');
+      console.error(`Total articles: ${await prisma.article.count({ where: { source: { name: 'AWS' } } })}`);
+      
+      // コンテンツ長の分布
+      const lengthDistribution = await prisma.$queryRaw<Array<{ range: string, count: bigint }>>`
+        SELECT 
+          CASE 
+            WHEN LENGTH(content) < 1000 THEN '< 1K'
+            WHEN LENGTH(content) < 2000 THEN '1K-2K'
+            WHEN LENGTH(content) < 5000 THEN '2K-5K'
+            WHEN LENGTH(content) < 10000 THEN '5K-10K'
+            ELSE '10K+'
+          END as range,
+          COUNT(*) as count
+        FROM "Article"
+        WHERE "sourceId" = (SELECT id FROM "Source" WHERE name = 'AWS')
+        GROUP BY range
+        ORDER BY range
+      `;
+      
+      console.error('Content length distribution:');
+      lengthDistribution.forEach(({ range, count }) => {
+        console.error(`  ${range}: ${count} articles`);
+      });
+    }
+    
+  } catch (error) {
+    console.error('❌ Enrichment error:', error instanceof Error ? error.message : String(error));
+    throw error;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// スクリプト実行
+enrichAWSContent().catch(error => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/scripts/scheduled/scheduler.ts
+++ b/scripts/scheduled/scheduler.ts
@@ -76,6 +76,20 @@ async function executeUpdatePipeline(
       }
     }
     
+    // 2.5. AWSのコンテンツエンリッチメント
+    if (sources.includes('AWS')) {
+      console.error('🔧 AWS記事のコンテンツをエンリッチ中...');
+      try {
+        const { stdout: enrichOutput }: ExecutionResult = await execAsync(
+          'npx tsx scripts/maintenance/enrich-aws-content.ts'
+        );
+        console.error(enrichOutput);
+      } catch (error) {
+        console.error('⚠️ AWSエンリッチメントでエラー（続行）:', error instanceof Error ? error.message : String(error));
+        // エラーが発生しても他の処理は続行
+      }
+    }
+    
     // 3. 要約生成（オプション）
     if (!options?.skipSummaries) {
       console.error('📝 要約・タグ生成中...');

--- a/scripts/scheduled/scheduler.ts
+++ b/scripts/scheduled/scheduler.ts
@@ -80,10 +80,21 @@ async function executeUpdatePipeline(
     if (sources.includes('AWS')) {
       console.error('🔧 AWS記事のコンテンツをエンリッチ中...');
       try {
-        const { stdout: enrichOutput }: ExecutionResult = await execAsync(
-          'npx tsx scripts/maintenance/enrich-aws-content.ts'
+        const { stdout: enrichOutput, stderr: enrichError }: ExecutionResult = await execAsync(
+          'npx tsx scripts/maintenance/enrich-aws-content.ts',
+          {
+            maxBuffer: 1024 * 1024 * 10, // 10MB buffer
+            timeout: 300000, // 5分のタイムアウト
+          }
         );
-        console.error(enrichOutput);
+        
+        // stdoutとstderrの両方をログ出力
+        if (enrichOutput) {
+          console.error(enrichOutput);
+        }
+        if (enrichError) {
+          console.error('⚠️ AWS enrichment stderr:', enrichError);
+        }
       } catch (error) {
         console.error('⚠️ AWSエンリッチメントでエラー（続行）:', error instanceof Error ? error.message : String(error));
         // エラーが発生しても他の処理は続行


### PR DESCRIPTION
## 概要
AWS記事のエンリッチメント機能を実装し、記事の完全なコンテンツを取得できるようにしました。

## 背景
- AWS記事が実際のコンテンツの約3%しか保存できていない問題が発生
- RSSフィードが記事の要約のみを提供していることが原因
- 318件のAWS記事すべてが不完全な状態

## 実装内容

### 1. AWSEnricherクラスの新規作成
- `lib/enrichers/aws.ts`
- BaseContentEnricherを継承
- aws.amazon.comドメインの記事を処理
- 複数のセレクタで記事本文を抽出
- サムネイル画像の取得にも対応

### 2. ContentEnricherFactoryへの登録
- `lib/enrichers/index.ts`を修正
- AWSEnricherをエンリッチャーリストに追加

### 3. 既存記事の再処理スクリプト
- `scripts/fix/enrich-aws-articles.ts`
- 318件の既存AWS記事を再処理
- プログレスバーで進捗表示
- ドライランモード対応
- レート制限（1.5秒間隔）実装

## 成果
- 平均コンテンツ長: 1,540文字 → 10,000文字以上（見込み）
- 記事の完全なコンテンツが取得可能に
- 要約生成の品質向上が期待できる

## テスト方法
1. エンリッチメントのドライラン実行
   ```bash
   npx tsx scripts/fix/enrich-aws-articles.ts --dry-run
   ```

2. 実際のエンリッチメント実行
   ```bash
   npx tsx scripts/fix/enrich-aws-articles.ts
   ```

## チェックリスト
- [x] ビルドが成功する
- [x] リントエラーがない
- [ ] 単体テストの作成（次フェーズ）
- [ ] 実際のAWS記事でのテスト

## 関連Issue/PR
- 調査報告書: `.claude/docs/investigate/investigate_20250902_003826_aws_enrichment.md`
- 実装計画書: `.claude/docs/plan/plan_20250902_004510_aws_enrichment_implementation.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - AWS公式サイトのコンテンツ取り込みを追加。複数レイアウトから本文を抽出し、不要要素を除去。サムネイル自動取得と相対URLの正規化、レート制御と最小文字数チェックを実装。
- テスト
  - AWS向け取り込み処理の包括的なユニットテストを追加（URL判定、本文抽出、サムネイル取得、エラー時の挙動検証）。
- チョア
  - AWS記事の再取り込み／保守用スクリプトを追加（dry-run・進捗表示・統計出力）。スケジューラにAWS処理を組み込み。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->