### PR TITLE
fix: WeeklyDigestテーブルのマイグレーション不整合を修正

### DIFF
--- a/prisma/migrations/20250918_add_weekly_digest_table/migration.sql
+++ b/prisma/migrations/20250918_add_weekly_digest_table/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "WeeklyDigest" (
+    "id" TEXT NOT NULL,
+    "weekStartDate" TIMESTAMP(3) NOT NULL,
+    "weekEndDate" TIMESTAMP(3) NOT NULL,
+    "articleCount" INTEGER NOT NULL,
+    "topArticles" JSONB NOT NULL,
+    "categories" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WeeklyDigest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WeeklyDigest_weekStartDate_key" ON "WeeklyDigest"("weekStartDate");
+
+-- CreateIndex
+CREATE INDEX "idx_weekly_digest_created_at" ON "WeeklyDigest"("createdAt" DESC);


### PR DESCRIPTION
## 概要
WeeklyDigestテーブルが開発環境には存在するが、テスト環境・本番環境に存在しない問題を修正しました。

## 問題の原因
過去に`prisma db push`を使用して開発DBに直接テーブルを作成したため、マイグレーションファイルが存在せず、他の環境でテーブルが作成されない状態でした。

## 修正内容
- ✅ WeeklyDigestテーブルのマイグレーションファイルを作成
- ✅ テストDBへの適用を確認
- ✅ E2Eテスト（digest.spec.ts）14/14テスト成功

## 技術詳細
### マイグレーションファイル
`prisma/migrations/20250918_add_weekly_digest_table/migration.sql`

```sql
CREATE TABLE "WeeklyDigest" (
    "id" TEXT NOT NULL,
    "weekStartDate" TIMESTAMP(3) NOT NULL,
    "weekEndDate" TIMESTAMP(3) NOT NULL,
    "articleCount" INTEGER NOT NULL,
    "topArticles" JSONB NOT NULL,
    "categories" JSONB NOT NULL,
    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
    CONSTRAINT "WeeklyDigest_pkey" PRIMARY KEY ("id")
);

CREATE UNIQUE INDEX "WeeklyDigest_weekStartDate_key" ON "WeeklyDigest"("weekStartDate");
CREATE INDEX "idx_weekly_digest_created_at" ON "WeeklyDigest"("createdAt" DESC);
```

## テスト結果
- digest.spec.ts: **14/14テスト成功** ✅
- 開発DBの既存データ（5件）は保持されています

## 本番環境への適用
マージ後、以下のコマンドで本番環境に適用してください：

```bash
DATABASE_URL=$PRODUCTION_DATABASE_URL npx prisma migrate deploy
```

## 関連Issue
- WeeklyDigestテーブル問題の調査と修正

🤖 Generated with [Claude Code](https://claude.ai/code)