### PR TITLE
fix: GitHub ActionsのE2EテストでAuth.js UntrustedHostエラーを修正

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -286,6 +286,8 @@ jobs:
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/techtrend_test
           NEXTAUTH_SECRET: test-secret-key-for-testing-purposes-only-32chars
+          NEXTAUTH_URL: http://localhost:3000  # CI環境用に追加
+          AUTH_TRUST_HOST: true  # テスト環境専用、本番では使用しない
           PORT: 3000
         run: npm run test:e2e:chromium
 

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -287,7 +287,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/techtrend_test
           NEXTAUTH_SECRET: test-secret-key-for-testing-purposes-only-32chars
           NEXTAUTH_URL: http://localhost:3000  # CI環境用に追加
-          AUTH_TRUST_HOST: true  # テスト環境専用、本番では使用しない
+          AUTH_TRUST_HOST: 'true'  # テスト環境専用、本番では使用しない
           PORT: 3000
         run: npm run test:e2e:chromium
 


### PR DESCRIPTION
## 問題

GitHub ActionsでE2Eテストを実行すると、Auth.jsから `UntrustedHost` エラーが発生し、テストが失敗していました。

### エラーメッセージ
```
Error: [WebServer] [auth][error] UntrustedHost: Host must be trusted. 
URL was: http://localhost:3000/api/auth/session
```

## 原因

CI環境で `NEXTAUTH_URL` 環境変数が設定されていなかったため、Auth.jsがホストを正しく認識できませんでした。

## 解決策

`.github/workflows/quality-checks.yml` のE2Eテストジョブに以下の環境変数を追加:
- `NEXTAUTH_URL: http://localhost:3000` - Auth.jsが信頼するベースURLを明示的に指定
- `AUTH_TRUST_HOST: true` - CI環境でのホスト検証を緩和（テスト環境専用）

## 変更内容

- E2Eテストジョブのみに環境変数を追加
- 他のCIジョブには影響なし
- コードロジックの変更なし（環境変数の追加のみ）

## テスト

- [ ] GitHub ActionsでE2Eテストが成功することを確認
- [ ] UntrustedHostエラーが解消されることを確認
- [ ] 他のCIジョブに影響がないことを確認

## 参考資料

- [Auth.js UntrustedHost Error Documentation](https://errors.authjs.dev#untrustedhost)
- 調査レポート: `.claude/docs/investigate/investigate_1757027422183_github_actions_e2e_auth_error.md`
- 実装計画書: `.claude/docs/plan/plan_1757027606767_github_actions_e2e_auth_fix.md`

## チェックリスト

- [x] コード変更を実施
- [x] テスト環境専用の設定であることをコメントで明記
- [ ] GitHub ActionsでE2Eテストの成功を確認
- [ ] レビュー承認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E実行時に環境変数を追加（NEXTAUTH_URL=http://localhost:3000、AUTH_TRUST_HOST=true）。CI上でのテスト再現性と信頼性を向上。
* **Chores**
  * 品質チェック用ワークフローのテスト環境設定を拡張。ユーザー向けの挙動変更はなし。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->