### PR TITLE
feat: GitHub Actionsスケジューラーを元の頻度に復旧

### DIFF
--- a/.github/workflows/scheduler-cleanup.yml
+++ b/.github/workflows/scheduler-cleanup.yml
@@ -1,12 +1,12 @@
-name: Scheduler - Daily Cleanup
+name: Scheduler - Weekly Cleanup
 
 on:
   schedule:
-    - cron: '0 17 * * 6' # Saturday 02:00 JST (UTC 17:00 Friday)
+    - cron: '0 17 * * 5' # Saturday 02:00 JST (UTC Friday 17:00)
   workflow_dispatch:
     inputs:
       confirm:
-        description: "Type 'YES' to confirm manual execution (DB quota risk)"
+        description: "Type 'YES' to confirm manual execution"
         required: true
         type: string
         default: "NO"

--- a/.github/workflows/scheduler-cleanup.yml
+++ b/.github/workflows/scheduler-cleanup.yml
@@ -1,9 +1,8 @@
 name: Scheduler - Daily Cleanup
 
 on:
-  # TEMPORARILY DISABLED DUE TO PRISMA QUOTA LIMIT (90% reached)
-  # schedule:
-  #   - cron: '0 13 * * *' # JST 22:00
+  schedule:
+    - cron: '0 17 * * 6' # Saturday 02:00 JST (UTC 17:00 Friday)
   workflow_dispatch:
     inputs:
       confirm:

--- a/.github/workflows/scheduler-qiita.yml
+++ b/.github/workflows/scheduler-qiita.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: "Type 'YES' to confirm manual execution (DB quota risk)"
+        description: "Type 'YES' to confirm manual execution"
         required: true
         type: string
         default: "NO"

--- a/.github/workflows/scheduler-qiita.yml
+++ b/.github/workflows/scheduler-qiita.yml
@@ -1,9 +1,9 @@
 name: Scheduler - Qiita Popular Twice Daily
 
 on:
-  # TEMPORARILY DISABLED DUE TO PRISMA QUOTA LIMIT (90% reached)
-  # schedule:
-  #   - cron: '0 23 * * *' # JST 8:00 (UTC 23:00) - Reduced from twice daily to save DB operations
+  schedule:
+    - cron: '5 20 * * *' # JST 05:05 (previous day 20:05 UTC)
+    - cron: '5 8 * * *' # JST 17:05
   workflow_dispatch:
     inputs:
       confirm:

--- a/.github/workflows/scheduler-quality-auto.yml
+++ b/.github/workflows/scheduler-quality-auto.yml
@@ -1,9 +1,8 @@
 name: Scheduler - Quality Check & Auto Regenerate
 
 on:
-  # TEMPORARILY DISABLED DUE TO PRISMA QUOTA LIMIT (90% reached)
-  # schedule:
-  #   - cron: '30 6 * * *' # JST 15:30
+  schedule:
+    - cron: '30 6 * * *' # JST 15:30
   workflow_dispatch:
     inputs:
       confirm:

--- a/.github/workflows/scheduler-quality-auto.yml
+++ b/.github/workflows/scheduler-quality-auto.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: "Type 'YES' to confirm manual execution (DB quota risk)"
+        description: "Type 'YES' to confirm manual execution"
         required: true
         type: string
         default: "NO"

--- a/.github/workflows/scheduler-rss-hourly.yml
+++ b/.github/workflows/scheduler-rss-hourly.yml
@@ -1,9 +1,8 @@
 name: Scheduler - RSS Hourly
 
 on:
-  # TEMPORARILY DISABLED DUE TO PRISMA QUOTA LIMIT (90% reached)
-  # schedule:
-  #   - cron: '0 21 * * *' # Daily at JST 6:00 (UTC 21:00) - Reduced from hourly to save DB operations
+  schedule:
+    - cron: '0 * * * *' # Every hour (UTC)
   workflow_dispatch:
     inputs:
       confirm:

--- a/.github/workflows/scheduler-rss-hourly.yml
+++ b/.github/workflows/scheduler-rss-hourly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: "Type 'YES' to confirm manual execution (DB quota risk)"
+        description: "Type 'YES' to confirm manual execution"
         required: true
         type: string
         default: "NO"

--- a/.github/workflows/scheduler-scraping.yml
+++ b/.github/workflows/scheduler-scraping.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: "Type 'YES' to confirm manual execution (DB quota risk)"
+        description: "Type 'YES' to confirm manual execution"
         required: true
         type: string
         default: "NO"

--- a/.github/workflows/scheduler-scraping.yml
+++ b/.github/workflows/scheduler-scraping.yml
@@ -1,9 +1,9 @@
 name: Scheduler - Scraping Twice Daily
 
 on:
-  # TEMPORARILY DISABLED DUE TO PRISMA QUOTA LIMIT (90% reached)
-  # schedule:
-  #   - cron: '0 3 * * *'  # JST 12:00 (UTC 03:00) - Reduced from twice daily to save DB operations
+  schedule:
+    - cron: '0 15 * * *'  # JST 00:00 (UTC 15:00)
+    - cron: '0 3 * * *'   # JST 12:00 (UTC 03:00)
   workflow_dispatch:
     inputs:
       confirm:

--- a/.github/workflows/scheduler-summary.yml
+++ b/.github/workflows/scheduler-summary.yml
@@ -1,9 +1,8 @@
 name: Scheduler - Daily Summaries
 
 on:
-  # TEMPORARILY DISABLED DUE TO PRISMA QUOTA LIMIT (90% reached)
-  # schedule:
-  #   - cron: '30 1 * * *' # JST 10:30
+  schedule:
+    - cron: '30 1 * * *' # JST 10:30
   workflow_dispatch:
     inputs:
       confirm:

--- a/.github/workflows/scheduler-summary.yml
+++ b/.github/workflows/scheduler-summary.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: "Type 'YES' to confirm manual execution (DB quota risk)"
+        description: "Type 'YES' to confirm manual execution"
         required: true
         type: string
         default: "NO"

--- a/.github/workflows/scheduler-tags.yml
+++ b/.github/workflows/scheduler-tags.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: "Type 'YES' to confirm manual execution (DB quota risk)"
+        description: "Type 'YES' to confirm manual execution"
         required: true
         type: string
         default: "NO"

--- a/.github/workflows/scheduler-tags.yml
+++ b/.github/workflows/scheduler-tags.yml
@@ -1,9 +1,9 @@
 name: Scheduler - Tags Twice Daily
 
 on:
-  # TEMPORARILY DISABLED DUE TO PRISMA QUOTA LIMIT (90% reached)
-  # schedule:
-  #   - cron: '30 11 * * *' # JST 20:30 (UTC 11:30) - Reduced from twice daily to save DB operations
+  schedule:
+    - cron: '30 23 * * *' # JST 08:30 (previous day 23:30 UTC)
+    - cron: '30 11 * * *' # JST 20:30
   workflow_dispatch:
     inputs:
       confirm:

--- a/.github/workflows/scheduler-weekly.yml
+++ b/.github/workflows/scheduler-weekly.yml
@@ -2,11 +2,11 @@ name: Scheduler - Weekly Cleanup
 
 on:
   schedule:
-    - cron: '0 16 * * 1' # Monday 01:00 JST (UTC 16:00 Sunday)
+    - cron: '0 16 * * 0' # Monday 01:00 JST (UTC Sunday 16:00)
   workflow_dispatch:
     inputs:
       confirm:
-        description: "Type 'YES' to confirm manual execution (DB quota risk)"
+        description: "Type 'YES' to confirm manual execution"
         required: true
         type: string
         default: "NO"

--- a/.github/workflows/scheduler-weekly.yml
+++ b/.github/workflows/scheduler-weekly.yml
@@ -1,9 +1,8 @@
 name: Scheduler - Weekly Cleanup
 
 on:
-  # TEMPORARILY DISABLED DUE TO PRISMA QUOTA LIMIT (90% reached)
-  # schedule:
-  #   - cron: '0 17 * * 6' # Sunday 02:00 JST
+  schedule:
+    - cron: '0 16 * * 1' # Monday 01:00 JST (UTC 16:00 Sunday)
   workflow_dispatch:
     inputs:
       confirm:


### PR DESCRIPTION
## 概要
Supabaseへのデータベース移行完了に伴い、一時停止していたGitHub Actionsの定期実行スケジューラーを元の頻度に復旧します。

## 背景
- Prisma.ioのQuota制限（90%到達）により全スケジューラーを停止していた
- 2025年9月3日にSupabaseへの移行が完了
- Supabaseは**データ転送量ベース**の課金でクエリ回数制限なし
- 記事データ程度の転送量（約1.5MB/日）なら問題なし

## 変更内容

### 高頻度スケジューラー
- **scheduler-rss-hourly.yml**: 毎時実行に復旧（0 * * * *）
  - 日次から毎時に戻す（24倍の頻度）
  
### 中頻度スケジューラー  
- **scheduler-tags.yml**: 1日2回に復旧
  - 8:30（30 23 * * *）と20:30（30 11 * * *）
  
### その他スケジューラー（コメントアウト解除）
- **scheduler-qiita.yml**: 5:05と17:05の2回実行
- **scheduler-scraping.yml**: 0時と12時の2回実行
- **scheduler-summary.yml**: 日次10:30実行
- **scheduler-quality-auto.yml**: 日次15:30実行
- **scheduler-weekly.yml**: 月曜1:00実行
- **scheduler-cleanup.yml**: 土曜2:00実行

## 安全性
- 手動実行時の確認機能（confirm: YES必須）は維持
- concurrencyグループ設定により多重実行を防止
- Supabase Free Planの転送量制限（500MB/月）に対して十分な余裕

## 転送量見積もり
- 記事データ: 平均3KB/記事
- 毎時収集: 約20記事 × 24回 = 480記事/日
- 転送量: 約1.5MB/日（45MB/月）
- **Free Plan制限の9%程度で問題なし**

## テスト
- [x] YAML構文チェック完了
- [ ] 各ワークフロー手動実行で動作確認
- [ ] 初回自動実行の監視（マージ後24時間）

## 関連Issue/PR
- #26 Prisma Quota制限対応

Closes #XX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- チョア
  - 各種スケジュール実行を再有効化・調整
  - RSS更新を毎時に変更
  - 記事スクレイピングを1日2回に変更
  - タグ更新を1日2回に変更
  - Qiita連携を1日2回に変更
  - サマリー生成を毎日実行に変更
  - 品質自動チェックを毎日実行に変更
  - クリーニングを毎週実行に変更（実行時刻を更新）
  - 手動実行確認メッセージを簡潔化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->