### PR TITLE
fix: 記事詳細ページの空コンテンツ表示問題を修正

### DIFF
--- a/__tests__/utils/summary-parser.test.ts
+++ b/__tests__/utils/summary-parser.test.ts
@@ -45,9 +45,9 @@ describe('parseSummary with summaryVersion 8', () => {
     const summary = `・項目1：内容1
 ・項目2：
 ・項目3：内容3`;
-    
+
     const sections = parseSummary(summary, { summaryVersion: 8 });
-    
+
     expect(sections).toHaveLength(3);
     expect(sections[0].title).toBe('項目1');
     expect(sections[0].content).toBe('内容1');
@@ -87,6 +87,32 @@ describe('parseSummary with summaryVersion 8', () => {
     expect(sections[1].content).toBe('これはコロンがない項目です');
     expect(sections[2].title).toBe('項目3');
     expect(sections[2].content).toBe('内容3');
+  });
+
+  it('コロンなしのサブ項目も正しく処理する（実際の問題データ）', () => {
+    const summary = `・発生した3つのインフラバグ：
+  - 8月5日、Sonnet 4のリクエストの一部が失敗
+  - 8月25日、Claude API TPUサーバーへのネットワーク問題
+  - 9月13日、Haikuモデルのサブセットがクラッシュ
+
+・検出困難だった理由：
+  - 社内使用が少なく、問題の顕在化が遅れた
+  - モニタリングツールのアラート設定が不適切だった`;
+
+    const sections = parseSummary(summary, { summaryVersion: 8 });
+
+    expect(sections).toHaveLength(2);
+
+    // 1つ目のセクション
+    expect(sections[0].title).toBe('発生した3つのインフラバグ');
+    expect(sections[0].content).toContain('8月5日、Sonnet 4のリクエストの一部が失敗');
+    expect(sections[0].content).toContain('8月25日、Claude API TPUサーバーへのネットワーク問題');
+    expect(sections[0].content).toContain('9月13日、Haikuモデルのサブセットがクラッシュ');
+
+    // 2つ目のセクション
+    expect(sections[1].title).toBe('検出困難だった理由');
+    expect(sections[1].content).toContain('社内使用が少なく、問題の顕在化が遅れた');
+    expect(sections[1].content).toContain('モニタリングツールのアラート設定が不適切だった');
   });
 
   it('複雑な階層構造を持つ実際のデータを処理する', () => {

--- a/__tests__/utils/summary-parser.test.ts
+++ b/__tests__/utils/summary-parser.test.ts
@@ -41,20 +41,19 @@ describe('parseSummary with summaryVersion 8', () => {
     expect(sections[1].content).toContain('複雑なロジックを要約するコメント');
   });
 
-  it('サブ項目がないコロン後が空のメイン項目も処理する', () => {
+  it('サブ項目がないコロン後が空のメイン項目は除外される', () => {
     const summary = `・項目1：内容1
 ・項目2：
 ・項目3：内容3`;
 
     const sections = parseSummary(summary, { summaryVersion: 8 });
 
-    expect(sections).toHaveLength(3);
+    // 空のセクション（項目2）は除外されるので、2つのセクションのみ
+    expect(sections).toHaveLength(2);
     expect(sections[0].title).toBe('項目1');
     expect(sections[0].content).toBe('内容1');
-    expect(sections[1].title).toBe('項目2');
-    expect(sections[1].content).toBe('');
-    expect(sections[2].title).toBe('項目3');
-    expect(sections[2].content).toBe('内容3');
+    expect(sections[1].title).toBe('項目3');
+    expect(sections[1].content).toBe('内容3');
   });
 
   it('独立したサブ項目を正しく処理する', () => {

--- a/lib/utils/summary-parser.ts
+++ b/lib/utils/summary-parser.ts
@@ -99,7 +99,7 @@ function getIconForFlexibleTitle(title: string): string {
 export function parseSummary(detailedSummary: string, options?: ParseOptions): SummarySection[] {
   if (!detailedSummary) return [];
 
-  const sections: SummarySection[] = [];
+  let sections: SummarySection[] = [];
   const lines = detailedSummary.split('\n');
   
   // summaryVersion 7または8の処理（AIが自由に項目を設定）
@@ -147,7 +147,7 @@ export function parseSummary(detailedSummary: string, options?: ParseOptions): S
             });
             currentMainSection = null;
           } else if (isSubItem) {
-            // サブ項目
+            // サブ項目（コロンがある場合）
             if (currentMainSection) {
               // 前のメイン項目のサブ項目として追加
               if (currentMainSection.content) {
@@ -164,27 +164,42 @@ export function parseSummary(detailedSummary: string, options?: ParseOptions): S
             }
           }
         } else {
-          // コロンがない場合は全体を内容として扱う
-          const content = trimmedLine.replace(/^[・-]\s*/, '').trim();
-          // 前のメイン項目があれば先に追加
-          if (currentMainSection) {
-            sections.push(currentMainSection);
-            currentMainSection = null;
+          // コロンがない場合の処理
+          if (isSubItem && currentMainSection) {
+            // サブ項目（コロンなし）を前のメイン項目に追加
+            const content = trimmedLine.replace(/^-\s*/, '').trim();
+            if (content) {
+              if (currentMainSection.content) {
+                currentMainSection.content += '\n';
+              }
+              currentMainSection.content += `• ${content}`;
+            }
+          } else if (isMainItem) {
+            // メイン項目（コロンなし）
+            const content = trimmedLine.replace(/^・\s*/, '').trim();
+            // 前のメイン項目があれば先に追加
+            if (currentMainSection) {
+              sections.push(currentMainSection);
+              currentMainSection = null;
+            }
+            sections.push({
+              title: '詳細',
+              content: content,
+              icon: '📝'
+            });
           }
-          sections.push({
-            title: '詳細',
-            content: content,
-            icon: '📝'
-          });
         }
       }
     }
-    
+
     // 最後のメイン項目を追加
-    if (currentMainSection) {
+    if (currentMainSection && currentMainSection.content) {
       sections.push(currentMainSection);
     }
-    
+
+    // 空のcontentを持つセクションを除外
+    sections = sections.filter(section => section.content && section.content.trim() !== '');
+
     return sections;
   }
   


### PR DESCRIPTION
## 概要
記事ID `cmfonlsw8004ote8u9m0n8npi` において、記事詳細ページの「記事の要約」セクションで階層構造を持つ箇条書きの内容が空で表示される問題を修正しました。

## 問題
- 「発生した3つのインフラバグ」セクションが空表示
- 「検出困難だった理由」セクションが空表示
- 原因: コロンなしのサブ項目（ハイフンで始まる行）がパースされていなかった

## 修正内容
### `lib/utils/summary-parser.ts` の改善
1. **コロンなしサブ項目の処理追加**
   - コロンがないサブ項目（`- 内容`形式）も正しく処理
   - サブ項目を親のメインセクションに追加

2. **空セクションのフィルタリング**
   - コンテンツが空のセクションを自動的に除外
   - 表示品質の向上

3. **変数定義の修正**
   - `sections`を`let`で定義して再代入可能に

## テスト
- 実際の問題データでのテストケース追加
- 階層構造のパーステストが成功することを確認

## 確認方法
1. 開発サーバーを起動
2. http://localhost:3000/articles/cmfonlsw8004ote8u9m0n8npi にアクセス
3. 「発生した3つのインフラバグ」と「検出困難だった理由」セクションに内容が表示されることを確認

## 関連ドキュメント
- 調査結果: `.claude/docs/investigate/investigate_20250918_153022_empty-article-content.md`
- 実装計画: `.claude/docs/plan/plan_20250918_155144_empty-article-content-fix.md`

Fixes #empty-article-content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - コロンなしのメイン項目を自動的に「詳細」セクションとして分離して表示。
- バグ修正
  - コロンなしのサブ項目を現在のセクションの箇条書きとして正しく取り込むよう改善。
  - 空のセクションを除外し、末尾セクションの取りこぼしを防止。
- テスト
  - コロンなし項目の取り扱いを検証する新しいケースを追加し、セクション構成と箇条書き結果を確認。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->