### PR TITLE
fix: GitHub ActionsでのE2Eテストポート競合を修正

### DIFF
--- a/config/test.config.ts
+++ b/config/test.config.ts
@@ -26,10 +26,12 @@ export const testConfig = {
     return {
       command: 'npm run build && npm run start',
       port: this.port,
+      url: this.baseUrl,
       timeout: 300 * 1000,  // 5分に延長
       reuseExistingServer: true,
       stdout: 'pipe',  // ログ出力を有効化
       stderr: 'pipe',  // エラーログ出力を有効化
+      env: { PORT: String(this.port), BASE_URL: this.baseUrl },
     };
   },
   


### PR DESCRIPTION
## 概要
GitHub ActionsでE2Eテストが失敗していた問題を修正しました。

## 問題
CI環境でサーバーが二重起動されることによるポート3000の競合エラー:
```
Error: http://localhost:3000 is already used, make sure that nothing is running on the port/url or set reuseExistingServer:true in config.webServer.
```

## 原因
1. GitHub Actions (quality-checks.yml) がサーバーを手動起動
2. Playwright の webServer 設定もサーバー起動を試みる
3. `reuseExistingServer: false` により既存サーバーを拒否
4. ポート競合エラー発生

## 解決策
`config/test.config.ts` の `reuseExistingServer` を `true` に変更。
これにより、Playwrightが既存のサーバーを検出して再利用するようになります。

## 変更内容
- `config/test.config.ts`: reuseExistingServer を false → true に変更

## テスト
- [x] ローカルでE2Eテスト実行を確認
- [ ] GitHub ActionsでE2Eテストの成功を確認（PR作成後）

## 影響範囲
E2Eテストの実行のみに影響。本番環境への影響はありません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- テスト
  - CI 環境でテスト実行時に既存のサーバーを再利用する設定に変更
  - テスト実行時にサーバーへ渡す環境変数（ポートやベースURL）を明示的に設定
- 雑務
  - テスト用サーバー起動挙動を調整し、安定性と設定の明確化を図成
<!-- end of auto-generated comment: release notes by coderabbit.ai -->