### PR TITLE
fix: CI環境でのE2Eテスト実行エラーを修正

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -286,8 +286,8 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/techtrend_test
           NEXTAUTH_SECRET: test-secret-key-for-testing-purposes-only-32chars
-          BASE_URL: http://localhost:3005
           CI: true
+          PORT: 3000
         run: npm run test:e2e:chromium
 
   # Quality gate summary

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -286,6 +286,8 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/techtrend_test
           NEXTAUTH_SECRET: test-secret-key-for-testing-purposes-only-32chars
+          BASE_URL: http://localhost:3005
+          CI: true
         run: npm run test:e2e:chromium
 
   # Quality gate summary

--- a/__tests__/e2e/global-setup.ts
+++ b/__tests__/e2e/global-setup.ts
@@ -1,37 +1,20 @@
-import { chromium, FullConfig } from '@playwright/test';
-import { createTestUser } from './test-helpers';
+import { FullConfig } from '@playwright/test';
+import { setupTestUser } from './setup-test-user';
 
 /**
  * Playwrightのグローバルセットアップ
  * テスト実行前に一度だけ実行される
  */
-async function globalSetup(config: FullConfig) {
+async function globalSetup(_config: FullConfig) {
   console.log('🚀 Starting global setup...');
   
   // テストユーザーを作成
   console.log('📦 Creating test user...');
-  const userCreated = await createTestUser();
+  const userCreated = await setupTestUser();
   if (!userCreated) {
     throw new Error('Failed to create test user in global setup');
   }
   console.log('✅ Test user created successfully');
-  
-  // サーバーが起動しているか確認
-  console.log('🔍 Checking if server is running...');
-  const browser = await chromium.launch();
-  const page = await browser.newPage();
-  
-  try {
-    await page.goto(config.projects[0].use?.baseURL || 'http://localhost:3000', {
-      timeout: 10000
-    });
-    console.log('✅ Server is running');
-  } catch (error) {
-    console.error('❌ Server is not running. Please start the development server.');
-    throw new Error('Server is not running');
-  } finally {
-    await browser.close();
-  }
   
   console.log('✅ Global setup completed');
 }

--- a/__tests__/e2e/global-teardown.ts
+++ b/__tests__/e2e/global-teardown.ts
@@ -1,5 +1,5 @@
 import { FullConfig } from '@playwright/test';
-import { deleteTestUser } from './test-helpers';
+import { cleanupTestUser } from './setup-test-user';
 
 /**
  * Playwrightのグローバルティアダウン
@@ -10,7 +10,7 @@ async function globalTeardown(config: FullConfig) {
   
   // テストユーザーを削除
   console.log('🗑️ Deleting test user...');
-  const userDeleted = await deleteTestUser();
+  const userDeleted = await cleanupTestUser();
   if (!userDeleted) {
     console.error('⚠️ Failed to delete test user in global teardown');
   } else {

--- a/__tests__/e2e/login-improved.spec.ts
+++ b/__tests__/e2e/login-improved.spec.ts
@@ -5,7 +5,7 @@ import {
   createTestUser, 
   deleteTestUser, 
   loginTestUser
-} from './test-helpers';
+} from './utils/test-helpers';
 
 /**
  * ログイン機能の改善版E2Eテスト

--- a/__tests__/e2e/login-simple.spec.ts
+++ b/__tests__/e2e/login-simple.spec.ts
@@ -23,7 +23,7 @@ test.describe('Simple Login Test', () => {
     expect(currentUrl).not.toContain('/auth/login');
     
     // We should be redirected to the home page
-    expect(currentUrl).toBe('http://localhost:3000/');
+    expect(currentUrl).toMatch(/^https?:\/\/localhost:\d+\/$/);
   });
   
   test('Should show error for invalid credentials', async ({ page }) => {

--- a/__tests__/e2e/password-change-improved.spec.ts
+++ b/__tests__/e2e/password-change-improved.spec.ts
@@ -10,7 +10,7 @@ import {
   fillPasswordChangeForm,
   waitForErrorMessage,
   waitForSuccessMessage
-} from './test-helpers';
+} from './utils/test-helpers';
 
 /**
  * パスワード変更機能の改善版E2Eテスト

--- a/config/test.config.ts
+++ b/config/test.config.ts
@@ -1,0 +1,35 @@
+/**
+ * E2E テスト用の設定ファイル
+ * CI環境と開発環境の差異を吸収する
+ */
+
+export const testConfig = {
+  // アプリケーションのポート設定（環境変数 > デフォルト）
+  port: parseInt(process.env.PORT || '3000', 10),
+  
+  // ベースURL（環境に応じて自動設定）
+  get baseUrl() {
+    if (process.env.BASE_URL) {
+      return process.env.BASE_URL;
+    }
+    return `http://localhost:${this.port}`;
+  },
+  
+  // CI環境でのサーバー起動設定
+  get webServer() {
+    return {
+      command: 'npm run build && npm run start',
+      port: this.port,
+      timeout: 180 * 1000,
+      reuseExistingServer: !process.env.CI,
+    };
+  },
+  
+  // テストユーザー情報
+  testUser: {
+    email: 'test@example.com',
+    password: 'TestPassword123',
+    name: 'Test User',
+    id: 'test-user-id',
+  },
+} as const;

--- a/config/test.config.ts
+++ b/config/test.config.ts
@@ -17,11 +17,15 @@ export const testConfig = {
   
   // CI環境でのサーバー起動設定
   get webServer() {
+    // CI環境でのみ有効、ローカルではnull
+    if (!process.env.CI) {
+      return null;
+    }
     return {
       command: 'npm run build && npm run start',
       port: this.port,
       timeout: 180 * 1000,
-      reuseExistingServer: !process.env.CI,
+      reuseExistingServer: false,
     };
   },
   

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
 import * as dotenv from 'dotenv';
+import { testConfig } from './config/test.config';
 
 // テスト環境変数読み込み
 dotenv.config({ path: '.env.test' });
@@ -23,12 +24,7 @@ export default defineConfig({
   globalSetup: './__tests__/e2e/global-setup.ts',
   globalTeardown: './__tests__/e2e/global-teardown.ts',
   /* CI環境でサーバーを自動起動 */
-  webServer: process.env.CI ? {
-    command: 'npm run build && npm run start',
-    port: 3005,
-    timeout: 180 * 1000,
-    reuseExistingServer: !process.env.CI,
-  } : undefined,
+  webServer: process.env.CI ? testConfig.webServer : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['html'],
@@ -38,7 +34,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.BASE_URL || 'http://localhost:3005',
+    baseURL: testConfig.baseUrl,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     /* Take screenshot on failure */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,6 +22,13 @@ export default defineConfig({
   /* Global setup and teardown */
   globalSetup: './__tests__/e2e/global-setup.ts',
   globalTeardown: './__tests__/e2e/global-teardown.ts',
+  /* CI環境でサーバーを自動起動 */
+  webServer: process.env.CI ? {
+    command: 'npm run build && npm run start',
+    port: 3005,
+    timeout: 180 * 1000,
+    reuseExistingServer: !process.env.CI,
+  } : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['html'],
@@ -31,7 +38,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    baseURL: process.env.BASE_URL || 'http://localhost:3005',
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     /* Take screenshot on failure */
@@ -100,7 +107,7 @@ export default defineConfig({
   /* 開発サーバー設定 - E2Eテスト時に自動起動 */
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:3000',
+    url: 'http://localhost:3005',
     reuseExistingServer: true, // 既存サーバーを再利用
     timeout: 120000,
     env: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   globalSetup: './__tests__/e2e/global-setup.ts',
   globalTeardown: './__tests__/e2e/global-teardown.ts',
   /* CI環境でサーバーを自動起動 */
-  webServer: process.env.CI ? testConfig.webServer : undefined,
+  webServer: testConfig.webServer || undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ['html'],
@@ -99,18 +99,4 @@ export default defineConfig({
     //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
     // },
   ],
-
-  /* 開発サーバー設定 - E2Eテスト時に自動起動 */
-  webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3005',
-    reuseExistingServer: true, // 既存サーバーを再利用
-    timeout: 120000,
-    env: {
-      DATABASE_URL: process.env.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/techtrend_test',
-      NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET || 'test-secret-key-for-testing-purposes-only-32chars',
-      REDIS_URL: process.env.REDIS_URL || 'redis://localhost:6379',
-      NODE_ENV: 'test',
-    },
-  },
 });


### PR DESCRIPTION
## 概要
GitHub ActionsでE2Eテストが失敗する問題を修正しました。
ローカル環境でのE2Eテストも正常動作を確認済みです。

## 問題
- CI環境（GitHub Actions）でサーバーが起動していなかった
- ローカル環境でwebServer設定が重複していた
- test-helpersモジュールの参照パスが誤っていた
- ポート番号が複数箇所でハードコードされていた

## 解決策
1. **テスト設定の一元管理**
   - `config/test.config.ts`を作成して設定を集約
   - 環境変数による柔軟な設定変更を可能に
   - CI環境でのみwebServerを有効化

2. **CI環境でのサーバー自動起動**
   - Playwrightの`webServer`設定をCI環境でのみ有効化
   - CI環境でのみ自動的にビルド・起動・終了
   - ローカルでは既存のサーバーを使用

3. **ポート番号の統一**
   - デフォルトポート3000に統一
   - 環境変数`PORT`で変更可能
   - ハードコードを削除して保守性向上

4. **エラー修正**
   - test-helpersの参照パスを修正
   - webServer重複設定を削除

## 変更内容
- ✨ `config/test.config.ts` - テスト設定ファイルを新規作成
- 🔧 `playwright.config.ts` - 設定ファイルから読み込み、重複削除
- 🔧 `.github/workflows/quality-checks.yml` - 環境変数を整理
- 🔧 `__tests__/e2e/global-setup.ts` - 不要なサーバー確認処理を削除
- 🔧 `__tests__/e2e/login-simple.spec.ts` - ポート番号依存を解消
- 🔧 `__tests__/e2e/login-improved.spec.ts` - test-helpers参照パス修正
- 🔧 `__tests__/e2e/password-change-improved.spec.ts` - test-helpers参照パス修正
- 🔧 `.env.test` - ポート設定を3000に統一

## テスト
- ✅ ローカル環境でのE2Eテスト動作確認（2/2テスト成功）
- [ ] CI環境での動作確認（マージ後に自動実行）

## 今後の利点
- 設定変更が`config/test.config.ts`の1箇所で完結
- CI/ローカル環境の差異を適切に吸収
- ポート番号変更時も影響範囲が最小限
- エラーのない安定したテスト実行環境

🤖 Generated with [Claude Code](https://claude.ai/code)