### PR TITLE
feat: ArticleViewテーブルにカスケード削除を追加

### DIFF
--- a/prisma/migrations/20250905071249_add_cascade_delete_to_article_view/migration.sql
+++ b/prisma/migrations/20250905071249_add_cascade_delete_to_article_view/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "ArticleView" DROP CONSTRAINT "ArticleView_articleId_fkey";
+ALTER TABLE "ArticleView" DROP CONSTRAINT "ArticleView_userId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "ArticleView" ADD CONSTRAINT "ArticleView_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ArticleView" ADD CONSTRAINT "ArticleView_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,8 +132,8 @@ model ArticleView {
   viewedAt  DateTime?
   isRead    Boolean   @default(false)
   readAt    DateTime?
-  article   Article   @relation(fields: [articleId], references: [id])
-  user      User      @relation(fields: [userId], references: [id])
+  article   Article   @relation(fields: [articleId], references: [id], onDelete: Cascade)
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, articleId])
   @@index([userId, viewedAt])

--- a/scripts/test/test-cascade-delete.ts
+++ b/scripts/test/test-cascade-delete.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env npx tsx
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function testCascadeDelete() {
+  console.log('=== カスケード削除テスト ===\n');
+  
+  try {
+    // 1. テストデータの準備
+    console.log('1. テストデータを作成中...');
+    
+    // Dev.toソースが存在することを確認
+    const devtoSource = await prisma.source.upsert({
+      where: { name: 'Dev.to' },
+      update: {},
+      create: {
+        name: 'Dev.to',
+        type: 'rss',
+        url: 'https://dev.to/feed',
+        enabled: true
+      }
+    });
+    
+    // テスト用ユーザーを作成
+    const testUser = await prisma.user.upsert({
+      where: { email: 'test-cascade@example.com' },
+      update: {},
+      create: {
+        email: 'test-cascade@example.com',
+        name: 'Test User for Cascade Delete',
+        password: 'dummy-password'
+      }
+    });
+    
+    // テスト記事を作成
+    const testArticle = await prisma.article.create({
+      data: {
+        title: `Test Article for Cascade Delete - ${Date.now()}`,
+        url: `https://dev.to/test/cascade-delete-${Date.now()}`,
+        sourceId: devtoSource.id,
+        publishedAt: new Date(),
+      }
+    });
+    
+    // ArticleViewレコードを作成
+    const articleView = await prisma.articleView.create({
+      data: {
+        userId: testUser.id,
+        articleId: testArticle.id,
+        viewedAt: new Date(),
+        isRead: true,
+        readAt: new Date()
+      }
+    });
+    
+    // お気に入りも作成（既にカスケード削除が設定されている）
+    const favorite = await prisma.favorite.create({
+      data: {
+        userId: testUser.id,
+        articleId: testArticle.id
+      }
+    });
+    
+    console.log('  テスト記事ID:', testArticle.id);
+    console.log('  ArticleView ID:', articleView.id);
+    console.log('  Favorite ID:', favorite.id, '\n');
+    
+    // 2. カスケード削除のテスト
+    console.log('2. カスケード削除テスト（記事削除）...');
+    
+    // 記事を削除（トランザクションなし、シンプルな削除）
+    await prisma.article.delete({
+      where: { id: testArticle.id }
+    });
+    
+    console.log('  記事削除完了\n');
+    
+    // 3. 削除結果の検証
+    console.log('3. 削除結果の検証...');
+    
+    // ArticleViewが自動削除されたか確認
+    const remainingView = await prisma.articleView.findUnique({
+      where: {
+        userId_articleId: {
+          userId: testUser.id,
+          articleId: testArticle.id
+        }
+      }
+    });
+    
+    // Favoriteが自動削除されたか確認
+    const remainingFavorite = await prisma.favorite.findFirst({
+      where: {
+        userId: testUser.id,
+        articleId: testArticle.id
+      }
+    });
+    
+    console.log('  残存ArticleView:', remainingView ? 'あり' : 'なし（期待値）');
+    console.log('  残存Favorite:', remainingFavorite ? 'あり' : 'なし（期待値）\n');
+    
+    // 4. ユーザー削除のカスケードテスト
+    console.log('4. カスケード削除テスト（ユーザー削除）...');
+    
+    // 新しいテストデータを作成
+    const testArticle2 = await prisma.article.create({
+      data: {
+        title: `Test Article 2 for User Delete - ${Date.now()}`,
+        url: `https://dev.to/test/user-cascade-${Date.now()}`,
+        sourceId: devtoSource.id,
+        publishedAt: new Date(),
+      }
+    });
+    
+    const testUser2 = await prisma.user.create({
+      data: {
+        email: `test-cascade2-${Date.now()}@example.com`,
+        name: 'Test User 2',
+        password: 'dummy-password'
+      }
+    });
+    
+    await prisma.articleView.create({
+      data: {
+        userId: testUser2.id,
+        articleId: testArticle2.id,
+        viewedAt: new Date()
+      }
+    });
+    
+    // ユーザーを削除
+    await prisma.user.delete({
+      where: { id: testUser2.id }
+    });
+    
+    // ArticleViewが削除されたか確認
+    const userViewCount = await prisma.articleView.count({
+      where: { userId: testUser2.id }
+    });
+    
+    console.log('  ユーザー削除後のArticleView数:', userViewCount, '（期待値: 0）\n');
+    
+    // 5. テスト結果の判定
+    console.log('5. テスト結果:');
+    let success = true;
+    
+    if (!remainingView) {
+      console.log('  ✅ ArticleViewは記事削除時に自動削除されました（カスケード成功）');
+    } else {
+      console.error('  ❌ ArticleViewが残存しています（カスケード失敗）');
+      success = false;
+    }
+    
+    if (!remainingFavorite) {
+      console.log('  ✅ Favoriteは記事削除時に自動削除されました（カスケード成功）');
+    } else {
+      console.error('  ❌ Favoriteが残存しています（カスケード失敗）');
+      success = false;
+    }
+    
+    if (userViewCount === 0) {
+      console.log('  ✅ ArticleViewはユーザー削除時に自動削除されました（カスケード成功）');
+    } else {
+      console.error('  ❌ ユーザー削除後もArticleViewが残存しています');
+      success = false;
+    }
+    
+    // 6. クリーンアップ
+    console.log('\n6. テストデータのクリーンアップ...');
+    
+    // 残存テストデータをクリーンアップ
+    await prisma.article.delete({
+      where: { id: testArticle2.id }
+    }).catch(() => {});
+    
+    await prisma.user.delete({
+      where: { id: testUser.id }
+    }).catch(() => {});
+    
+    console.log('  クリーンアップ完了\n');
+    
+    if (success) {
+      console.log('✅ カスケード削除が正常に動作しています！');
+      console.log('   トランザクション処理なしで削除が可能になりました。');
+      return 0;
+    } else {
+      console.error('❌ カスケード削除のテストに失敗しました');
+      return 1;
+    }
+    
+  } catch (error) {
+    console.error('エラーが発生しました:', error);
+    return 1;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// テスト実行
+testCascadeDelete()
+  .then((exitCode) => {
+    process.exit(exitCode);
+  })
+  .catch((error) => {
+    console.error('予期しないエラー:', error);
+    process.exit(1);
+  });

--- a/scripts/test/test-cascade-delete.ts
+++ b/scripts/test/test-cascade-delete.ts
@@ -28,8 +28,7 @@ async function testCascadeDelete() {
       update: {},
       create: {
         email: 'test-cascade@example.com',
-        name: 'Test User for Cascade Delete',
-        password: 'dummy-password'
+        name: 'Test User for Cascade Delete'
       }
     });
     
@@ -90,10 +89,12 @@ async function testCascadeDelete() {
     });
     
     // Favoriteが自動削除されたか確認
-    const remainingFavorite = await prisma.favorite.findFirst({
+    const remainingFavorite = await prisma.favorite.findUnique({
       where: {
-        userId: testUser.id,
-        articleId: testArticle.id
+        userId_articleId: {
+          userId: testUser.id,
+          articleId: testArticle.id
+        }
       }
     });
     
@@ -116,8 +117,7 @@ async function testCascadeDelete() {
     const testUser2 = await prisma.user.create({
       data: {
         email: `test-cascade2-${Date.now()}@example.com`,
-        name: 'Test User 2',
-        password: 'dummy-password'
+        name: 'Test User 2'
       }
     });
     


### PR DESCRIPTION
## 概要
ArticleViewテーブルにカスケード削除設定を追加し、記事削除時の外部キー制約エラーを根本的に解決しました。

## 背景
- #23 でトランザクション処理による暫定対応を実施済み（Phase 1）
- 今回はPhase 2として、データベースレベルでの根本解決を実施
- Favoriteテーブルでは既にカスケード削除が実装済みで実績あり

## 変更内容
### 1. Prismaスキーマ修正
- ArticleViewモデルに`onDelete: Cascade`を追加
- 記事削除時とユーザー削除時の両方に対応

### 2. マイグレーション
- 外部キー制約の再定義でカスケード削除を有効化
- `prisma migrate deploy`で適用済み

### 3. テスト追加
- `scripts/test/test-cascade-delete.ts`: カスケード削除の動作確認テスト
- 記事削除、ユーザー削除の両シナリオをテスト

## テスト結果
✅ 既存テスト（test-delete-articles.ts）: 全て合格
✅ カスケード削除テスト: 全て成功
- 記事削除時のArticleView自動削除: 動作確認済み
- ユーザー削除時のArticleView自動削除: 動作確認済み
- Favoriteテーブルのカスケード削除: 動作確認済み

## 影響範囲
- **パフォーマンス向上**: トランザクション処理が不要になり、削除が高速化
- **コードの簡潔性**: 複雑なトランザクション処理を削除可能
- **データ整合性**: データベースレベルで保証

## 今後の作業
- [ ] ステージング環境での検証（Phase 2）
- [ ] 本番環境への適用（Phase 3）
- [ ] トランザクション処理の削除（Phase 4、オプション）

## 関連PR/Issue
- #23: Phase 1実装（トランザクション処理による暫定対応）

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - （該当なし）
- バグ修正
  - 記事またはユーザー削除時に関連する閲覧履歴やお気に入りが自動で削除され、孤立データや不整合の発生を防ぎます。
- テスト
  - カスケード削除の挙動を検証するエンドツーエンドテストを追加し、削除時の関連レコード消去を確認します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->