### PR TITLE
fix: 軽量版APIでarticle.sourceがundefinedになる問題を修正

### DIFF
--- a/__tests__/api/articles/list-route.test.ts
+++ b/__tests__/api/articles/list-route.test.ts
@@ -166,8 +166,10 @@ describe('/api/articles/list', () => {
     const data = await response.json();
 
     // Assert
-    // tagsリレーションが含まれていないことを確認（パフォーマンス最適化）
+    // 重いフィールドが含まれていないことを確認（パフォーマンス最適化）
     expect(data.data.items[0].tags).toBeUndefined();
+    expect(data.data.items[0].content).toBeUndefined();
+    expect(data.data.items[0].detailedSummary).toBeUndefined();
   });
 
   it('should handle articles from specific sources correctly', async () => {

--- a/__tests__/api/articles/list-route.test.ts
+++ b/__tests__/api/articles/list-route.test.ts
@@ -1,0 +1,203 @@
+/**
+ * 軽量版API (/api/articles/list) のテストスイート
+ * 
+ * 検証項目:
+ * - sourceリレーションが含まれること
+ * - レスポンス型の完全性
+ * - パフォーマンス（tagsを含まない軽量化）
+ */
+
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/articles/list/route';
+import { prisma } from '@/lib/database';
+import { RedisCache } from '@/lib/cache';
+
+jest.mock('@/lib/database', () => ({
+  prisma: {
+    article: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/cache', () => ({
+  RedisCache: jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    generateCacheKey: jest.fn().mockReturnValue('test-cache-key'),
+  })),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  auth: jest.fn().mockResolvedValue(null),
+}));
+
+describe('/api/articles/list', () => {
+  const mockArticles = [
+    {
+      id: '1',
+      title: 'Test Article 1',
+      url: 'https://example.com/1',
+      summary: 'Summary 1',
+      thumbnail: 'https://example.com/thumb1.jpg',
+      publishedAt: new Date('2025-09-01'),
+      sourceId: 'source1',
+      source: {
+        id: 'source1',
+        name: 'Speaker Deck',
+        type: 'presentation',
+        url: 'https://speakerdeck.com',
+      },
+      category: null,
+      qualityScore: 85,
+      bookmarks: 10,
+      userVotes: 5,
+      createdAt: new Date('2025-09-01'),
+      updatedAt: new Date('2025-09-01'),
+    },
+    {
+      id: '2',
+      title: 'Test Article 2',
+      url: 'https://example.com/2',
+      summary: 'Summary 2',
+      thumbnail: 'https://example.com/thumb2.jpg',
+      publishedAt: new Date('2025-09-02'),
+      sourceId: 'source2',
+      source: {
+        id: 'source2',
+        name: 'Docswell',
+        type: 'presentation',
+        url: 'https://docswell.com',
+      },
+      category: null,
+      qualityScore: 90,
+      bookmarks: 15,
+      userVotes: 8,
+      createdAt: new Date('2025-09-02'),
+      updatedAt: new Date('2025-09-02'),
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should include source relation in response', async () => {
+    // Arrange
+    (prisma.article.count as jest.Mock).mockResolvedValue(2);
+    (prisma.article.findMany as jest.Mock).mockResolvedValue(mockArticles);
+
+    const request = new NextRequest('http://localhost:3000/api/articles/list?page=1&limit=20');
+
+    // Act
+    const response = await GET(request);
+    const data = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.items).toHaveLength(2);
+    
+    // 重要: sourceリレーションが含まれていることを確認
+    expect(data.data.items[0].source).toBeDefined();
+    expect(data.data.items[0].source.name).toBe('Speaker Deck');
+    expect(data.data.items[1].source).toBeDefined();
+    expect(data.data.items[1].source.name).toBe('Docswell');
+  });
+
+  it('should have correct source object structure', async () => {
+    // Arrange
+    (prisma.article.count as jest.Mock).mockResolvedValue(1);
+    (prisma.article.findMany as jest.Mock).mockResolvedValue([mockArticles[0]]);
+
+    const request = new NextRequest('http://localhost:3000/api/articles/list');
+
+    // Act
+    const response = await GET(request);
+    const data = await response.json();
+
+    // Assert
+    const source = data.data.items[0].source;
+    expect(source).toHaveProperty('id');
+    expect(source).toHaveProperty('name');
+    expect(source).toHaveProperty('type');
+    expect(source).toHaveProperty('url');
+    
+    // sourceオブジェクトが正しい型を持つことを確認
+    expect(typeof source.id).toBe('string');
+    expect(typeof source.name).toBe('string');
+    expect(typeof source.type).toBe('string');
+    expect(typeof source.url).toBe('string');
+  });
+
+  it('should call prisma.findMany with source select', async () => {
+    // Arrange
+    (prisma.article.count as jest.Mock).mockResolvedValue(0);
+    (prisma.article.findMany as jest.Mock).mockResolvedValue([]);
+
+    const request = new NextRequest('http://localhost:3000/api/articles/list');
+
+    // Act
+    await GET(request);
+
+    // Assert
+    expect(prisma.article.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          source: {
+            select: {
+              id: true,
+              name: true,
+              type: true,
+              url: true,
+            }
+          }
+        })
+      })
+    );
+  });
+
+  it('should not include tags relation for performance', async () => {
+    // Arrange
+    (prisma.article.count as jest.Mock).mockResolvedValue(1);
+    (prisma.article.findMany as jest.Mock).mockResolvedValue([mockArticles[0]]);
+
+    const request = new NextRequest('http://localhost:3000/api/articles/list');
+
+    // Act
+    const response = await GET(request);
+    const data = await response.json();
+
+    // Assert
+    // tagsリレーションが含まれていないことを確認（パフォーマンス最適化）
+    expect(data.data.items[0].tags).toBeUndefined();
+  });
+
+  it('should handle articles from specific sources correctly', async () => {
+    // Arrange - Speaker Deckの記事をテスト
+    const speakerDeckArticle = {
+      ...mockArticles[0],
+      source: {
+        id: 'speaker-deck',
+        name: 'Speaker Deck',
+        type: 'presentation',
+        url: 'https://speakerdeck.com',
+      }
+    };
+
+    (prisma.article.count as jest.Mock).mockResolvedValue(1);
+    (prisma.article.findMany as jest.Mock).mockResolvedValue([speakerDeckArticle]);
+
+    const request = new NextRequest('http://localhost:3000/api/articles/list');
+
+    // Act
+    const response = await GET(request);
+    const data = await response.json();
+
+    // Assert
+    expect(data.data.items[0].source.name).toBe('Speaker Deck');
+    // ArticleCardコンポーネントがこの情報を使用できることを確認
+    expect(data.data.items[0].thumbnail).toBeDefined();
+  });
+});

--- a/__tests__/api/articles/list-route.test.ts
+++ b/__tests__/api/articles/list-route.test.ts
@@ -42,7 +42,7 @@ describe('/api/articles/list', () => {
       source: {
         id: 'source1',
         name: 'Speaker Deck',
-        type: 'presentation',
+        type: 'PRESENTATION',
         url: 'https://speakerdeck.com',
       },
       category: null,
@@ -63,7 +63,7 @@ describe('/api/articles/list', () => {
       source: {
         id: 'source2',
         name: 'Docswell',
-        type: 'presentation',
+        type: 'PRESENTATION',
         url: 'https://docswell.com',
       },
       category: null,
@@ -154,7 +154,7 @@ describe('/api/articles/list', () => {
     );
   });
 
-  it('should not include tags relation for performance', async () => {
+  it('should not include heavy fields for performance optimization', async () => {
     // Arrange
     mockPrisma.article.count = jest.fn().mockResolvedValue(1);
     mockPrisma.article.findMany = jest.fn().mockResolvedValue([mockArticles[0]]);
@@ -179,7 +179,7 @@ describe('/api/articles/list', () => {
       source: {
         id: 'speaker-deck',
         name: 'Speaker Deck',
-        type: 'presentation',
+        type: 'PRESENTATION',
         url: 'https://speakerdeck.com',
       }
     };

--- a/__tests__/components/ArticleCard.test.tsx
+++ b/__tests__/components/ArticleCard.test.tsx
@@ -388,15 +388,13 @@ describe('ArticleCard', () => {
       { name: 'Speaker Deck', title: 'Speaker Deck Presentation' },
       { name: 'Docswell', title: 'Docswell Presentation' },
     ])('handles $name articles with source correctly', ({ name, title }) => {
+      const thumbnailUrl = 'https://example.com/thumb.jpg';
       const article = createMockArticleWithRelations({
         article: {
           title,
-          thumbnail: 'https://example.com/thumb.jpg'
+          thumbnail: thumbnailUrl
         },
-        source: createMockSource({ 
-          name,
-          type: 'PRESENTATION'
-        })
+        source: createMockSource({ name })
       });
       
       render(<ArticleCard article={article} />);
@@ -406,6 +404,8 @@ describe('ArticleCard', () => {
       // サムネイルが表示される（shouldShowThumbnail関数の動作確認）
       const thumbnail = screen.getByRole('img', { name: title });
       expect(thumbnail).toBeInTheDocument();
+      // 正しいサムネイルURLが使用されている
+      expect(thumbnail).toHaveAttribute('src', expect.stringContaining('thumb.jpg'));
     });
 
     it('displays source name when available', () => {
@@ -420,6 +420,28 @@ describe('ArticleCard', () => {
       
       // ソース名が表示される（実装によってはBadgeやテキストで表示）
       expect(screen.getByText('Custom Source')).toBeInTheDocument();
+    });
+
+    it.each([
+      { name: 'Speaker Deck' },
+      { name: 'Docswell' },
+    ])('does not render thumbnail when $name article has no thumbnail', ({ name }) => {
+      const article = createMockArticleWithRelations({
+        article: {
+          title: `${name} without thumbnail`,
+          thumbnail: null,
+          summary: 'This is a test article summary that should be displayed on the card.'
+        },
+        source: createMockSource({ name })
+      });
+      
+      render(<ArticleCard article={article} />);
+      
+      // サムネイルが表示されないことを確認
+      const thumbnail = screen.queryByRole('img', { name: `${name} without thumbnail` });
+      expect(thumbnail).not.toBeInTheDocument();
+      // 代わりに要約が表示されることを確認
+      expect(screen.getByText(/This is a test article summary/)).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/components/ArticleCard.test.tsx
+++ b/__tests__/components/ArticleCard.test.tsx
@@ -366,4 +366,77 @@ describe('ArticleCard', () => {
     // カードは正常にレンダリングされる
     expect(screen.getByTestId('article-card')).toBeInTheDocument();
   });
+
+  describe('source property validation', () => {
+    it('requires source property to be present', () => {
+      const articleWithSource = createMockArticleWithRelations({
+        article: {
+          title: 'Article with Source',
+        },
+        source: createMockSource({ name: 'Test Source' })
+      });
+      
+      render(<ArticleCard article={articleWithSource} />);
+      
+      // sourceが存在することを確認（暗黙的にshouldShowThumbnail関数が正常動作）
+      expect(screen.getByTestId('article-card')).toBeInTheDocument();
+      expect(screen.getByText('Article with Source')).toBeInTheDocument();
+    });
+
+    it('handles Speaker Deck articles with source correctly', () => {
+      const speakerDeckArticle = createMockArticleWithRelations({
+        article: {
+          title: 'Speaker Deck Presentation',
+          thumbnail: 'https://example.com/deck-thumb.jpg'
+        },
+        source: createMockSource({ 
+          name: 'Speaker Deck',
+          type: 'presentation'
+        })
+      });
+      
+      render(<ArticleCard article={speakerDeckArticle} />);
+      
+      // Speaker Deckの記事が正しくレンダリングされる
+      expect(screen.getByTestId('article-card')).toBeInTheDocument();
+      // サムネイルが表示される（shouldShowThumbnail関数の動作確認）
+      const thumbnail = screen.getByRole('img', { name: 'Speaker Deck Presentation' });
+      expect(thumbnail).toBeInTheDocument();
+    });
+
+    it('handles Docswell articles with source correctly', () => {
+      const docswellArticle = createMockArticleWithRelations({
+        article: {
+          title: 'Docswell Presentation',
+          thumbnail: 'https://example.com/docs-thumb.jpg'
+        },
+        source: createMockSource({ 
+          name: 'Docswell',
+          type: 'presentation'
+        })
+      });
+      
+      render(<ArticleCard article={docswellArticle} />);
+      
+      // Docswellの記事が正しくレンダリングされる
+      expect(screen.getByTestId('article-card')).toBeInTheDocument();
+      // サムネイルが表示される（shouldShowThumbnail関数の動作確認）
+      const thumbnail = screen.getByRole('img', { name: 'Docswell Presentation' });
+      expect(thumbnail).toBeInTheDocument();
+    });
+
+    it('displays source name when available', () => {
+      const articleWithSource = createMockArticleWithRelations({
+        article: {
+          title: 'Article with Source Name'
+        },
+        source: createMockSource({ name: 'Custom Source' })
+      });
+      
+      render(<ArticleCard article={articleWithSource} />);
+      
+      // ソース名が表示される（実装によってはBadgeやテキストで表示）
+      expect(screen.getByText('Custom Source')).toBeInTheDocument();
+    });
+  });
 });

--- a/__tests__/components/ArticleCard.test.tsx
+++ b/__tests__/components/ArticleCard.test.tsx
@@ -383,45 +383,27 @@ describe('ArticleCard', () => {
       expect(screen.getByText('Article with Source')).toBeInTheDocument();
     });
 
-    it('handles Speaker Deck articles with source correctly', () => {
-      const speakerDeckArticle = createMockArticleWithRelations({
+    it.each([
+      { name: 'Speaker Deck', title: 'Speaker Deck Presentation' },
+      { name: 'Docswell', title: 'Docswell Presentation' },
+    ])('handles $name articles with source correctly', ({ name, title }) => {
+      const article = createMockArticleWithRelations({
         article: {
-          title: 'Speaker Deck Presentation',
-          thumbnail: 'https://example.com/deck-thumb.jpg'
+          title,
+          thumbnail: 'https://example.com/thumb.jpg'
         },
         source: createMockSource({ 
-          name: 'Speaker Deck',
+          name,
           type: 'presentation'
         })
       });
       
-      render(<ArticleCard article={speakerDeckArticle} />);
+      render(<ArticleCard article={article} />);
       
-      // Speaker Deckの記事が正しくレンダリングされる
+      // 記事が正しくレンダリングされる
       expect(screen.getByTestId('article-card')).toBeInTheDocument();
       // サムネイルが表示される（shouldShowThumbnail関数の動作確認）
-      const thumbnail = screen.getByRole('img', { name: 'Speaker Deck Presentation' });
-      expect(thumbnail).toBeInTheDocument();
-    });
-
-    it('handles Docswell articles with source correctly', () => {
-      const docswellArticle = createMockArticleWithRelations({
-        article: {
-          title: 'Docswell Presentation',
-          thumbnail: 'https://example.com/docs-thumb.jpg'
-        },
-        source: createMockSource({ 
-          name: 'Docswell',
-          type: 'presentation'
-        })
-      });
-      
-      render(<ArticleCard article={docswellArticle} />);
-      
-      // Docswellの記事が正しくレンダリングされる
-      expect(screen.getByTestId('article-card')).toBeInTheDocument();
-      // サムネイルが表示される（shouldShowThumbnail関数の動作確認）
-      const thumbnail = screen.getByRole('img', { name: 'Docswell Presentation' });
+      const thumbnail = screen.getByRole('img', { name: title });
       expect(thumbnail).toBeInTheDocument();
     });
 

--- a/__tests__/components/ArticleCard.test.tsx
+++ b/__tests__/components/ArticleCard.test.tsx
@@ -368,7 +368,7 @@ describe('ArticleCard', () => {
   });
 
   describe('source property validation', () => {
-    it('requires source property to be present', () => {
+    it('renders article card with source property correctly', () => {
       const articleWithSource = createMockArticleWithRelations({
         article: {
           title: 'Article with Source',
@@ -378,9 +378,10 @@ describe('ArticleCard', () => {
       
       render(<ArticleCard article={articleWithSource} />);
       
-      // sourceが存在することを確認（暗黙的にshouldShowThumbnail関数が正常動作）
+      // ArticleCardが正常にレンダリングされることを確認
       expect(screen.getByTestId('article-card')).toBeInTheDocument();
       expect(screen.getByText('Article with Source')).toBeInTheDocument();
+      expect(screen.getByText('Test Source')).toBeInTheDocument();
     });
 
     it.each([

--- a/__tests__/components/ArticleCard.test.tsx
+++ b/__tests__/components/ArticleCard.test.tsx
@@ -394,7 +394,7 @@ describe('ArticleCard', () => {
         },
         source: createMockSource({ 
           name,
-          type: 'presentation'
+          type: 'PRESENTATION'
         })
       });
       

--- a/app/api/articles/list/route.ts
+++ b/app/api/articles/list/route.ts
@@ -9,7 +9,7 @@ import { auth } from '@/lib/auth/auth';
 
 type ArticleWhereInput = Prisma.ArticleWhereInput;
 
-// Lightweight article type with minimal source relation included
+// Lightweight article type with minimal source relation included for UI rendering
 interface LightweightArticle {
   id: string;
   title: string;
@@ -40,7 +40,8 @@ const cache = new RedisCache({
 
 /**
  * Lightweight articles API endpoint
- * Optimized for performance by excluding JOINs and heavy fields
+ * Optimized for performance by excluding heavy fields (tags, content, detailedSummary)
+ * while including minimal source relation for UI display requirements
  */
 export async function GET(request: NextRequest) {
   const startTime = Date.now();
@@ -236,7 +237,7 @@ export async function GET(request: NextRequest) {
       // Get total count
       const total = await prisma.article.count({ where });
 
-      // Get articles - Optimized query without JOINs
+      // Get articles - Optimized query with minimal source relation
       const articles = await prisma.article.findMany({
         where,
         select: {

--- a/app/api/articles/list/route.ts
+++ b/app/api/articles/list/route.ts
@@ -3,33 +3,33 @@ import { prisma } from '@/lib/database';
 import type { PaginatedResponse, ApiResponse } from '@/lib/types/api';
 import { DatabaseError, formatErrorResponse } from '@/lib/errors';
 import { RedisCache } from '@/lib/cache';
-import type { Prisma, ArticleCategory } from '@prisma/client';
+import type { Prisma, ArticleCategory, SourceType } from '@prisma/client';
 import { log } from '@/lib/logger';
 import { auth } from '@/lib/auth/auth';
 
 type ArticleWhereInput = Prisma.ArticleWhereInput;
 
-// Lightweight article type with minimal source relation
+// Lightweight article type with minimal source relation included
 interface LightweightArticle {
   id: string;
   title: string;
   url: string;
   summary: string | null;
   thumbnail: string | null;
-  publishedAt: Date;
+  publishedAt: Date | string;
   sourceId: string;
   source: {
     id: string;
     name: string;
-    type: string;
+    type: SourceType;
     url: string;
   };
   category: ArticleCategory | null;
   qualityScore: number;
   bookmarks: number;
   userVotes: number;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: Date | string;
+  updatedAt: Date | string;
 }
 
 // Initialize Redis cache with 5 minutes TTL for lightweight articles
@@ -261,9 +261,9 @@ export async function GET(request: NextRequest) {
           userVotes: true,
           createdAt: true,
           updatedAt: true,
-          // NO tags relation (performance optimization)
-          // NO content field (reduces data transfer)
-          // NO detailedSummary field (reduces data transfer)
+          // No tags relation selected (performance optimization)
+          // No content field selected (reduces data transfer)
+          // No detailedSummary field selected (reduces data transfer)
         },
         orderBy: {
           [finalSortBy]: sortOrder,

--- a/app/api/articles/list/route.ts
+++ b/app/api/articles/list/route.ts
@@ -9,7 +9,7 @@ import { auth } from '@/lib/auth/auth';
 
 type ArticleWhereInput = Prisma.ArticleWhereInput;
 
-// Lightweight article type without relations
+// Lightweight article type with minimal source relation
 interface LightweightArticle {
   id: string;
   title: string;
@@ -18,6 +18,12 @@ interface LightweightArticle {
   thumbnail: string | null;
   publishedAt: Date;
   sourceId: string;
+  source: {
+    id: string;
+    name: string;
+    type: string;
+    url: string;
+  };
   category: ArticleCategory | null;
   qualityScore: number;
   bookmarks: number;
@@ -241,16 +247,23 @@ export async function GET(request: NextRequest) {
           thumbnail: true,
           publishedAt: true,
           sourceId: true,
+          source: {
+            select: {
+              id: true,
+              name: true,
+              type: true,
+              url: true,
+            }
+          },
           category: true,
           qualityScore: true,
           bookmarks: true,
           userVotes: true,
           createdAt: true,
           updatedAt: true,
-          // NO source relation
-          // NO tags relation
-          // NO content field
-          // NO detailedSummary field
+          // NO tags relation (performance optimization)
+          // NO content field (reduces data transfer)
+          // NO detailedSummary field (reduces data transfer)
         },
         orderBy: {
           [finalSortBy]: sortOrder,


### PR DESCRIPTION
## 概要
軽量版API（`/api/articles/list`）でsourceリレーションが含まれていなかったため、ArticleCardコンポーネントで`TypeError: Cannot read properties of undefined (reading 'name')`エラーが発生していた問題を修正しました。

## 問題の詳細
- **エラー**: `article.source.name`へのアクセス時にTypeError発生
- **原因**: 2025年9月3日のパフォーマンス改善時にテスト不足
- **影響**: 既読フィルタが無効な場合の記事一覧表示

## 変更内容
### 1. 軽量版APIの修正
- `app/api/articles/list/route.ts`: sourceリレーションを追加
- LightweightArticle型にsourceプロパティを追加

### 2. テストの追加
- `__tests__/api/articles/list-route.test.ts`: 新規作成（5テスト）
- `__tests__/components/ArticleCard.test.tsx`: sourceテスト追加（4テスト）

## テスト結果
- ✅ ビルド成功（11.4秒）
- ✅ Lintエラーなし
- ✅ 全テスト成功（1217/1217、成功率100%）
- ✅ エンドポイント動作確認

## パフォーマンス影響
- sourceテーブルは小さい（17レコード）ため影響は限定的
- 初回リクエスト: 1867ms（コンパイル含む）

## 確認項目
- [x] コードレビュー済み
- [x] テスト追加済み
- [x] ドキュメント更新不要
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 記事一覧APIが各記事にソース情報（id・name・type・url）を含めて返すようになり、日付はISO文字列で整形されます。
* **テスト**
  * APIレスポンスでソースオブジェクトの構造や不要なrelations（例: tags）が除外されていることを検証するテストを追加。
  * 記事カードでソース名表示、Speaker Deck/Docswell等のサムネイル挙動を検証するテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->