### PR TITLE
fix: scripts直下のテストファイルをscripts/test/へ移動

### DIFF
--- a/scripts/test/fetch-moneyforward-test.ts
+++ b/scripts/test/fetch-moneyforward-test.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env tsx
+import { CorporateTechBlogFetcher } from '../lib/fetchers/corporate-tech-blog';
+import { PrismaClient } from '@prisma/client';
+
+async function testMoneyForwardFetch() {
+  const fetcher = new CorporateTechBlogFetcher();
+  const prisma = new PrismaClient();
+  
+  console.error("=== マネーフォワード記事取得テスト ===");
+  console.error(`環境変数 EXCLUDE_EVENT_ARTICLES: ${process.env.EXCLUDE_EVENT_ARTICLES || 'undefined (default: false)'}`);
+  console.error(`現在日時: ${new Date().toISOString()}`);
+  
+  try {
+    // 記事を取得
+    const articles = await fetcher.fetch();
+    
+    // マネーフォワードの記事のみフィルタリング
+    const moneyForwardArticles = articles.filter((article: any) => 
+      article.url.includes('moneyforward-dev.jp')
+    );
+    
+    console.error(`\n取得された記事数: ${articles.length}件`);
+    console.error(`マネーフォワードの記事数: ${moneyForwardArticles.length}件`);
+    
+    // CTF関連記事を探す
+    const ctfArticles = moneyForwardArticles.filter((article: any) =>
+      article.title.toLowerCase().includes('ctf')
+    );
+    
+    console.error(`\nCTF関連記事: ${ctfArticles.length}件`);
+    
+    if (ctfArticles.length > 0) {
+      console.error("\nCTF関連記事の詳細:");
+      ctfArticles.forEach((article: any, index: number) => {
+        console.error(`\n[${index + 1}] ${article.title}`);
+        console.error(`  URL: ${article.url}`);
+        console.error(`  公開日: ${article.publishedAt}`);
+        console.error(`  タグ: ${article.tags.join(', ')}`);
+        
+        // SECCON記事の特別チェック
+        if (article.title.includes('SECCON')) {
+          console.error(`  ✅ SECCON記事が正常に取得されました！`);
+          
+          // データベースに存在するか確認
+          prisma.article.findFirst({
+            where: { url: article.url }
+          }).then(existing => {
+            if (existing) {
+              console.error(`  データベース: 既に存在 (ID: ${existing.id})`);
+            } else {
+              console.error(`  データベース: 未保存`);
+            }
+          });
+        }
+      });
+    } else {
+      console.error("\n❌ CTF関連記事が取得されていません");
+      console.error("考えられる原因:");
+      console.error("1. RSSフィードに含まれていない");
+      console.error("2. 何らかのフィルタリングで除外されている");
+      console.error("3. 取得タイミングの問題");
+    }
+    
+    // 最新のマネーフォワード記事を表示
+    if (moneyForwardArticles.length > 0) {
+      console.error("\n最新のマネーフォワード記事（5件）:");
+      moneyForwardArticles.slice(0, 5).forEach((article: any, index: number) => {
+        console.error(`${index + 1}. ${article.title}`);
+        console.error(`   ${article.publishedAt}`);
+      });
+    }
+    
+  } catch (error) {
+    console.error("エラー:", error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+testMoneyForwardFetch().catch(console.error);

--- a/scripts/test/fetch-moneyforward-test.ts
+++ b/scripts/test/fetch-moneyforward-test.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env tsx
-import { CorporateTechBlogFetcher } from '../lib/fetchers/corporate-tech-blog';
+import { CorporateTechBlogFetcher } from '../../lib/fetchers/corporate-tech-blog';
 import { PrismaClient } from '@prisma/client';
 
 async function testMoneyForwardFetch() {

--- a/scripts/test/test-detailed-summary-display.ts
+++ b/scripts/test/test-detailed-summary-display.ts
@@ -3,7 +3,7 @@
  * サブ項目が改行されて表示されることを確認
  */
 
-import { parseSummary } from '../lib/utils/summary-parser';
+import { parseSummary } from '../../lib/utils/summary-parser';
 
 // テストデータ（実際の問題があったパターン）
 const testData = `・コメントの基本方針：「What」より「Why」：優れたコメントは、コードから読み取れる「何をしているか(What)」ではなく、「なぜそうしているか(Why)」を説明する必要がある。

--- a/scripts/test/test-detailed-summary-display.ts
+++ b/scripts/test/test-detailed-summary-display.ts
@@ -1,0 +1,74 @@
+/**
+ * 詳細要約の表示改善テスト
+ * サブ項目が改行されて表示されることを確認
+ */
+
+import { parseSummary } from '../lib/utils/summary-parser';
+
+// テストデータ（実際の問題があったパターン）
+const testData = `・コメントの基本方針：「What」より「Why」：優れたコメントは、コードから読み取れる「何をしているか(What)」ではなく、「なぜそうしているか(Why)」を説明する必要がある。
+・コードの価値を高める「良いコメント」の具体例：
+- 意図や背景を説明するコメント：コードだけでは理解できないビジネス上の理由や技術的な判断を記述する。
+- 複雑なロジックを要約するコメント：正規表現や難解なアルゴリズムなど、理解しにくいコードの前に、平易な言葉で要約する。
+- \`TODO\` や \`FIXME\` といったコメント：将来的な対応が必要な事項や既知の問題点を明確に示す。
+・コードの価値を下げる「悪いコメント」の具体例：
+- コードの「日本語訳」にすぎないコメント：コードを読めばわかることをそのままコメントに書くことは、コードの重複でありノイズとなる。
+- メンテナンスされていない古いコメント：コードを修正した際にコメントを更新しないと、コードとコメントに食い違いが生じ、混乱を招く。`;
+
+console.error('=== 詳細要約の表示改善テスト ===\n');
+
+// parseSummary関数でパース
+const sections = parseSummary(testData, { summaryVersion: 8 });
+
+console.error(`セクション数: ${sections.length}\n`);
+
+// 各セクションの内容を確認
+sections.forEach((section, index) => {
+  console.error(`--- セクション ${index + 1} ---`);
+  console.error(`タイトル: ${section.title}`);
+  console.error(`アイコン: ${section.icon}`);
+  console.error('コンテンツ:');
+  
+  // 改行で分割されたコンテンツを表示
+  const lines = section.content.split('\n');
+  if (lines.length > 1) {
+    console.error(`  (${lines.length}行のコンテンツ)`);
+    lines.forEach((line, lineIndex) => {
+      console.error(`  行${lineIndex + 1}: ${line}`);
+    });
+  } else {
+    console.error(`  ${section.content}`);
+  }
+  console.error();
+});
+
+// UIコンポーネントでの表示シミュレーション
+console.error('=== UIコンポーネントでの表示シミュレーション ===\n');
+
+sections.forEach((section) => {
+  console.error(`【${section.icon} ${section.title}】`);
+  
+  const lines = section.content.split('\n');
+  if (lines.length > 1) {
+    // 複数行の場合（サブ項目あり）
+    lines.forEach((line, lineIndex) => {
+      if (lineIndex > 0) {
+        console.error(''); // 改行（mt-2クラスに相当）
+      }
+      console.error(`  ${line}`);
+    });
+  } else {
+    // 単一行の場合
+    console.error(`  ${section.content}`);
+  }
+  console.error('\n---\n');
+});
+
+// 成功判定
+const hasMultilineContent = sections.some(s => s.content.includes('\n'));
+if (hasMultilineContent) {
+  console.error('✅ サブ項目が改行されて保存されています');
+  console.error('✅ UIコンポーネントで各行が別々の<p>タグとして表示されます');
+} else {
+  console.error('❌ サブ項目が改行されていません');
+}

--- a/scripts/test/test-devto-fetch-and-save.ts
+++ b/scripts/test/test-devto-fetch-and-save.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env npx tsx
+
+import { DevToFetcher } from '../lib/fetchers/devto';
+import { prisma } from '../lib/database';
+import { Source } from '@prisma/client';
+
+async function testDevToFetchAndSave() {
+  console.error('=== Dev.to フェッチャー統合テスト ===\n');
+
+  try {
+    // Dev.toソースを取得または作成
+    let devtoSource = await prisma.source.findFirst({
+      where: { name: 'Dev.to' }
+    });
+
+    if (!devtoSource) {
+      console.error('Dev.toソースが見つからないため、作成します...');
+      devtoSource = await prisma.source.create({
+        data: {
+          id: 'devto-test',
+          name: 'Dev.to',
+          url: 'https://dev.to',
+          type: 'api',
+          enabled: true,
+        }
+      });
+    }
+
+    console.error('ソース:', devtoSource.name);
+    console.error('ソースID:', devtoSource.id);
+    console.error();
+
+    // フェッチャーを作成
+    const fetcher = new DevToFetcher(devtoSource);
+    
+    // 記事を取得（最大3件に制限してテスト）
+    console.error('Dev.to APIから記事を取得中...');
+    const originalFetch = fetcher.fetch.bind(fetcher);
+    fetcher.fetch = async () => {
+      const result = await originalFetch();
+      // テスト用に3件に制限
+      result.articles = result.articles.slice(0, 3);
+      return result;
+    };
+
+    const { articles, errors } = await fetcher.fetch();
+    
+    console.error(`取得した記事数: ${articles.length}`);
+    if (errors.length > 0) {
+      console.error('エラー:', errors);
+    }
+    console.error();
+
+    // 各記事のタグを確認
+    console.error('記事とタグの確認:');
+    for (const article of articles) {
+      console.error(`\n記事: ${article.title.substring(0, 60)}...`);
+      console.error(`  URL: ${article.url}`);
+      console.error(`  タグ: ${article.tagNames.join(', ')}`);
+      console.error(`  タグ数: ${article.tagNames.length}`);
+      
+      // 1文字タグがないことを確認
+      const singleCharTags = article.tagNames.filter(tag => 
+        tag.length === 1 && !/^\d$/.test(tag)
+      );
+      if (singleCharTags.length > 0) {
+        console.error(`  ⚠️ 警告: 1文字タグが検出されました: ${singleCharTags}`);
+      } else {
+        console.error(`  ✅ 1文字タグなし`);
+      }
+    }
+
+    // データベースに保存（テスト用）
+    console.error('\n=== データベース保存テスト ===\n');
+    
+    let savedCount = 0;
+    let skippedCount = 0;
+    
+    for (const articleData of articles) {
+      try {
+        // 既存の記事をチェック
+        const existing = await prisma.article.findUnique({
+          where: { url: articleData.url }
+        });
+
+        if (existing) {
+          console.error(`スキップ（既存）: ${articleData.title.substring(0, 40)}...`);
+          skippedCount++;
+          
+          // 既存記事のタグを確認
+          const existingWithTags = await prisma.article.findUnique({
+            where: { url: articleData.url },
+            include: { tags: true }
+          });
+          
+          if (existingWithTags) {
+            const badTags = existingWithTags.tags.filter(tag => 
+              tag.name.length === 1 && !/^\d$/.test(tag.name)
+            );
+            if (badTags.length > 0) {
+              console.error(`  ⚠️ 既存記事に不正なタグ: ${badTags.map(t => t.name).join(', ')}`);
+            }
+          }
+        } else {
+          // 新規作成
+          const article = await prisma.article.create({
+            data: {
+              title: articleData.title,
+              url: articleData.url,
+              summary: articleData.summary,
+              content: articleData.content,
+              publishedAt: articleData.publishedAt,
+              sourceId: devtoSource.id,
+              tags: {
+                connectOrCreate: articleData.tagNames.map(name => ({
+                  where: { name },
+                  create: { name },
+                })),
+              },
+            },
+            include: {
+              tags: true,
+            }
+          });
+          
+          console.error(`✅ 保存: ${article.title.substring(0, 40)}...`);
+          console.error(`  タグ: ${article.tags.map(t => t.name).join(', ')}`);
+          savedCount++;
+        }
+      } catch (error) {
+        console.error(`エラー: ${articleData.title}`, error);
+      }
+    }
+
+    console.error(`\n結果: ${savedCount}件保存, ${skippedCount}件スキップ`);
+
+  } catch (error) {
+    console.error('テスト失敗:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+
+  console.error('\n=== テスト完了 ===');
+}
+
+testDevToFetchAndSave().catch(console.error);

--- a/scripts/test/test-devto-fetch-and-save.ts
+++ b/scripts/test/test-devto-fetch-and-save.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env npx tsx
 
-import { DevToFetcher } from '../lib/fetchers/devto';
-import { prisma } from '../lib/database';
+import { DevToFetcher } from '../../lib/fetchers/devto';
+import { prisma } from '../../lib/database';
 import { Source } from '@prisma/client';
 
 async function testDevToFetchAndSave() {

--- a/scripts/test/test-devto-fetcher.ts
+++ b/scripts/test/test-devto-fetcher.ts
@@ -6,7 +6,7 @@
  */
 
 import { PrismaClient } from '@prisma/client';
-import { DevToFetcher } from '../lib/fetchers/devto';
+import { DevToFetcher } from '../../lib/fetchers/devto';
 
 const prisma = new PrismaClient();
 

--- a/scripts/test/test-devto-fetcher.ts
+++ b/scripts/test/test-devto-fetcher.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env npx tsx
+
+/**
+ * Dev.toフェッチャーの動作テスト
+ * 改修後の個別記事詳細取得機能を確認
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { DevToFetcher } from '../lib/fetchers/devto';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  console.error('🚀 Dev.toフェッチャー動作テスト');
+  console.error('================================\n');
+
+  try {
+    // Dev.toソースを取得
+    const devtoSource = await prisma.source.findFirst({
+      where: { name: 'Dev.to' }
+    });
+
+    if (!devtoSource) {
+      console.error('❌ Dev.toソースが見つかりません');
+      return;
+    }
+
+    // フェッチャーのインスタンスを作成
+    const fetcher = new DevToFetcher(devtoSource);
+    
+    console.error('📡 Dev.toから記事を取得中...\n');
+    
+    // 記事を取得（最初の3件のみ詳細確認）
+    const result = await fetcher.fetch();
+    
+    if (result.errors.length > 0) {
+      console.error('⚠️ エラーが発生しました:');
+      result.errors.forEach(error => {
+        console.error(`  - ${error.message}`);
+      });
+      console.error('');
+    }
+    
+    console.error(`✅ 取得記事数: ${result.articles.length}件\n`);
+    
+    // 最初の3件の詳細を表示
+    const articlesToShow = Math.min(3, result.articles.length);
+    for (let i = 0; i < articlesToShow; i++) {
+      const article = result.articles[i];
+      console.error(`[${i + 1}] ${article.title}`);
+      console.error(`  URL: ${article.url}`);
+      console.error(`  タグ: ${Array.isArray(article.tagNames) ? article.tagNames.join(', ') : 'なし'}`);
+      console.error(`  ブックマーク: ${article.bookmarks}`);
+      console.error(`  コンテンツ長: ${article.content?.length || 0}文字`);
+      
+      // HTMLタグがあるか確認（本文が取得できているか）
+      const hasHtmlContent = article.content?.includes('<') && article.content?.includes('>');
+      console.error(`  HTML本文: ${hasHtmlContent ? '✅ あり' : '❌ なし（descriptionのみ）'}`);
+      
+      // 最初の100文字を表示
+      if (article.content && article.content.length > 0) {
+        const preview = article.content.substring(0, 100).replace(/\n/g, ' ');
+        console.error(`  プレビュー: ${preview}...`);
+      }
+      console.error('');
+    }
+    
+    // 統計情報
+    const contentLengths = result.articles.map(a => a.content?.length || 0);
+    const avgLength = Math.round(contentLengths.reduce((a, b) => a + b, 0) / contentLengths.length);
+    const htmlArticles = result.articles.filter(a => 
+      a.content?.includes('<') && a.content?.includes('>')
+    ).length;
+    
+    console.error('📊 統計情報:');
+    console.error(`  平均コンテンツ長: ${avgLength}文字`);
+    console.error(`  HTML本文あり: ${htmlArticles}/${result.articles.length}件`);
+    console.error(`  HTML本文取得率: ${Math.round(htmlArticles / result.articles.length * 100)}%`);
+
+  } catch (error) {
+    console.error('❌ エラーが発生しました:', error);
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// 実行
+main().catch(error => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/scripts/test/test-enrichment.ts
+++ b/scripts/test/test-enrichment.ts
@@ -4,7 +4,7 @@
  */
 
 import { PrismaClient } from '@prisma/client';
-import { GoogleDevEnricher } from '../lib/enrichers/google-dev';
+import { GoogleDevEnricher } from '../../lib/enrichers/google-dev';
 
 const prisma = new PrismaClient();
 const enricher = new GoogleDevEnricher();

--- a/scripts/test/test-enrichment.ts
+++ b/scripts/test/test-enrichment.ts
@@ -1,0 +1,63 @@
+/**
+ * Google Developers Blog Enrichment Test Script
+ * エンリッチメント機能のテスト実行（5件）
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { GoogleDevEnricher } from '../lib/enrichers/google-dev';
+
+const prisma = new PrismaClient();
+const enricher = new GoogleDevEnricher();
+
+async function testEnrichment() {
+  console.log('=== Google Developers Blog Enrichment Test (5 articles) ===');
+  
+  try {
+    // Google Developers Blogの最新5記事を取得
+    const articles = await prisma.article.findMany({
+      where: {
+        source: {
+          name: 'Google Developers Blog'
+        }
+      },
+      include: {
+        source: true
+      },
+      orderBy: {
+        publishedAt: 'desc'
+      },
+      take: 5
+    });
+    
+    console.log(`Testing with ${articles.length} articles`);
+    
+    for (const article of articles) {
+      console.log(`\n--- ${article.title} ---`);
+      console.log(`Current content length: ${article.content?.length || 0} chars`);
+      
+      try {
+        const enrichedData = await enricher.enrich(article.url);
+        
+        if (enrichedData && enrichedData.content) {
+          console.log(`Enriched content length: ${enrichedData.content.length} chars`);
+          console.log(`Improvement: ${enrichedData.content.length - (article.content?.length || 0)} chars`);
+          console.log(`Thumbnail: ${enrichedData.thumbnail ? 'Found' : 'Not found'}`);
+        } else {
+          console.log('Enrichment failed or returned no content');
+        }
+      } catch (error) {
+        console.error(`Error enriching: ${error}`);
+      }
+      
+      // Rate limit対策
+      await new Promise(resolve => setTimeout(resolve, 2000));
+    }
+    
+  } catch (error) {
+    console.error('Script error:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+testEnrichment().catch(console.error);

--- a/scripts/test/test-event-filter.ts
+++ b/scripts/test/test-event-filter.ts
@@ -1,0 +1,70 @@
+/**
+ * イベント記事フィルタリング機能のテストスクリプト
+ */
+
+import { CorporateTechBlogFetcher } from '../lib/fetchers/corporate-tech-blog';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function testEventFilter() {
+  try {
+    // Corporate Tech Blogソースを取得
+    const source = await prisma.source.findFirst({
+      where: { name: 'Corporate Tech Blog' }
+    });
+
+    if (!source) {
+      console.error('Corporate Tech Blog source not found');
+      return;
+    }
+
+    console.error('Testing event article filter...');
+    console.error('EXCLUDE_EVENT_ARTICLES:', process.env.EXCLUDE_EVENT_ARTICLES || 'undefined (default: false)');
+    console.error('---');
+
+    // フェッチャーを初期化
+    const fetcher = new CorporateTechBlogFetcher(source);
+
+    // 記事を取得
+    const result = await fetcher.fetch();
+
+    console.error(`Total articles fetched: ${result.articles.length}`);
+    
+    // 記事のタイトルを表示（最初の10件）
+    console.error('\nFirst 10 articles:');
+    result.articles.slice(0, 10).forEach((article, index) => {
+      console.error(`${index + 1}. ${article.title}`);
+    });
+
+    // エラーがあれば表示
+    if (result.errors.length > 0) {
+      console.error('\nErrors:');
+      result.errors.forEach(error => {
+        console.error(`- ${error.message}`);
+      });
+    }
+
+    // イベント系キーワードを含む記事をカウント
+    const eventKeywords = ['登壇', 'イベント', 'セミナー', '勉強会', 'カンファレンス', 'meetup', '参加募集', '開催'];
+    const eventArticles = result.articles.filter(article => 
+      eventKeywords.some(keyword => article.title.includes(keyword))
+    );
+
+    console.error(`\nArticles with event keywords: ${eventArticles.length}`);
+    if (eventArticles.length > 0) {
+      console.error('Event articles found:');
+      eventArticles.forEach(article => {
+        console.error(`- ${article.title}`);
+      });
+    }
+
+  } catch (error) {
+    console.error('Error during test:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// 実行
+testEventFilter();

--- a/scripts/test/test-event-filter.ts
+++ b/scripts/test/test-event-filter.ts
@@ -2,7 +2,7 @@
  * イベント記事フィルタリング機能のテストスクリプト
  */
 
-import { CorporateTechBlogFetcher } from '../lib/fetchers/corporate-tech-blog';
+import { CorporateTechBlogFetcher } from '../../lib/fetchers/corporate-tech-blog';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();

--- a/scripts/test/test-hatena-enrichment-detailed.ts
+++ b/scripts/test/test-hatena-enrichment-detailed.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env npx tsx
+/**
+ * はてなブックマークフェッチャーのエンリッチメント機能詳細テスト
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { HatenaExtendedFetcher } from '../lib/fetchers/hatena-extended';
+
+const prisma = new PrismaClient();
+
+interface TestResult {
+  testName: string;
+  passed: boolean;
+  message: string;
+  details?: any;
+}
+
+async function runTests(): Promise<TestResult[]> {
+  const results: TestResult[] = [];
+  
+  try {
+    // はてなブックマークのソースを取得
+    const source = await prisma.source.findFirst({
+      where: { name: 'はてなブックマーク' }
+    });
+
+    if (!source) {
+      results.push({
+        testName: 'ソース取得',
+        passed: false,
+        message: 'はてなブックマークのソースが見つかりません'
+      });
+      return results;
+    }
+
+    // テスト1: フェッチャーのインスタンス作成
+    console.error('テスト1: フェッチャーのインスタンス作成...');
+    try {
+      const fetcher = new HatenaExtendedFetcher(source);
+      results.push({
+        testName: 'フェッチャーインスタンス作成',
+        passed: true,
+        message: 'フェッチャーが正常に作成されました'
+      });
+    } catch (error) {
+      results.push({
+        testName: 'フェッチャーインスタンス作成',
+        passed: false,
+        message: `エラー: ${error}`
+      });
+      return results;
+    }
+
+    // テスト2: 記事の取得とエンリッチメント
+    console.error('テスト2: 記事の取得とエンリッチメント...');
+    const fetcher = new HatenaExtendedFetcher(source);
+    const startTime = Date.now();
+    const result = await fetcher.fetch();
+    const endTime = Date.now();
+    const executionTime = endTime - startTime;
+
+    results.push({
+      testName: '記事取得',
+      passed: result.articles.length > 0,
+      message: `${result.articles.length}件の記事を取得 (実行時間: ${executionTime}ms)`,
+      details: {
+        articleCount: result.articles.length,
+        errorCount: result.errors.length,
+        executionTimeMs: executionTime
+      }
+    });
+
+    // テスト3: エンリッチメントの効果測定
+    console.error('テスト3: エンリッチメントの効果測定...');
+    const enrichmentStats = {
+      totalArticles: result.articles.length,
+      enrichedArticles: 0,
+      averageContentExpansion: 0,
+      maxContentExpansion: 0,
+      articlesWithThumbnail: 0
+    };
+
+    const contentExpansions: number[] = [];
+    
+    for (const article of result.articles) {
+      const contentLength = article.content?.length || 0;
+      
+      // 一般的なRSS抜粋の長さ（300文字）より長い場合はエンリッチメント成功とみなす
+      if (contentLength > 300) {
+        enrichmentStats.enrichedArticles++;
+        // 拡張率の推定（元の長さを200文字と仮定）
+        const expansion = contentLength / 200;
+        contentExpansions.push(expansion);
+        enrichmentStats.maxContentExpansion = Math.max(enrichmentStats.maxContentExpansion, expansion);
+      }
+      
+      if (article.thumbnail) {
+        enrichmentStats.articlesWithThumbnail++;
+      }
+    }
+
+    if (contentExpansions.length > 0) {
+      enrichmentStats.averageContentExpansion = 
+        contentExpansions.reduce((a, b) => a + b, 0) / contentExpansions.length;
+    }
+
+    results.push({
+      testName: 'エンリッチメント効果',
+      passed: enrichmentStats.enrichedArticles > 0,
+      message: `${enrichmentStats.enrichedArticles}/${enrichmentStats.totalArticles}件でエンリッチメント成功`,
+      details: enrichmentStats
+    });
+
+    // テスト4: コンテンツ品質チェック
+    console.error('テスト4: コンテンツ品質チェック...');
+    const qualityCheck = {
+      articlesWithContent: 0,
+      articlesWithLongContent: 0, // 1000文字以上
+      articlesWithVeryLongContent: 0, // 3000文字以上
+      shortestContent: Infinity,
+      longestContent: 0
+    };
+
+    for (const article of result.articles) {
+      const contentLength = article.content?.length || 0;
+      if (contentLength > 0) {
+        qualityCheck.articlesWithContent++;
+        if (contentLength >= 1000) qualityCheck.articlesWithLongContent++;
+        if (contentLength >= 3000) qualityCheck.articlesWithVeryLongContent++;
+        qualityCheck.shortestContent = Math.min(qualityCheck.shortestContent, contentLength);
+        qualityCheck.longestContent = Math.max(qualityCheck.longestContent, contentLength);
+      }
+    }
+
+    results.push({
+      testName: 'コンテンツ品質',
+      passed: qualityCheck.articlesWithLongContent > 0,
+      message: `${qualityCheck.articlesWithLongContent}件が1000文字以上のコンテンツを持つ`,
+      details: qualityCheck
+    });
+
+    // テスト5: エラーハンドリング
+    console.error('テスト5: エラーハンドリング...');
+    const errorHandling = {
+      totalErrors: result.errors.length,
+      criticalErrors: 0,
+      recoveredFromErrors: result.articles.length > 0 && result.errors.length > 0
+    };
+
+    results.push({
+      testName: 'エラーハンドリング',
+      passed: errorHandling.totalErrors === 0 || errorHandling.recoveredFromErrors,
+      message: errorHandling.totalErrors === 0 
+        ? 'エラーなし' 
+        : `${errorHandling.totalErrors}件のエラーが発生したが処理継続`,
+      details: errorHandling
+    });
+
+    // テスト6: 具体的な記事のサンプル確認
+    console.error('テスト6: 具体的な記事のサンプル確認...');
+    const sampleArticles = result.articles.slice(0, 3).map(article => ({
+      title: article.title.substring(0, 50) + '...',
+      contentLength: article.content?.length || 0,
+      hasThumbnail: !!article.thumbnail,
+      bookmarks: article.bookmarks
+    }));
+
+    results.push({
+      testName: 'サンプル記事確認',
+      passed: true,
+      message: `上位${sampleArticles.length}件の記事を確認`,
+      details: sampleArticles
+    });
+
+  } catch (error) {
+    results.push({
+      testName: '全体テスト',
+      passed: false,
+      message: `テスト実行中にエラーが発生: ${error}`
+    });
+  }
+
+  return results;
+}
+
+async function main() {
+  console.error('='.repeat(60));
+  console.error('はてなブックマークエンリッチメント機能詳細テスト');
+  console.error('='.repeat(60));
+  console.error();
+
+  const results = await runTests();
+  
+  console.error('\n' + '='.repeat(60));
+  console.error('テスト結果サマリー');
+  console.error('='.repeat(60));
+  
+  let passedCount = 0;
+  let failedCount = 0;
+  
+  for (const result of results) {
+    const status = result.passed ? '✅ PASS' : '❌ FAIL';
+    console.error(`\n${status}: ${result.testName}`);
+    console.error(`  ${result.message}`);
+    
+    if (result.details) {
+      console.error('  詳細:');
+      console.error('  ', JSON.stringify(result.details, null, 2).split('\n').join('\n    '));
+    }
+    
+    if (result.passed) {
+      passedCount++;
+    } else {
+      failedCount++;
+    }
+  }
+  
+  console.error('\n' + '='.repeat(60));
+  console.error(`総合結果: ${passedCount}/${results.length} テスト成功`);
+  
+  if (failedCount === 0) {
+    console.error('🎉 すべてのテストが成功しました！');
+  } else {
+    console.error(`⚠️  ${failedCount}件のテストが失敗しました`);
+  }
+  console.error('='.repeat(60));
+  
+  await prisma.$disconnect();
+  
+  // Exit code based on test results
+  process.exit(failedCount > 0 ? 1 : 0);
+}
+
+main().catch(console.error);

--- a/scripts/test/test-hatena-enrichment-detailed.ts
+++ b/scripts/test/test-hatena-enrichment-detailed.ts
@@ -4,7 +4,7 @@
  */
 
 import { PrismaClient } from '@prisma/client';
-import { HatenaExtendedFetcher } from '../lib/fetchers/hatena-extended';
+import { HatenaExtendedFetcher } from '../../lib/fetchers/hatena-extended';
 
 const prisma = new PrismaClient();
 

--- a/scripts/test/test-hatena-enrichment.ts
+++ b/scripts/test/test-hatena-enrichment.ts
@@ -4,7 +4,7 @@
  */
 
 import { PrismaClient } from '@prisma/client';
-import { HatenaExtendedFetcher } from '../lib/fetchers/hatena-extended';
+import { HatenaExtendedFetcher } from '../../lib/fetchers/hatena-extended';
 
 const prisma = new PrismaClient();
 

--- a/scripts/test/test-hatena-enrichment.ts
+++ b/scripts/test/test-hatena-enrichment.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env npx tsx
+/**
+ * はてなブックマークフェッチャーのエンリッチメント機能テスト
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { HatenaExtendedFetcher } from '../lib/fetchers/hatena-extended';
+
+const prisma = new PrismaClient();
+
+async function testHatenaEnrichment() {
+  try {
+    // はてなブックマークのソースを取得
+    const source = await prisma.source.findFirst({
+      where: { name: 'はてなブックマーク' }
+    });
+
+    if (!source) {
+      console.error('はてなブックマークのソースが見つかりません');
+      return;
+    }
+
+    console.error('はてなブックマークフェッチャーのテストを開始...');
+    
+    // フェッチャーのインスタンスを作成
+    const fetcher = new HatenaExtendedFetcher(source);
+    
+    // fetch()メソッドを実行（最初の数記事のみテスト）
+    console.error('記事の取得とエンリッチメントを実行中...');
+    const result = await fetcher.fetch();
+    
+    // 結果を表示
+    console.error(`\n取得した記事数: ${result.articles.length}`);
+    console.error(`エラー数: ${result.errors.length}`);
+    
+    // 最初の3記事のコンテンツ長を表示
+    result.articles.slice(0, 3).forEach((article, index) => {
+      console.error(`\n記事 ${index + 1}:`);
+      console.error(`  タイトル: ${article.title}`);
+      console.error(`  URL: ${article.url}`);
+      console.error(`  コンテンツ長: ${article.content?.length || 0} 文字`);
+      console.error(`  サムネイル: ${article.thumbnail ? 'あり' : 'なし'}`);
+      console.error(`  ブックマーク数: ${article.bookmarks}`);
+    });
+
+    // エラーがあれば表示
+    if (result.errors.length > 0) {
+      console.error('\nエラー:');
+      result.errors.forEach(error => {
+        console.error(`  - ${error.message}`);
+      });
+    }
+
+  } catch (error) {
+    console.error('テスト実行中にエラーが発生しました:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// テスト実行
+testHatenaEnrichment();

--- a/scripts/test/test-hatena-quick.ts
+++ b/scripts/test/test-hatena-quick.ts
@@ -5,7 +5,7 @@
  */
 
 import { PrismaClient } from '@prisma/client';
-import { ContentEnricherFactory } from '../lib/enrichers';
+import { ContentEnricherFactory } from '../../lib/enrichers';
 
 const prisma = new PrismaClient();
 

--- a/scripts/test/test-hatena-quick.ts
+++ b/scripts/test/test-hatena-quick.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env npx tsx
+/**
+ * はてなブックマークフェッチャーのエンリッチメント機能クイックテスト
+ * （タイムアウト対策版）
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { ContentEnricherFactory } from '../lib/enrichers';
+
+const prisma = new PrismaClient();
+
+async function quickTest() {
+  console.error('='.repeat(60));
+  console.error('はてなブックマークエンリッチメント機能クイックテスト');
+  console.error('='.repeat(60));
+  
+  try {
+    // 1. エンリッチャーファクトリーテスト
+    console.error('\n1. エンリッチャーファクトリーテスト');
+    const factory = new ContentEnricherFactory();
+    
+    const testUrls = [
+      'https://www.itmedia.co.jp/news/articles/test.html',
+      'https://zenn.dev/test/articles/test',
+      'https://qiita.com/test/items/test'
+    ];
+    
+    for (const url of testUrls) {
+      const enricher = factory.getEnricher(url);
+      console.error(`  ${url}: ${enricher ? enricher.constructor.name : 'No enricher'}`);
+    }
+    
+    // 2. 実際のエンリッチメントテスト（1件のみ）
+    console.error('\n2. 実際のエンリッチメントテスト');
+    const testUrl = 'https://www.itmedia.co.jp/news/articles/2508/15/news072.html';
+    const enricher = factory.getEnricher(testUrl);
+    
+    if (enricher) {
+      console.error(`  テストURL: ${testUrl}`);
+      console.error(`  使用エンリッチャー: ${enricher.constructor.name}`);
+      
+      try {
+        const startTime = Date.now();
+        const enrichedData = await enricher.enrich(testUrl);
+        const endTime = Date.now();
+        
+        if (enrichedData && enrichedData.content) {
+          console.error(`  ✅ エンリッチメント成功`);
+          console.error(`    - コンテンツ長: ${enrichedData.content.length} 文字`);
+          console.error(`    - サムネイル: ${enrichedData.thumbnail ? 'あり' : 'なし'}`);
+          console.error(`    - 実行時間: ${endTime - startTime}ms`);
+        } else {
+          console.error(`  ⚠️  エンリッチメント結果が空`);
+        }
+      } catch (error) {
+        console.error(`  ❌ エンリッチメントエラー: ${error}`);
+      }
+    }
+    
+    // 3. はてなブックマークソースの確認
+    console.error('\n3. はてなブックマークソースの確認');
+    const source = await prisma.source.findFirst({
+      where: { name: 'はてなブックマーク' }
+    });
+    
+    if (source) {
+      console.error(`  ✅ ソース存在: ID=${source.id}, URL=${source.url}`);
+      
+      // 最近の記事のコンテンツ長を確認
+      const recentArticles = await prisma.article.findMany({
+        where: { sourceId: source.id },
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+        select: {
+          id: true,
+          title: true,
+          content: true,
+          thumbnail: true,
+          createdAt: true
+        }
+      });
+      
+      console.error(`\n  最近の記事（${recentArticles.length}件）:`);
+      for (const article of recentArticles) {
+        const contentLength = article.content?.length || 0;
+        const hasThumb = !!article.thumbnail;
+        console.error(`    - ${article.title.substring(0, 40)}...`);
+        console.error(`      コンテンツ: ${contentLength}文字, サムネイル: ${hasThumb ? '✅' : '❌'}`);
+      }
+    } else {
+      console.error(`  ❌ はてなブックマークソースが見つかりません`);
+    }
+    
+    // 4. 総合評価
+    console.error('\n' + '='.repeat(60));
+    console.error('テスト結果サマリー');
+    console.error('='.repeat(60));
+    console.error('✅ エンリッチャーファクトリー: 正常動作');
+    console.error('✅ エンリッチメント処理: 正常動作');
+    console.error('✅ データベース連携: 正常動作');
+    console.error('\n🎉 基本機能テスト成功！');
+    
+  } catch (error) {
+    console.error('\n❌ テストエラー:', error);
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+quickTest().catch(console.error);

--- a/scripts/test/test-improved-fetcher.ts
+++ b/scripts/test/test-improved-fetcher.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env tsx
+import { CorporateTechBlogFetcher } from '../lib/fetchers/corporate-tech-blog';
+import { PrismaClient } from '@prisma/client';
+
+async function testImprovedFetcher() {
+  const fetcher = new CorporateTechBlogFetcher();
+  const prisma = new PrismaClient();
+  
+  console.error("=== Corporate Tech Blog Fetcher 改善版テスト ===");
+  console.error(`環境変数 EXCLUDE_EVENT_ARTICLES: ${process.env.EXCLUDE_EVENT_ARTICLES || 'undefined (default: false)'}`);
+  console.error(`環境変数 MAX_ARTICLES_PER_COMPANY: ${process.env.MAX_ARTICLES_PER_COMPANY || 'undefined (default: 30)'}`);
+  console.error(`現在日時: ${new Date().toISOString()}`);
+  console.error("");
+  
+  try {
+    const startTime = Date.now();
+    
+    // 記事を取得
+    const result = await fetcher.fetch();
+    
+    const endTime = Date.now();
+    const elapsedTime = (endTime - startTime) / 1000;
+    
+    console.error("\n=== 取得結果サマリー ===");
+    console.error(`処理時間: ${elapsedTime.toFixed(2)}秒`);
+    console.error(`取得された記事総数: ${result.articles.length}件`);
+    console.error(`エラー数: ${result.errors.length}件`);
+    
+    // 企業別の記事数を集計
+    const articlesByCompany = new Map<string, number>();
+    const ctfArticles: any[] = [];
+    const englishTitleJapaneseArticles: any[] = [];
+    
+    for (const article of result.articles) {
+      // 企業名タグ（最初のタグ）で集計
+      const companyTag = article.tagNames[0];
+      articlesByCompany.set(companyTag, (articlesByCompany.get(companyTag) || 0) + 1);
+      
+      // CTF関連記事を検出
+      if (article.title.toLowerCase().includes('ctf')) {
+        ctfArticles.push(article);
+      }
+      
+      // 英数字タイトルの日本語記事を検出
+      const hasJapaneseInTitle = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/.test(article.title);
+      const hasJapaneseInContent = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/.test(article.content || '');
+      if (!hasJapaneseInTitle && hasJapaneseInContent) {
+        englishTitleJapaneseArticles.push(article);
+      }
+    }
+    
+    console.error("\n=== 企業別記事数 ===");
+    for (const [company, count] of articlesByCompany.entries()) {
+      console.error(`${company}: ${count}件`);
+    }
+    
+    // マネーフォワードの記事を詳しく表示
+    const moneyForwardArticles = result.articles.filter(article => 
+      article.url.includes('moneyforward-dev.jp')
+    );
+    
+    console.error(`\n=== マネーフォワードの記事 (${moneyForwardArticles.length}件) ===`);
+    moneyForwardArticles.forEach((article, index) => {
+      console.error(`[${index + 1}] ${article.title}`);
+      console.error(`    URL: ${article.url}`);
+      console.error(`    公開日: ${article.publishedAt}`);
+      
+      // SECCON記事の特別確認
+      if (article.title.includes('SECCON')) {
+        console.error(`    ✅ SECCON記事が正常に取得されました！`);
+      }
+    });
+    
+    // CTF関連記事の確認
+    if (ctfArticles.length > 0) {
+      console.error(`\n=== CTF関連記事 (${ctfArticles.length}件) ===`);
+      ctfArticles.forEach((article, index) => {
+        console.error(`[${index + 1}] ${article.title}`);
+        console.error(`    企業: ${article.tagNames[0]}`);
+        console.error(`    URL: ${article.url}`);
+      });
+    }
+    
+    // 英数字タイトルの日本語記事
+    if (englishTitleJapaneseArticles.length > 0) {
+      console.error(`\n=== 英数字タイトルの日本語記事 (${englishTitleJapaneseArticles.length}件) ===`);
+      console.error("（改善により正しく取得されるようになった記事）");
+      englishTitleJapaneseArticles.forEach((article, index) => {
+        console.error(`[${index + 1}] ${article.title}`);
+        console.error(`    企業: ${article.tagNames[0]}`);
+      });
+    }
+    
+    // 日付範囲の確認
+    const dates = result.articles.map(a => a.publishedAt).sort();
+    if (dates.length > 0) {
+      const oldestDate = dates[0];
+      const newestDate = dates[dates.length - 1];
+      const thirtyDaysAgo = new Date();
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+      
+      console.error("\n=== 日付範囲 ===");
+      console.error(`最古の記事: ${oldestDate}`);
+      console.error(`最新の記事: ${newestDate}`);
+      console.error(`30日前: ${thirtyDaysAgo.toISOString()}`);
+      
+      const oldArticles = result.articles.filter(a => a.publishedAt < thirtyDaysAgo);
+      if (oldArticles.length > 0) {
+        console.error(`⚠️ 30日より古い記事が ${oldArticles.length}件含まれています`);
+      } else {
+        console.error(`✅ すべての記事が30日以内です`);
+      }
+    }
+    
+    // エラーの表示
+    if (result.errors.length > 0) {
+      console.error("\n=== エラー ===");
+      result.errors.forEach((error, index) => {
+        console.error(`[${index + 1}] ${error.message}`);
+      });
+    }
+    
+    // データベースへの保存はテスト時は行わない
+    console.error("\n注意: これはテスト実行のため、データベースへの保存は行いません");
+    
+  } catch (error) {
+    console.error("エラー:", error);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+testImprovedFetcher().catch(console.error);

--- a/scripts/test/test-improved-fetcher.ts
+++ b/scripts/test/test-improved-fetcher.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env tsx
-import { CorporateTechBlogFetcher } from '../lib/fetchers/corporate-tech-blog';
+import { CorporateTechBlogFetcher } from '../../lib/fetchers/corporate-tech-blog';
 import { PrismaClient } from '@prisma/client';
 
 async function testImprovedFetcher() {

--- a/scripts/test/test-japanese-check.ts
+++ b/scripts/test/test-japanese-check.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env tsx
-import { CorporateTechBlogFetcher } from '../lib/fetchers/corporate-tech-blog';
+import { CorporateTechBlogFetcher } from '../../lib/fetchers/corporate-tech-blog';
 
 async function testJapaneseCheck() {
   const fetcher = new CorporateTechBlogFetcher();

--- a/scripts/test/test-japanese-check.ts
+++ b/scripts/test/test-japanese-check.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env tsx
+import { CorporateTechBlogFetcher } from '../lib/fetchers/corporate-tech-blog';
+
+async function testJapaneseCheck() {
+  const fetcher = new CorporateTechBlogFetcher();
+  
+  // SECCON記事のデータ（RSSフィードから取得した内容）
+  const testTitle = "SECCON Beginners CTF 2025 Writeup";
+  const testDescription = "株式会社マネーフォワード ビジネスカンパニー ERP開発本部の関西開発部に所属しているnanriです. 弊社有志でCTFに参加しました. この記事は僕が解いた問題のWriteup(問題の解き方をまとめたもの)になります. What is SECCON Beginners CTF? What is CTF? CTFについては関西開発部のインタビューより以下のとおりです. CTF（Capture The Flag:旗取り合戦）は、情報セキュリティのスキルを競い合うセキュリティコンテストです。 参加者は与えられた課題の中から隠された「FLAG」と呼ばれる文字列を見つけ出し、得点を競います。 また、さ…";
+  
+  // containsJapanese メソッドを直接呼び出す
+  const containsJapanese = (fetcher as any).containsJapanese;
+  
+  console.error("=== 日本語判定テスト ===");
+  console.error(`タイトル: "${testTitle}"`);
+  console.error(`タイトルに日本語を含む: ${containsJapanese(testTitle)}`);
+  console.error("");
+  console.error(`説明文: "${testDescription.substring(0, 100)}..."`);
+  console.error(`説明文に日本語を含む: ${containsJapanese(testDescription)}`);
+  console.error("");
+  
+  // 複合判定（実際のfetchメソッドの判定ロジック）
+  const hasJapanese = containsJapanese(testTitle) || containsJapanese(testDescription);
+  console.error(`総合判定（タイトル OR 説明文）: ${hasJapanese}`);
+  
+  if (!hasJapanese) {
+    console.error("\n❌ この記事は非日本語記事として除外されます");
+    console.error("\n原因分析:");
+    console.error("- タイトルが英数字のみで構成されている");
+    console.error("- 説明文に日本語が含まれていない可能性");
+    
+    // 詳細分析
+    const japanesePattern = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/g;
+    const matches = testDescription.match(japanesePattern);
+    if (matches) {
+      console.error(`\n説明文中の日本語文字（最初の10文字）: ${matches.slice(0, 10).join('')}`);
+    } else {
+      console.error("\n説明文に日本語文字が検出されませんでした");
+    }
+  } else {
+    console.error("\n✅ この記事は日本語記事として処理されます");
+  }
+}
+
+testJapaneseCheck().catch(console.error);

--- a/scripts/test/test-moneyforward-only.ts
+++ b/scripts/test/test-moneyforward-only.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env tsx
+import Parser from 'rss-parser';
+
+async function testMoneyForwardOnly() {
+  const parser = new Parser();
+  
+  console.error("=== マネーフォワード記事取得テスト（改善版） ===");
+  console.error(`環境変数 EXCLUDE_EVENT_ARTICLES: ${process.env.EXCLUDE_EVENT_ARTICLES || 'false'}`);
+  console.error("");
+  
+  try {
+    const feed = await parser.parseURL('https://moneyforward-dev.jp/feed');
+    
+    console.error(`RSSフィードから${feed.items?.length || 0}件の記事を取得`);
+    
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    
+    let processedCount = 0;
+    let skippedNonJapanese = 0;
+    let skippedOld = 0;
+    let skippedEvent = 0;
+    const articles: any[] = [];
+    
+    for (const item of feed.items || []) {
+      if (!item.title || !item.link) continue;
+      
+      // 日付チェック
+      const publishedAt = item.isoDate ? new Date(item.isoDate) :
+                         item.pubDate ? new Date(item.pubDate) : new Date();
+      
+      if (publishedAt < thirtyDaysAgo) {
+        skippedOld++;
+        continue;
+      }
+      
+      // 日本語チェック（改善版）
+      const textToCheck = item.description || item.content || 
+                         item.summary || item.contentSnippet || '';
+      const japanesePattern = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/;
+      const hasJapanese = japanesePattern.test(item.title) || 
+                         japanesePattern.test(textToCheck);
+      
+      if (!hasJapanese) {
+        console.error(`非日本語記事をスキップ: ${item.title}`);
+        skippedNonJapanese++;
+        continue;
+      }
+      
+      // イベント記事チェック（環境変数で制御）
+      const excludeEvents = process.env.EXCLUDE_EVENT_ARTICLES === 'true';
+      if (excludeEvents) {
+        const eventKeywords = [
+          '登壇', 'イベント', 'セミナー', '勉強会',
+          'カンファレンス', 'meetup', '参加募集', '開催しました',
+          '開催します', '参加者募集'
+        ];
+        const excludeExceptions = ['振り返り', 'レポート', '技術解説', 'まとめ'];
+        
+        const hasException = excludeExceptions.some(exception => 
+          item.title.includes(exception)
+        );
+        
+        if (!hasException) {
+          const hasEventKeyword = eventKeywords.some(keyword => 
+            item.title.includes(keyword) || item.title.toLowerCase().includes(keyword.toLowerCase())
+          );
+          
+          if (hasEventKeyword) {
+            console.error(`イベント記事を除外: ${item.title}`);
+            skippedEvent++;
+            continue;
+          }
+        }
+      }
+      
+      processedCount++;
+      articles.push({
+        title: item.title,
+        url: item.link,
+        publishedAt: publishedAt.toISOString(),
+        hasDescription: !!item.description,
+        hasContent: !!item.content,
+        hasSummary: !!item.summary
+      });
+    }
+    
+    console.error("\n=== 処理結果サマリー ===");
+    console.error(`処理された記事: ${processedCount}件`);
+    console.error(`スキップ（30日より古い）: ${skippedOld}件`);
+    console.error(`スキップ（非日本語）: ${skippedNonJapanese}件`);
+    console.error(`スキップ（イベント記事）: ${skippedEvent}件`);
+    
+    console.error("\n=== 取得された記事一覧 ===");
+    articles.forEach((article, index) => {
+      console.error(`[${index + 1}] ${article.title}`);
+      console.error(`    URL: ${article.url}`);
+      console.error(`    公開日: ${article.publishedAt}`);
+      console.error(`    フィールド: description=${article.hasDescription}, content=${article.hasContent}, summary=${article.hasSummary}`);
+      
+      // SECCON記事の特別確認
+      if (article.title.includes('SECCON')) {
+        console.error(`    ✅ SECCON記事が正常に取得されました！`);
+      }
+    });
+    
+    // SECCON記事が含まれているか最終確認
+    const hasSecconArticle = articles.some(a => a.title.includes('SECCON'));
+    if (!hasSecconArticle) {
+      console.error("\n⚠️ SECCON記事が取得されませんでした");
+      
+      // RSSフィードにSECCON記事が存在するか確認
+      const secconInFeed = feed.items?.some(item => item.title?.includes('SECCON'));
+      if (secconInFeed) {
+        console.error("RSSフィードにはSECCON記事が存在しますが、フィルタリングされました");
+      }
+    }
+    
+  } catch (error) {
+    console.error("エラー:", error);
+  }
+}
+
+testMoneyForwardOnly().catch(console.error);

--- a/scripts/test/test-parse-summary.ts
+++ b/scripts/test/test-parse-summary.ts
@@ -1,4 +1,4 @@
-import { parseSummary } from '../lib/utils/summary-parser';
+import { parseSummary } from '../../lib/utils/summary-parser';
 
 const detailedSummary = `・コメントの基本方針：「What」より「Why」：優れたコメントは、コードから読み取れる「何をしているか(What)」ではなく、「なぜそうしているか(Why)」を説明する必要がある。ビジネス上の背景や技術的な意図を記述することで、コードの理解度を高め、保守性を向上させる。例として、新規ユーザーの強制リダイレクト処理における背景説明が挙げられている。
 ・コードの価値を高める「良いコメント」の具体例：

--- a/scripts/test/test-parse-summary.ts
+++ b/scripts/test/test-parse-summary.ts
@@ -1,0 +1,36 @@
+import { parseSummary } from '../lib/utils/summary-parser';
+
+const detailedSummary = `・コメントの基本方針：「What」より「Why」：優れたコメントは、コードから読み取れる「何をしているか(What)」ではなく、「なぜそうしているか(Why)」を説明する必要がある。ビジネス上の背景や技術的な意図を記述することで、コードの理解度を高め、保守性を向上させる。例として、新規ユーザーの強制リダイレクト処理における背景説明が挙げられている。
+・コードの価値を高める「良いコメント」の具体例：
+- 意図や背景を説明するコメント：コードだけでは理解できないビジネス上の理由や技術的な判断を記述する。例として、GitHub経由の新規ユーザーの電話番号未入力状態への対応が挙げられている。これにより、他の開発者や将来の自分が仕様を理解しやすくなる。
+- 複雑なロジックを要約するコメント：正規表現や難解なアルゴリズムなど、理解しにくいコードの前に、平易な言葉で要約する。例として、全角カタカナ、半角カタカナ、長音符のみを許可する正規表現の解説が挙げられている。
+- \`TODO\` や \`FIXME\` といったコメント：将来的な対応が必要な事項や既知の問題点を明確に示す。\`TODO\`は今後の機能追加やリファクタリング、\`FIXME\`は修正が必要な箇所を示す。例として、N+1問題の最適化や外部APIのタイムアウト処理への対応が挙げられている。
+・コードの価値を下げる「悪いコメント」の具体例：
+- コードの「日本語訳」にすぎないコメント：コードを読めばわかることをそのままコメントに書くことは、コードの重複でありノイズとなる。例として、「iを1増やす」というコメントが挙げられている。
+- メンテナンスされていない古いコメント：コードを修正した際にコメントを更新しないと、コードとコメントに食い違いが生じ、混乱を招く。間違ったコメントは、コメントがないよりも有害である。
+- コメントアウトされたコードの残骸：Gitなどのバージョン管理システムを使用している場合は、不要になったコードはコメントアウトせず、削除するべきである。過去のコードはGitの履歴で管理できる。`;
+
+console.error('=== Testing parseSummary with summaryVersion 8 ===\n');
+
+const sections = parseSummary(detailedSummary, { summaryVersion: 8 });
+
+console.error(`Total sections found: ${sections.length}\n`);
+
+sections.forEach((section, index) => {
+  console.error(`Section ${index + 1}:`);
+  console.error(`  Title: ${section.title}`);
+  console.error(`  Icon: ${section.icon}`);
+  console.error(`  Content: ${section.content.substring(0, 100)}${section.content.length > 100 ? '...' : ''}`);
+  console.error();
+});
+
+// 問題の分析
+console.error('=== Analysis ===');
+const detailSections = sections.filter(s => s.title === '詳細');
+console.error(`Number of "詳細" sections: ${detailSections.length}`);
+if (detailSections.length > 0) {
+  console.error('\n"詳細" sections content:');
+  detailSections.forEach((section, index) => {
+    console.error(`  ${index + 1}. ${section.content}`);
+  });
+}

--- a/scripts/test/test-rss-parse.ts
+++ b/scripts/test/test-rss-parse.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env tsx
+import Parser from 'rss-parser';
+
+async function testRSSParse() {
+  const parser = new Parser();
+  
+  console.error("=== マネーフォワードRSSフィード解析テスト ===");
+  
+  try {
+    const feed = await parser.parseURL('https://moneyforward-dev.jp/feed');
+    
+    // SECCON記事を探す
+    const secconArticle = feed.items?.find(item => 
+      item.title?.includes('SECCON')
+    );
+    
+    if (secconArticle) {
+      console.error("\nSECCON記事の詳細:");
+      console.error("----------------------------------------");
+      console.error(`タイトル: ${secconArticle.title}`);
+      console.error(`リンク: ${secconArticle.link}`);
+      console.error(`公開日: ${secconArticle.pubDate}`);
+      console.error(`\ndescriptionフィールド:`);
+      console.error(`- 存在: ${secconArticle.description !== undefined}`);
+      console.error(`- 型: ${typeof secconArticle.description}`);
+      console.error(`- 長さ: ${secconArticle.description?.length || 0} 文字`);
+      
+      if (secconArticle.description) {
+        console.error(`- 最初の100文字: "${secconArticle.description.substring(0, 100)}..."`);
+        
+        // 日本語チェック
+        const japanesePattern = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/;
+        const hasJapanese = japanesePattern.test(secconArticle.description);
+        console.error(`- 日本語を含む: ${hasJapanese}`);
+        
+        if (!hasJapanese) {
+          console.error("\n⚠️ descriptionに日本語が含まれていません！");
+        }
+      } else {
+        console.error("\n⚠️ descriptionフィールドが空です！");
+      }
+      
+      console.error(`\ncontentフィールド:`);
+      console.error(`- 存在: ${secconArticle.content !== undefined}`);
+      console.error(`- 型: ${typeof secconArticle.content}`);
+      console.error(`- 長さ: ${secconArticle.content?.length || 0} 文字`);
+      
+      const japanesePattern = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FAF]/;
+      
+      if (secconArticle.content) {
+        console.error(`- 最初の100文字: "${secconArticle.content.substring(0, 100)}..."`);
+        
+        const hasJapanese = japanesePattern.test(secconArticle.content);
+        console.error(`- 日本語を含む: ${hasJapanese}`);
+      }
+      
+      console.error(`\nsummaryフィールド:`);
+      console.error(`- 存在: ${(secconArticle as any).summary !== undefined}`);
+      if ((secconArticle as any).summary) {
+        const summary = (secconArticle as any).summary;
+        console.error(`- 型: ${typeof summary}`);
+        console.error(`- 長さ: ${summary.length || 0} 文字`);
+        console.error(`- 最初の100文字: "${summary.substring(0, 100)}..."`);
+        
+        const hasJapanese = japanesePattern.test(summary);
+        console.error(`- 日本語を含む: ${hasJapanese}`);
+      }
+      
+      console.error("\n全フィールド一覧:");
+      console.error(Object.keys(secconArticle));
+      
+    } else {
+      console.error("\n❌ SECCON記事がRSSフィードに見つかりません");
+    }
+    
+  } catch (error) {
+    console.error("エラー:", error);
+  }
+}
+
+testRSSParse().catch(console.error);

--- a/scripts/test/test-speakerdeck-detailed.ts
+++ b/scripts/test/test-speakerdeck-detailed.ts
@@ -1,0 +1,74 @@
+import { SpeakerDeckFetcher } from '../lib/fetchers/speakerdeck';
+import { speakerDeckConfig } from '../lib/config/speakerdeck';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// デバッグモードを有効化
+speakerDeckConfig.debug = false;
+speakerDeckConfig.maxArticles = 10; // テスト用に10件に制限
+
+(async () => {
+  try {
+    // データベースから実際のソースを取得
+    const source = await prisma.source.findFirst({
+      where: { name: 'Speaker Deck' }
+    });
+    
+    if (!source) {
+      console.error('❌ Speaker Deckソースが見つかりません');
+      process.exit(1);
+    }
+    
+    console.error('🔍 Speaker Deck 最新記事チェック...\n');
+    
+    const fetcher = new SpeakerDeckFetcher(source);
+    const result = await fetcher.fetch();
+    
+    console.error(`📊 取得結果: ${result.articles.length}件\n`);
+    
+    // 取得した記事をチェック
+    for (const article of result.articles) {
+      // URLで既存記事をチェック
+      const existing = await prisma.article.findFirst({
+        where: { url: article.url }
+      });
+      
+      if (existing) {
+        console.error(`❌ 重複: ${article.title}`);
+        console.error(`   URL: ${article.url}`);
+        console.error(`   既存日付: ${new Date(existing.publishedAt).toISOString().split('T')[0]}`);
+        console.error(`   新規日付: ${article.publishedAt.toISOString().split('T')[0]}`);
+      } else {
+        console.error(`✅ 新規: ${article.title}`);
+        console.error(`   URL: ${article.url}`);
+        console.error(`   日付: ${article.publishedAt.toISOString().split('T')[0]}`);
+      }
+      console.error('');
+    }
+    
+    // 最新の記事を確認
+    console.error('📅 データベースの最新Speaker Deck記事:');
+    const latestArticles = await prisma.article.findMany({
+      where: {
+        source: { name: 'Speaker Deck' }
+      },
+      orderBy: { publishedAt: 'desc' },
+      take: 5,
+      select: {
+        title: true,
+        publishedAt: true,
+        url: true
+      }
+    });
+    
+    for (const article of latestArticles) {
+      console.error(`  - ${new Date(article.publishedAt).toISOString().split('T')[0]}: ${article.title}`);
+    }
+    
+  } catch (error) {
+    console.error('❌ テスト失敗:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+})();

--- a/scripts/test/test-speakerdeck-detailed.ts
+++ b/scripts/test/test-speakerdeck-detailed.ts
@@ -1,5 +1,5 @@
-import { SpeakerDeckFetcher } from '../lib/fetchers/speakerdeck';
-import { speakerDeckConfig } from '../lib/config/speakerdeck';
+import { SpeakerDeckFetcher } from '../../lib/fetchers/speakerdeck';
+import { speakerDeckConfig } from '../../lib/config/speakerdeck';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();

--- a/scripts/test/test-speakerdeck-fetcher.ts
+++ b/scripts/test/test-speakerdeck-fetcher.ts
@@ -1,0 +1,64 @@
+import { SpeakerDeckFetcher } from '../lib/fetchers/speakerdeck';
+import { speakerDeckConfig } from '../lib/config/speakerdeck';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+// デバッグモードを有効化
+speakerDeckConfig.debug = true;
+speakerDeckConfig.maxArticles = 5; // テスト用に5件に制限
+
+(async () => {
+  try {
+    // データベースから実際のソースを取得
+    const source = await prisma.source.findFirst({
+      where: { name: 'Speaker Deck' }
+    });
+    
+    if (!source) {
+      console.error('❌ Speaker Deckソースが見つかりません');
+      process.exit(1);
+    }
+    
+    console.error('🔍 Speaker Deck フェッチャーテスト開始...');
+    console.error('ソース情報:');
+    console.error('  - ID:', source.id);
+    console.error('  - Name:', source.name);
+    console.error('  - Enabled:', source.enabled);
+    console.error('');
+    console.error('設定:');
+    console.error('  - minViews:', speakerDeckConfig.minViews);
+    console.error('  - maxAge:', speakerDeckConfig.maxAge);
+    console.error('  - enableDetailFetch:', speakerDeckConfig.enableDetailFetch);
+    console.error('');
+    
+    const fetcher = new SpeakerDeckFetcher(source);
+    const result = await fetcher.fetch();
+    
+    console.error('');
+    console.error('📊 取得結果:');
+    console.error('  - 記事数:', result.articles.length);
+    console.error('  - エラー数:', result.errors.length);
+    
+    if (result.articles.length > 0) {
+      console.error('');
+      console.error('📝 取得した記事:');
+      result.articles.forEach((article, i) => {
+        console.error(`  ${i + 1}. ${article.title}`);
+        console.error(`     URL: ${article.url}`);
+        console.error(`     日付: ${article.publishedAt.toISOString().split('T')[0]}`);
+        console.error(`     著者: ${article.author || 'N/A'}`);
+      });
+    }
+    
+    if (result.errors.length > 0) {
+      console.error('');
+      console.error('❌ エラー:');
+      result.errors.forEach(err => console.error('  -', err.message));
+    }
+  } catch (error) {
+    console.error('❌ テスト失敗:', error);
+  } finally {
+    await prisma.$disconnect();
+  }
+})();

--- a/scripts/test/test-speakerdeck-fetcher.ts
+++ b/scripts/test/test-speakerdeck-fetcher.ts
@@ -1,5 +1,5 @@
-import { SpeakerDeckFetcher } from '../lib/fetchers/speakerdeck';
-import { speakerDeckConfig } from '../lib/config/speakerdeck';
+import { SpeakerDeckFetcher } from '../../lib/fetchers/speakerdeck';
+import { speakerDeckConfig } from '../../lib/config/speakerdeck';
 import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();

--- a/scripts/test/test-specific-article.ts
+++ b/scripts/test/test-specific-article.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env tsx
+import { CorporateTechBlogFetcher } from '../lib/fetchers/corporate-tech-blog';
+
+async function testSpecificArticle() {
+  const fetcher = new CorporateTechBlogFetcher();
+  
+  // テスト対象の記事情報
+  const testTitle = "SECCON Beginners CTF 2025 Writeup";
+  const testUrl = "https://moneyforward-dev.jp/entry/2025/08/08/103559";
+  
+  // isEventArticle メソッドを直接呼び出す（private メソッドなので any でキャスト）
+  const isEvent = (fetcher as any).isEventArticle(testTitle, testUrl);
+  
+  console.error("=== マネーフォワード記事フィルタリングテスト ===");
+  console.error(`タイトル: ${testTitle}`);
+  console.error(`URL: ${testUrl}`);
+  console.error(`イベント記事として判定: ${isEvent ? 'YES（除外される）' : 'NO（除外されない）'}`);
+  
+  if (isEvent) {
+    console.error("\n除外理由の分析:");
+    
+    // イベントキーワードチェック
+    const eventKeywords = [
+      '登壇', 'イベント', 'セミナー', '勉強会',
+      'カンファレンス', 'meetup', '参加募集', '開催しました',
+      '開催します', '参加者募集'
+    ];
+    
+    const matchedKeywords = eventKeywords.filter(keyword => 
+      testTitle.includes(keyword) || testTitle.toLowerCase().includes(keyword.toLowerCase())
+    );
+    
+    if (matchedKeywords.length > 0) {
+      console.error(`- イベントキーワードにマッチ: ${matchedKeywords.join(', ')}`);
+    }
+    
+    // URLパターンチェック
+    if (/\/(event|seminar|meetup|conference)/i.test(testUrl)) {
+      console.error("- URLにイベント関連パスが含まれる");
+    }
+    
+    // 日付パターンチェック
+    const futureDatePattern = /20\d{2}\/\d{1,2}\/\d{1,2}/;
+    if (futureDatePattern.test(testTitle)) {
+      const match = testTitle.match(futureDatePattern);
+      console.error(`- タイトルに日付パターンが含まれる: ${match?.[0]}`);
+    }
+    
+    // タイトル内の「2025」チェック
+    if (testTitle.includes('2025')) {
+      console.error("- タイトルに「2025」が含まれる（年度表記として誤検知の可能性）");
+    }
+  }
+}
+
+testSpecificArticle().catch(console.error);

--- a/scripts/test/test-specific-article.ts
+++ b/scripts/test/test-specific-article.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env tsx
-import { CorporateTechBlogFetcher } from '../lib/fetchers/corporate-tech-blog';
+import { CorporateTechBlogFetcher } from '../../lib/fetchers/corporate-tech-blog';
 
 async function testSpecificArticle() {
   const fetcher = new CorporateTechBlogFetcher();

--- a/scripts/test/test-tag-normalization.ts
+++ b/scripts/test/test-tag-normalization.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env npx tsx
 
-import { normalizeTagInput } from '../lib/utils/tag-normalizer';
+import { normalizeTagInput } from '../../lib/utils/tag-normalizer';
 
 async function testTagNormalization() {
   console.error('=== Dev.to タグ正規化テスト ===\n');

--- a/scripts/test/test-tag-normalization.ts
+++ b/scripts/test/test-tag-normalization.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env npx tsx
+
+import { normalizeTagInput } from '../lib/utils/tag-normalizer';
+
+async function testTagNormalization() {
+  console.error('=== Dev.to タグ正規化テスト ===\n');
+
+  // テストケース1: 配列形式（リストAPI）
+  console.error('1. 配列形式のタグ（リストAPI形式）');
+  const arrayTags = ['webdev', 'javascript', 'programming', 'opensource'];
+  console.error('  入力:', arrayTags);
+  console.error('  出力:', normalizeTagInput(arrayTags));
+  console.error();
+
+  // テストケース2: 文字列形式（詳細API）
+  console.error('2. 文字列形式のタグ（詳細API形式）');
+  const stringTags = 'webdev, javascript, programming, opensource';
+  console.error('  入力:', stringTags);
+  console.error('  出力:', normalizeTagInput(stringTags));
+  console.error();
+
+  // テストケース3: 1文字タグの混入
+  console.error('3. 1文字タグが混入した場合');
+  const contaminatedTags = ['g', 'p', 't', ',', ' ', 'b', 'u', 's', 'i', 'n', 'e', 's', 's', 'react', 'javascript'];
+  console.error('  入力:', contaminatedTags);
+  console.error('  出力:', normalizeTagInput(contaminatedTags));
+  console.error();
+
+  // テストケース4: 実際のDev.to APIコール
+  console.error('4. 実際のDev.to APIからの取得');
+  try {
+    // リストAPI
+    const listResponse = await fetch('https://dev.to/api/articles?per_page=1&top=1');
+    const listArticles = await listResponse.json();
+    
+    if (listArticles.length > 0) {
+      const article = listArticles[0];
+      console.error('  リストAPI:');
+      console.error('    記事:', article.title.substring(0, 50) + '...');
+      console.error('    tag_list:', article.tag_list);
+      console.error('    正規化後:', normalizeTagInput(article.tag_list));
+      
+      // 詳細API
+      const detailResponse = await fetch(`https://dev.to/api/articles/${article.id}`);
+      const detailArticle = await detailResponse.json();
+      console.error('  詳細API:');
+      console.error('    tag_list:', detailArticle.tag_list);
+      console.error('    型:', Array.isArray(detailArticle.tag_list) ? 'array' : typeof detailArticle.tag_list);
+      console.error('    正規化後:', normalizeTagInput(detailArticle.tag_list));
+    }
+  } catch (error) {
+    console.error('  APIエラー:', error);
+  }
+  console.error();
+
+  // テストケース5: エッジケース
+  console.error('5. エッジケース');
+  console.error('  null:', normalizeTagInput(null));
+  console.error('  undefined:', normalizeTagInput(undefined));
+  console.error('  空文字列:', normalizeTagInput(''));
+  console.error('  カンマのみ:', normalizeTagInput(',,,'));
+  console.error('  数字の1文字:', normalizeTagInput(['5', 'a', 'react']));
+  
+  console.error('\n=== テスト完了 ===');
+}
+
+testTagNormalization().catch(console.error);


### PR DESCRIPTION
## 概要
scripts/直下に散在していた18個のテストファイルを適切な場所（scripts/test/）に移動し、プロジェクト構造を整理しました。

## 背景
開発過程で作成されたテストスクリプトがscripts/直下に放置され、git管理されていない状態でした。
これらは本来scripts/test/ディレクトリに配置すべきファイルでした。

## 変更内容
### ファイル移動（18ファイル）
- scripts/直下のtest-*.tsファイル → scripts/test/へ移動
- 全ファイルをgit管理下に追加

### importパス修正
移動に伴い、以下のパス修正を実施：
- `from '../lib/` → `from '../../lib/`
- `from "../lib/` → `from "../../lib/`

## 移動したファイル一覧
- fetch-moneyforward-test.ts
- test-detailed-summary-display.ts
- test-devto-fetch-and-save.ts
- test-devto-fetcher.ts
- test-enrichment.ts
- test-event-filter.ts
- test-hatena-enrichment-detailed.ts
- test-hatena-enrichment.ts
- test-hatena-quick.ts
- test-improved-fetcher.ts
- test-japanese-check.ts
- test-moneyforward-only.ts
- test-parse-summary.ts
- test-rss-parse.ts
- test-speakerdeck-detailed.ts
- test-speakerdeck-fetcher.ts
- test-specific-article.ts
- test-tag-normalization.ts

## テスト結果
### ✅ 全項目合格
- ファイル存在確認: ✅
- テストスクリプト実行: ✅
- TypeScriptコンパイル: ✅
- プロジェクトビルド: ✅
- Lintチェック: ✅

## 影響範囲
- プロジェクト全体への影響: **なし**
- CI/CDへの影響: **なし**
- 既存機能への影響: **なし**

## 今後の推奨事項
1. 開発ガイドラインにテストファイル配置ルールを追記
2. .gitignoreの更新を検討（scripts直下のtest-*.tsを除外）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- テスト
  - Dev.to、Speaker Deck、はてなブックマーク、Google Developers Blog、Corporate Tech Blog（Money Forward含む）の取得・保存・拡張の統合テストスクリプトを追加。
  - RSS解析、イベント記事除外、日本語判定、タグ正規化の検証スクリプトを追加し、ケース別の動作確認を強化。
  - 詳細要約の解析・表示ロジックを検証するテストを追加。
  - 失敗要因の切り分けに役立つ詳細ログと統計出力を整備。
  - いずれも手動実行向けで本番機能・挙動には影響なし。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->