### PR TITLE
fix: E2Eテスト安定性改善 Phase 1 - タイムアウト設定最適化

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -241,11 +241,10 @@ jobs:
   e2e:
     name: E2E Tests
     if: |
-      github.ref == 'refs/heads/main' ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-e2e')) ||
-      (github.event_name == 'push' && contains(github.event.head_commit.message, '[e2e]')) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[e2e]'))
+      github.event_name == 'pull_request' ||
+      github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     services:
       postgres:
         image: postgres:15
@@ -314,9 +313,9 @@ jobs:
           npm run start 2>&1 | tee server.log &
           SERVER_PID=$!
 
-          # サーバー起動待機（最大60秒）
+          # サーバー起動待機（最大120秒）
           echo "Waiting for server to be ready..."
-          MAX_ATTEMPTS=60
+          MAX_ATTEMPTS=120
           ATTEMPT=0
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
             if curl -s -f --max-time 5 -o /dev/null http://localhost:3000 2>/dev/null; then

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   testDir: './',
   testMatch: ['**/e2e/**/*.spec.ts'],
   /* Global timeout for each test */
-  timeout: process.env.CI ? 60000 : 30000,  // 環境別タイムアウト
+  timeout: process.env.CI ? 90000 : 45000,  // CI: 90秒、ローカル: 45秒（改訂版）
   /* Run tests in files in parallel */
   fullyParallel: true,  // ファイル単位での並列実行を有効化
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -46,16 +46,16 @@ export default defineConfig({
     /* Record video on failure */
     video: 'retain-on-failure',
     /* Timeout for each action */
-    actionTimeout: process.env.CI ? 15000 : 10000,
+    actionTimeout: process.env.CI ? 20000 : 15000,  // CI: 20秒、ローカル: 15秒（改訂版）
     /* Timeout for navigation */
-    navigationTimeout: process.env.CI ? 30000 : 15000,
+    navigationTimeout: process.env.CI ? 45000 : 30000,  // CI: 45秒、ローカル: 30秒（改訂版）
     /* VRT用設定追加 */
     ignoreHTTPSErrors: true,
   },
 
   /* Visual Regression Testing設定 */
   expect: {
-    timeout: process.env.CI ? 10000 : 5000,
+    timeout: process.env.CI ? 15000 : 10000,  // CI: 15秒、ローカル: 10秒（改訂版）
     toHaveScreenshot: {
       threshold: 0.2,
       maxDiffPixelRatio: 0.15,


### PR DESCRIPTION
## 概要
E2EテストのGitHub Actions環境での安定性を改善するPhase 1実装です。
34個のE2Eテストファイルに対応したタイムアウト設定の最適化を行いました。

## 問題点
- GitHub ActionsでE2Eテストがタイムアウトにより失敗（ローカル成功率80%、CI環境で更に低下）
- ジョブレベルのタイムアウト未設定（デフォルト6時間）
- 条件付き実行により通常のPRでE2Eテストが実行されない

## 変更内容

### GitHub Actions設定（.github/workflows/quality-checks.yml）
- ✅ ジョブレベルタイムアウト: 20分設定（34個のテストに対応）
- ✅ 実行条件: 全PR・mainブランチで自動実行に簡素化
- ✅ サーバー起動待機: 60秒→120秒に延長

### Playwright設定（playwright.config.ts）
CI環境のタイムアウト値を全体的に延長：
- ✅ グローバルタイムアウト: 60秒→90秒
- ✅ アクションタイムアウト: 15秒→20秒
- ✅ ナビゲーションタイムアウト: 30秒→45秒
- ✅ expectタイムアウト: 10秒→15秒

## テスト結果
- ESLint: ✅ 成功（警告数495以下）
- TypeScript: ✅ エラー0件
- ビルド: ✅ 成功

## 今後の予定

### Phase 2（1週間以内）
- テストデータ量の増加（50記事以上）
- リトライ回数の増加（CI環境で3回）
- 失敗時のアーティファクト保存

### Phase 3（1ヶ月以内）
- テスト分割実行戦略
- Playwrightブラウザのキャッシュ
- フレーク検出システム

## 関連Issue/PR
- #31: E2Eテスト安定性改善
- #34: E2Eテスト改善
- #36: CodeRabbitレビュー対応
- #43: E2Eテスト成功率100%達成

## チェックリスト
- [x] コード変更完了
- [x] ESLintチェック通過
- [x] TypeScriptエラーなし
- [x] ビルド成功
- [ ] GitHub ActionsでのE2Eテスト確認（PR作成後）

🤖 Created with Claude Code