### PR TITLE
fix: Playwright webServer設定エラーを修正

### DIFF
--- a/config/test.config.ts
+++ b/config/test.config.ts
@@ -25,7 +25,6 @@ export const testConfig = {
     }
     return {
       command: 'npm run build && npm run start',
-      port: this.port,
       url: this.baseUrl,
       timeout: 300 * 1000,  // 5分に延長
       reuseExistingServer: true,


### PR DESCRIPTION
## 概要
PR #37でCodeRabbitの提案を実装した際に発生した、PlaywrightのwebServer設定エラーを修正します。

## 問題
- エラーメッセージ: `Either 'port' or 'url' should be specified in config.webServer`
- 原因: `port`と`url`の両方が設定されていた（Playwrightでは排他的）

## 変更内容
- `config/test.config.ts`から`port`プロパティを削除
- `url`プロパティのみを使用するよう修正

## 動作確認
- [x] ローカルでE2Eテスト成功
- [x] CI環境シミュレーション(`CI=true`)でも成功

## 関連Issue/PR
- #37 - 元のポート競合修正PR

## テスト結果
```
8 passed (24.7s)
```

## 今後の検討事項
PR作成時にもE2Eテストを実行するようGitHub Actionsワークフローを改善することを検討中です。
これにより、mainブランチマージ前にエラーを検出できるようになります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- テスト
  - テスト用Webサーバー設定の明示的なポート指定を廃止し、環境変数での管理に統一。
  - 起動コマンド、URL、タイムアウト、ログ出力など既存設定は変更なし。
  - テスト環境の設定整合性と柔軟性を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->