### PR TITLE
feat: スクロール位置復元機能の改善 - 初回アクセス時の動作修正

### DIFF
--- a/app/components/common/scroll-restoration-loading.tsx
+++ b/app/components/common/scroll-restoration-loading.tsx
@@ -8,12 +8,14 @@ interface ScrollRestorationLoadingProps {
   currentPage: number;
   targetPages: number;
   onCancel: () => void;
+  itemsPerPage?: number; // 既定 20
 }
 
 export function ScrollRestorationLoading({
   currentPage,
   targetPages,
-  onCancel
+  onCancel,
+  itemsPerPage = 20
 }: ScrollRestorationLoadingProps) {
   const progress = targetPages > 0 ? (currentPage / targetPages) * 100 : 0;
   
@@ -40,7 +42,7 @@ export function ScrollRestorationLoading({
 
           <p className="text-sm text-gray-500 dark:text-gray-400">
             {targetPages > 1
-              ? `約${targetPages * 20}件の記事を読み込んで、前回の位置まで復元しています...`
+              ? `約${targetPages * itemsPerPage}件の記事を読み込んで、前回の位置まで復元しています...`
               : '前回の位置まで記事を読み込んでいます...'}
           </p>
           

--- a/app/components/common/scroll-restoration-loading.tsx
+++ b/app/components/common/scroll-restoration-loading.tsx
@@ -32,14 +32,16 @@ export function ScrollRestorationLoading({
           
           <div className="space-y-2">
             <div className="flex justify-between text-sm text-gray-600 dark:text-gray-400">
-              <span>{currentPage} / {targetPages} ページ</span>
+              <span>記事を読み込んでいます（{currentPage}/{targetPages}ページ）</span>
               <span>{Math.round(progress)}%</span>
             </div>
             <Progress value={progress} className="h-2" />
           </div>
-          
+
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            前回の位置まで記事を読み込んでいます...
+            {targetPages > 1
+              ? `約${targetPages * 20}件の記事を読み込んで、前回の位置まで復元しています...`
+              : '前回の位置まで記事を読み込んでいます...'}
           </p>
           
           <Button 

--- a/app/components/home/home-client-infinite.tsx
+++ b/app/components/home/home-client-infinite.tsx
@@ -8,6 +8,7 @@ import { InfiniteScrollTrigger } from '@/app/components/common/infinite-scroll-t
 import { useInfiniteArticles } from '@/app/hooks/use-infinite-articles';
 import { useScrollRestoration } from '@/app/hooks/use-scroll-restoration';
 import { buildScrollStorageKey } from '@/lib/utils/scroll';
+import { PAGINATION, SCROLL } from '@/lib/constants/index';
 import type { Source, Tag } from '@prisma/client';
 import { Button } from '@/components/ui/button';
 import { RecommendationSectionInline } from '@/components/recommendation/recommendation-section-inline';
@@ -219,7 +220,7 @@ export function HomeClientInfinite({
     // 追跡していたスクロール位置を保存
     const scrollY = currentScrollPositionRef.current;
 
-    if (scrollY > 50) {
+    if (scrollY > SCROLL.MIN_SCROLL_SAVE_THRESHOLD) {
       // 記事のインデックスを取得
       const articleIndex = allArticles.findIndex(a => a.id === articleId);
 
@@ -254,6 +255,7 @@ export function HomeClientInfinite({
             currentPage={currentPage}
             targetPages={targetPages}
             onCancel={cancelRestoration}
+            itemsPerPage={PAGINATION.ITEMS_PER_PAGE}
           />
         )}
         

--- a/app/components/home/home-client-infinite.tsx
+++ b/app/components/home/home-client-infinite.tsx
@@ -220,16 +220,21 @@ export function HomeClientInfinite({
     const scrollY = currentScrollPositionRef.current;
 
     if (scrollY > 50) {
+      // 記事のインデックスを取得
+      const articleIndex = allArticles.findIndex(a => a.id === articleId);
+
       const scrollKey = buildScrollStorageKey();
       sessionStorage.setItem(scrollKey, JSON.stringify({
         scrollY: scrollY,
         timestamp: Date.now(),
-        articleId: articleId || null
+        articleId: articleId || null,
+        articleIndex: articleIndex >= 0 ? articleIndex : undefined, // 新規追加
+        totalArticlesLoaded: allArticles.length  // 新規追加
       }));
     } else {
       // 小さいスクロール位置は保存しない
     }
-  }, []);
+  }, [allArticles]);
 
   if (isError) {
     return (

--- a/app/components/home/home-client-infinite.tsx
+++ b/app/components/home/home-client-infinite.tsx
@@ -221,17 +221,24 @@ export function HomeClientInfinite({
     const scrollY = currentScrollPositionRef.current;
 
     if (scrollY > SCROLL.MIN_SCROLL_SAVE_THRESHOLD) {
-      // 記事のインデックスを取得
-      const articleIndex = allArticles.findIndex(a => a.id === articleId);
+      // articleIdがある場合のみ記事のインデックスを取得
+      const idx = articleId ? allArticles.findIndex(a => a.id === articleId) : -1;
 
       const scrollKey = buildScrollStorageKey();
-      sessionStorage.setItem(scrollKey, JSON.stringify({
-        scrollY: scrollY,
+      const payload = {
+        scrollY,
         timestamp: Date.now(),
-        articleId: articleId || null,
-        articleIndex: articleIndex >= 0 ? articleIndex : undefined, // 新規追加
-        totalArticlesLoaded: allArticles.length  // 新規追加
-      }));
+        articleId: articleId ?? null,
+        articleIndex: idx >= 0 ? idx : undefined,
+        totalArticlesLoaded: allArticles.length,
+      };
+
+      try {
+        sessionStorage.setItem(scrollKey, JSON.stringify(payload));
+      } catch {
+        // Safari Private Browsing等での保存失敗時は復元なしでフォールバック
+        // console.warn('Failed to save scroll position to sessionStorage');
+      }
     } else {
       // 小さいスクロール位置は保存しない
     }

--- a/app/hooks/use-scroll-restoration.ts
+++ b/app/hooks/use-scroll-restoration.ts
@@ -2,12 +2,13 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { buildScrollStorageKey } from '@/lib/utils/scroll';
+import { PAGINATION, TIMEOUTS, SCROLL } from '@/lib/constants/index';
 
 export function useScrollRestoration(
   articlesCount: number,
   pagesLoaded: number,
   filters: Record<string, string>,
-  fetchNextPage: () => void,
+  fetchNextPage: () => Promise<any>,
   hasNextPage: boolean,
   isFetchingNextPage: boolean,
   scrollContainerRef?: React.RefObject<HTMLElement | null>,
@@ -19,7 +20,8 @@ export function useScrollRestoration(
   const restorationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const restorationAbortRef = useRef<boolean>(false);
   const fetchingPagesRef = useRef<boolean>(false);
-  const ITEMS_PER_PAGE = 20; // 1ページあたりの記事数
+  const pagesLoadedRef = useRef<number>(pagesLoaded);
+  const restorationStartedRef = useRef<boolean>(false);
 
   // Helper to manage timeouts safely
   const setRestorationTimeout = useCallback((fn: () => void, delay: number) => {
@@ -33,6 +35,11 @@ export function useScrollRestoration(
     restorationTimeoutRef.current = handle as unknown as NodeJS.Timeout;
     return handle;
   }, []);
+
+  // pagesLoadedRefをpagesLoadedの変更に同期
+  useEffect(() => {
+    pagesLoadedRef.current = pagesLoaded;
+  }, [pagesLoaded]);
 
   // スクロール位置復元処理（記事詳細から戻った時のみ）
   useEffect(() => {
@@ -66,8 +73,8 @@ export function useScrollRestoration(
     }
     const age = Date.now() - Number(timestamp);
 
-    // 30分以内のデータのみ有効
-    if (age > 30 * 60 * 1000) {
+    // 指定時間以内のデータのみ有効
+    if (age > SCROLL.RESTORE_DATA_EXPIRY_MINUTES * 60 * 1000) {
       sessionStorage.removeItem(scrollKey);
       return;
     }
@@ -77,12 +84,21 @@ export function useScrollRestoration(
     const calculateRequiredPages = () => {
       if (typeof articleIndex === 'number' && articleIndex >= 0) {
         // 記事インデックスから必要なページ数を計算
-        return Math.min(Math.ceil((articleIndex + 1) / ITEMS_PER_PAGE), 10); // 最大10ページまで
+        return Math.min(
+          Math.ceil((articleIndex + 1) / PAGINATION.ITEMS_PER_PAGE),
+          PAGINATION.MAX_PREFETCH_PAGES
+        );
       }
       return 1; // デフォルトは1ページ
     };
 
     const requiredPages = calculateRequiredPages();
+
+    // 多重起動防止チェック
+    if (restorationStartedRef.current) {
+      return;
+    }
+    restorationStartedRef.current = true;
 
     // スクロール位置を復元
     // ローディングUIを表示
@@ -90,10 +106,13 @@ export function useScrollRestoration(
     setCurrentPage(pagesLoaded);
     setTargetPages(requiredPages);
 
+    // pagesLoadedRefを更新
+    pagesLoadedRef.current = pagesLoaded;
+
     const restoreScroll = () => {
       // 可能なら記事要素の上端に合わせる（タイトルが確実に見える）
       const mainContainer = document.getElementById('main-scroll-container');
-      const HEADER_OFFSET_PX = 8;
+      const HEADER_OFFSET_PX = SCROLL.HEADER_OFFSET_PX;
 
       const tryScrollToElement = (id: string): boolean => {
         const el = document.getElementById(`article-${id}`) || document.querySelector(`[data-article-id="${id}"]`) as HTMLElement | null;
@@ -163,26 +182,53 @@ export function useScrollRestoration(
           const evt = new CustomEvent('scrollRestored', { detail: { restored: true, cancelled: false } });
           window.dispatchEvent(evt);
         } catch {}
-      }, 700);
+      }, TIMEOUTS.SCROLL_RESTORE_UI_DELAY);
     };
 
     // 必要なページをフェッチしてから復元
     const fetchRequiredPagesAndRestore = async () => {
-      if (requiredPages > pagesLoaded && !fetchingPagesRef.current) {
+      if (requiredPages > pagesLoadedRef.current && !fetchingPagesRef.current) {
         fetchingPagesRef.current = true;
+        try {
+          // 必要なページまで自動的にフェッチ
+          while (pagesLoadedRef.current < requiredPages && hasNextPage && !restorationAbortRef.current) {
+            // fetchNextPageの結果を待ち、成功したらpagesLoadedRefを更新
+            const result = await fetchNextPage();
 
-        // 必要なページまで自動的にフェッチ
-        let currentLoadedPages = pagesLoaded;
-        while (currentLoadedPages < requiredPages && hasNextPage && !restorationAbortRef.current) {
-          await fetchNextPage();
-          currentLoadedPages++;
-          setCurrentPage(currentLoadedPages);
+            // abortチェック
+            if (restorationAbortRef.current) {
+              break;
+            }
 
-          // 少し待機（レンダリングを待つ）
-          await new Promise(resolve => setTimeout(resolve, 100));
+            // 実際にロードされたページ数を確認
+            // fetchNextPageがページ数を返さない場合はインクリメント
+            if (result?.pageParams?.length) {
+              pagesLoadedRef.current = result.pageParams.length;
+            } else {
+              pagesLoadedRef.current++;
+            }
+
+            // UI更新（abort前に再チェック）
+            if (!restorationAbortRef.current) {
+              setCurrentPage(pagesLoadedRef.current);
+            }
+
+            // hasNextPageの再評価（fetchNextPageの結果を反映）
+            if (result?.hasNextPage === false) {
+              break;
+            }
+
+            // 少し待機（レンダリングを待つ）
+            await new Promise(resolve => setTimeout(resolve, TIMEOUTS.PAGE_FETCH_WAIT));
+
+            // 待機後の最終abortチェック
+            if (restorationAbortRef.current) {
+              break;
+            }
+          }
+        } finally {
+          fetchingPagesRef.current = false;
         }
-
-        fetchingPagesRef.current = false;
       }
     };
 
@@ -192,8 +238,8 @@ export function useScrollRestoration(
       await fetchRequiredPagesAndRestore();
 
       let attempts = 0;
-      const maxAttempts = 12; // 約1.2秒 (100ms間隔)
-      const interval = 100;
+      const maxAttempts = TIMEOUTS.SCROLL_RESTORE_MAX_ATTEMPTS;
+      const interval = TIMEOUTS.SCROLL_RESTORE_RETRY_INTERVAL;
 
       const tryOnce = () => {
         if (restorationAbortRef.current) return;
@@ -232,6 +278,7 @@ export function useScrollRestoration(
       // cleanup on effect dispose
       restorationAbortRef.current = true;
       fetchingPagesRef.current = false;
+      restorationStartedRef.current = false;
       if (restorationTimeoutRef.current) {
         clearTimeout(restorationTimeoutRef.current);
         restorationTimeoutRef.current = null;
@@ -247,6 +294,7 @@ export function useScrollRestoration(
   // 復元キャンセル（互換性のため残す）
   const cancelRestoration = useCallback(() => {
     restorationAbortRef.current = true;
+    restorationStartedRef.current = false;
     setIsRestoring(false);
     setCurrentPage(0);
     setTargetPages(0);

--- a/app/hooks/use-scroll-restoration.ts
+++ b/app/hooks/use-scroll-restoration.ts
@@ -18,6 +18,8 @@ export function useScrollRestoration(
   const [targetPages, setTargetPages] = useState(0);
   const restorationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const restorationAbortRef = useRef<boolean>(false);
+  const fetchingPagesRef = useRef<boolean>(false);
+  const ITEMS_PER_PAGE = 20; // 1ページあたりの記事数
 
   // Helper to manage timeouts safely
   const setRestorationTimeout = useCallback((fn: () => void, delay: number) => {
@@ -57,7 +59,7 @@ export function useScrollRestoration(
       sessionStorage.removeItem(scrollKey);
       return;
     }
-    const { scrollY, timestamp, articleId } = parsed ?? {};
+    const { scrollY, timestamp, articleId, articleIndex } = parsed ?? {};
     if (typeof timestamp !== 'number') {
       sessionStorage.removeItem(scrollKey);
       return;
@@ -71,11 +73,22 @@ export function useScrollRestoration(
     }
 
 
+    // 必要なページ数を計算
+    const calculateRequiredPages = () => {
+      if (typeof articleIndex === 'number' && articleIndex >= 0) {
+        // 記事インデックスから必要なページ数を計算
+        return Math.min(Math.ceil((articleIndex + 1) / ITEMS_PER_PAGE), 10); // 最大10ページまで
+      }
+      return 1; // デフォルトは1ページ
+    };
+
+    const requiredPages = calculateRequiredPages();
+
     // スクロール位置を復元
     // ローディングUIを表示
     setIsRestoring(true);
-    setCurrentPage(1);
-    setTargetPages(1);
+    setCurrentPage(pagesLoaded);
+    setTargetPages(requiredPages);
 
     const restoreScroll = () => {
       // 可能なら記事要素の上端に合わせる（タイトルが確実に見える）
@@ -153,8 +166,31 @@ export function useScrollRestoration(
       }, 700);
     };
 
+    // 必要なページをフェッチしてから復元
+    const fetchRequiredPagesAndRestore = async () => {
+      if (requiredPages > pagesLoaded && !fetchingPagesRef.current) {
+        fetchingPagesRef.current = true;
+
+        // 必要なページまで自動的にフェッチ
+        let currentLoadedPages = pagesLoaded;
+        while (currentLoadedPages < requiredPages && hasNextPage && !restorationAbortRef.current) {
+          await fetchNextPage();
+          currentLoadedPages++;
+          setCurrentPage(currentLoadedPages);
+
+          // 少し待機（レンダリングを待つ）
+          await new Promise(resolve => setTimeout(resolve, 100));
+        }
+
+        fetchingPagesRef.current = false;
+      }
+    };
+
     // 少し遅延してから復元（DOMの準備を待つ）
-    const tryRestoreWithRetry = () => {
+    const tryRestoreWithRetry = async () => {
+      // まず必要なページをフェッチ
+      await fetchRequiredPagesAndRestore();
+
       let attempts = 0;
       const maxAttempts = 12; // 約1.2秒 (100ms間隔)
       const interval = 100;
@@ -195,12 +231,13 @@ export function useScrollRestoration(
     return () => {
       // cleanup on effect dispose
       restorationAbortRef.current = true;
+      fetchingPagesRef.current = false;
       if (restorationTimeoutRef.current) {
         clearTimeout(restorationTimeoutRef.current);
         restorationTimeoutRef.current = null;
       }
     };
-  }, [isReturningFromArticle, scrollContainerRef, setRestorationTimeout]);
+  }, [isReturningFromArticle, scrollContainerRef, setRestorationTimeout, fetchNextPage, hasNextPage, pagesLoaded]);
 
   // スクロール位置を保存（互換性のため残す）
   const saveScrollPosition = useCallback(() => {

--- a/app/hooks/use-scroll-restoration.ts
+++ b/app/hooks/use-scroll-restoration.ts
@@ -8,7 +8,7 @@ export function useScrollRestoration(
   articlesCount: number,
   pagesLoaded: number,
   filters: Record<string, string>,
-  fetchNextPage: () => Promise<any>,
+  fetchNextPage: () => Promise<unknown>,
   hasNextPage: boolean,
   isFetchingNextPage: boolean,
   scrollContainerRef?: React.RefObject<HTMLElement | null>,
@@ -80,7 +80,7 @@ export function useScrollRestoration(
     const age = Date.now() - Number(timestamp);
 
     // 指定時間以内のデータのみ有効
-    if (age > SCROLL.RESTORE_DATA_EXPIRY_MINUTES * 60 * 1000) {
+    if (age > SCROLL.RESTORE_DATA_EXPIRY_MS) {
       sessionStorage.removeItem(scrollKey);
       return;
     }
@@ -115,12 +115,19 @@ export function useScrollRestoration(
     // pagesLoadedRefを更新
     pagesLoadedRef.current = pagesLoaded;
 
+    // prefers-reduced-motionを尊重したスクロール動作を取得
+    const getScrollBehavior = (): ScrollBehavior => {
+      const prefersReduced = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches === true;
+      return prefersReduced ? 'auto' : 'smooth';
+    };
+
     const restoreScroll = () => {
       // 可能なら記事要素の上端に合わせる（タイトルが確実に見える）
       const mainContainer = document.getElementById('main-scroll-container');
       const HEADER_OFFSET_PX = SCROLL.HEADER_OFFSET_PX;
 
       const tryScrollToElement = (id: string): boolean => {
+        const behavior = getScrollBehavior();
         const el = document.getElementById(`article-${id}`) || document.querySelector(`[data-article-id="${id}"]`) as HTMLElement | null;
         if (!el) return false;
         // コンテナがスクロール領域の場合はoffsetTopを使う
@@ -128,18 +135,18 @@ export function useScrollRestoration(
           const target = Math.max(el.offsetTop - HEADER_OFFSET_PX, 0);
           const containerElement = mainContainer as unknown;
           if (containerElement && typeof (containerElement as { scrollTo?: (options: { top: number; behavior: string }) => void }).scrollTo === 'function') {
-            (containerElement as { scrollTo: (options: { top: number; behavior: string }) => void }).scrollTo({ top: target, behavior: 'smooth' });
+            (containerElement as { scrollTo: (options: { top: number; behavior: string }) => void }).scrollTo({ top: target, behavior });
           } else {
             (mainContainer as HTMLElement).scrollTop = target;
           }
           // メインコンテナを使う場合、ウィンドウは最上部に固定
-          window.scrollTo({ top: 0, behavior: 'auto' });
+          window.scrollTo({ top: 0, behavior });
           return true;
         }
         // windowスクロールの場合
         const rect = el.getBoundingClientRect();
         const y = Math.max(window.scrollY + rect.top - HEADER_OFFSET_PX, 0);
-        window.scrollTo({ top: y, behavior: 'smooth' });
+        window.scrollTo({ top: y, behavior });
         return true;
       };
 
@@ -147,13 +154,14 @@ export function useScrollRestoration(
         // OK: 要素に合わせて復元完了
       } else {
         // フォールバック: 保存されたスクロール値に微調整を加えて復元
+        const behavior = getScrollBehavior();
         const RESTORE_OFFSET_PX = 0; // 要素に合わせられない場合はそのまま使う
         const adjustedScrollY = Math.max((scrollY ?? 0) + RESTORE_OFFSET_PX, 0);
-        window.scrollTo({ top: adjustedScrollY, behavior: 'smooth' });
+        window.scrollTo({ top: adjustedScrollY, behavior });
         if (mainContainer) {
           const containerElement = mainContainer as unknown;
           if (containerElement && typeof (containerElement as { scrollTo?: (options: { top: number; behavior: string }) => void }).scrollTo === 'function') {
-            (containerElement as { scrollTo: (options: { top: number; behavior: string }) => void }).scrollTo({ top: adjustedScrollY, behavior: 'smooth' });
+            (containerElement as { scrollTo: (options: { top: number; behavior: string }) => void }).scrollTo({ top: adjustedScrollY, behavior });
           } else {
             mainContainer.scrollTop = adjustedScrollY;
           }
@@ -161,7 +169,7 @@ export function useScrollRestoration(
         if (scrollContainerRef?.current) {
           const sc = scrollContainerRef.current as unknown;
           if (sc && typeof (sc as { scrollTo?: (options: { top: number; behavior: string }) => void }).scrollTo === 'function') {
-            (sc as { scrollTo: (options: { top: number; behavior: string }) => void }).scrollTo({ top: adjustedScrollY, behavior: 'smooth' });
+            (sc as { scrollTo: (options: { top: number; behavior: string }) => void }).scrollTo({ top: adjustedScrollY, behavior });
           } else {
             (scrollContainerRef.current as HTMLElement).scrollTop = adjustedScrollY;
           }
@@ -170,7 +178,7 @@ export function useScrollRestoration(
         scrollableElements.forEach((el, _index) => {
           const anyEl = el as unknown;
           if (anyEl && typeof (anyEl as { scrollTo?: (options: { top: number; behavior: string }) => void }).scrollTo === 'function') {
-            (anyEl as { scrollTo: (options: { top: number; behavior: string }) => void }).scrollTo({ top: adjustedScrollY, behavior: 'smooth' });
+            (anyEl as { scrollTo: (options: { top: number; behavior: string }) => void }).scrollTo({ top: adjustedScrollY, behavior });
           } else {
             (el as HTMLElement).scrollTop = adjustedScrollY;
           }
@@ -199,22 +207,22 @@ export function useScrollRestoration(
         try {
           // 必要なページまで自動的にフェッチ
           while (pagesLoadedRef.current < requiredPages && hasNextPageRef.current && !restorationAbortRef.current) {
-            // fetchNextPageの結果を待ち、成功したらpagesLoadedRefを更新
-            const result = await fetchNextPage();
+            const previousPages = pagesLoadedRef.current;
+
+            // fetchNextPageを実行（戻り値は使用しない）
+            await fetchNextPage();
 
             // abortチェック
             if (restorationAbortRef.current) {
               break;
             }
 
-            // 実際にロードされたページ数を確認（React Query v5のレスポンス構造に対応）
-            // result.data.pageParamsから取得する
-            if (result?.data?.pageParams?.length) {
-              pagesLoadedRef.current = result.data.pageParams.length;
-            } else if (result?.pageParams?.length) {
-              // 互換性のためのフォールバック
-              pagesLoadedRef.current = result.pageParams.length;
-            } else {
+            // 親コンポーネントがpagesLoadedを更新するのを短時間待つ
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            // pagesLoadedが変化していない場合は自前でインクリメント
+            // （親コンポーネントが更新しなかった場合のフォールバック）
+            if (pagesLoadedRef.current === previousPages) {
               pagesLoadedRef.current++;
             }
 
@@ -223,16 +231,9 @@ export function useScrollRestoration(
               setCurrentPage(pagesLoadedRef.current);
             }
 
-            // hasNextPageの再評価（fetchNextPageの結果を反映）
-            if (result?.data?.hasNextPage !== undefined) {
-              hasNextPageRef.current = result.data.hasNextPage;
-            } else if (result?.hasNextPage !== undefined) {
-              // 互換性のためのフォールバック
-              hasNextPageRef.current = result.hasNextPage;
-            }
-
-            // hasNextPageがfalseならループ終了
-            if (hasNextPageRef.current === false) {
+            // hasNextPageがfalseになったら終了
+            // （hasNextPageRefは外部から更新される）
+            if (!hasNextPageRef.current) {
               break;
             }
 

--- a/app/hooks/use-scroll-restoration.ts
+++ b/app/hooks/use-scroll-restoration.ts
@@ -17,11 +17,12 @@ export function useScrollRestoration(
   const [isRestoring, setIsRestoring] = useState(false);
   const [currentPage, setCurrentPage] = useState(0);
   const [targetPages, setTargetPages] = useState(0);
-  const restorationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const restorationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const restorationAbortRef = useRef<boolean>(false);
   const fetchingPagesRef = useRef<boolean>(false);
   const pagesLoadedRef = useRef<number>(pagesLoaded);
   const restorationStartedRef = useRef<boolean>(false);
+  const hasNextPageRef = useRef<boolean>(hasNextPage);
 
   // Helper to manage timeouts safely
   const setRestorationTimeout = useCallback((fn: () => void, delay: number) => {
@@ -32,7 +33,7 @@ export function useScrollRestoration(
       if (restorationAbortRef.current) return;
       fn();
     }, delay);
-    restorationTimeoutRef.current = handle as unknown as NodeJS.Timeout;
+    restorationTimeoutRef.current = handle;
     return handle;
   }, []);
 
@@ -40,6 +41,11 @@ export function useScrollRestoration(
   useEffect(() => {
     pagesLoadedRef.current = pagesLoaded;
   }, [pagesLoaded]);
+
+  // hasNextPageRefをhasNextPageの変更に同期
+  useEffect(() => {
+    hasNextPageRef.current = hasNextPage;
+  }, [hasNextPage]);
 
   // スクロール位置復元処理（記事詳細から戻った時のみ）
   useEffect(() => {
@@ -178,6 +184,7 @@ export function useScrollRestoration(
       setRestorationTimeout(() => {
         if (restorationAbortRef.current) return;
         setIsRestoring(false);
+        restorationStartedRef.current = false;
         try {
           const evt = new CustomEvent('scrollRestored', { detail: { restored: true, cancelled: false } });
           window.dispatchEvent(evt);
@@ -191,7 +198,7 @@ export function useScrollRestoration(
         fetchingPagesRef.current = true;
         try {
           // 必要なページまで自動的にフェッチ
-          while (pagesLoadedRef.current < requiredPages && hasNextPage && !restorationAbortRef.current) {
+          while (pagesLoadedRef.current < requiredPages && hasNextPageRef.current && !restorationAbortRef.current) {
             // fetchNextPageの結果を待ち、成功したらpagesLoadedRefを更新
             const result = await fetchNextPage();
 
@@ -200,9 +207,12 @@ export function useScrollRestoration(
               break;
             }
 
-            // 実際にロードされたページ数を確認
-            // fetchNextPageがページ数を返さない場合はインクリメント
-            if (result?.pageParams?.length) {
+            // 実際にロードされたページ数を確認（React Query v5のレスポンス構造に対応）
+            // result.data.pageParamsから取得する
+            if (result?.data?.pageParams?.length) {
+              pagesLoadedRef.current = result.data.pageParams.length;
+            } else if (result?.pageParams?.length) {
+              // 互換性のためのフォールバック
               pagesLoadedRef.current = result.pageParams.length;
             } else {
               pagesLoadedRef.current++;
@@ -214,7 +224,15 @@ export function useScrollRestoration(
             }
 
             // hasNextPageの再評価（fetchNextPageの結果を反映）
-            if (result?.hasNextPage === false) {
+            if (result?.data?.hasNextPage !== undefined) {
+              hasNextPageRef.current = result.data.hasNextPage;
+            } else if (result?.hasNextPage !== undefined) {
+              // 互換性のためのフォールバック
+              hasNextPageRef.current = result.hasNextPage;
+            }
+
+            // hasNextPageがfalseならループ終了
+            if (hasNextPageRef.current === false) {
               break;
             }
 
@@ -269,7 +287,7 @@ export function useScrollRestoration(
         }
       };
 
-      setRestorationTimeout(tryOnce, 100);
+      setRestorationTimeout(tryOnce, interval);
     };
 
     tryRestoreWithRetry();

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -10,7 +10,10 @@ export const PAGINATION = {
 } as const;
 
 // 互換性レイヤー（将来的に削除予定）
-// DEPRECATED: 直接参照は避け、PAGINATION.ITEMS_PER_PAGE を使用してください
+/**
+ * @deprecated 直接参照は避け、PAGINATION.ITEMS_PER_PAGE を使用してください。
+ *             v2.0.0で削除予定。
+ */
 export const ARTICLES_PER_PAGE = PAGINATION.ITEMS_PER_PAGE;
 
 // タイムアウト関連
@@ -29,7 +32,9 @@ export const TIMEOUTS = {
 export const SCROLL = {
   /** スクロール保存のしきい値（px） */
   MIN_SCROLL_SAVE_THRESHOLD: 50,
-  /** スクロール復元データの有効期限（分） */
+  /** スクロール復元データの有効期限（ms） */
+  RESTORE_DATA_EXPIRY_MS: 30 * 60 * 1000, // 30分
+  /** スクロール復元データの有効期限（分） @deprecated RESTORE_DATA_EXPIRY_MSを使用してください */
   RESTORE_DATA_EXPIRY_MINUTES: 30,
   /** ヘッダーオフセット（px） */
   HEADER_OFFSET_PX: 8,

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -1,8 +1,6 @@
 export const SITE_NAME = 'TechTrend';
 export const SITE_DESCRIPTION = '最新テックトレンドを一括収集・表示';
 
-export const ARTICLES_PER_PAGE = 20;
-
 // ページネーション関連
 export const PAGINATION = {
   /** 1ページあたりの表示記事数 */
@@ -10,6 +8,10 @@ export const PAGINATION = {
   /** スクロール復元時の最大プリフェッチページ数（UX/パフォーマンス観点の上限） */
   MAX_PREFETCH_PAGES: 10,
 } as const;
+
+// 互換性レイヤー（将来的に削除予定）
+// DEPRECATED: 直接参照は避け、PAGINATION.ITEMS_PER_PAGE を使用してください
+export const ARTICLES_PER_PAGE = PAGINATION.ITEMS_PER_PAGE;
 
 // タイムアウト関連
 export const TIMEOUTS = {

--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -2,6 +2,36 @@ export const SITE_NAME = 'TechTrend';
 export const SITE_DESCRIPTION = '最新テックトレンドを一括収集・表示';
 
 export const ARTICLES_PER_PAGE = 20;
+
+// ページネーション関連
+export const PAGINATION = {
+  /** 1ページあたりの表示記事数 */
+  ITEMS_PER_PAGE: 20,
+  /** スクロール復元時の最大プリフェッチページ数（UX/パフォーマンス観点の上限） */
+  MAX_PREFETCH_PAGES: 10,
+} as const;
+
+// タイムアウト関連
+export const TIMEOUTS = {
+  /** スクロール復元リトライの最大試行回数 */
+  SCROLL_RESTORE_MAX_ATTEMPTS: 12,
+  /** スクロール復元リトライ間隔（ミリ秒） */
+  SCROLL_RESTORE_RETRY_INTERVAL: 100,
+  /** スクロール復元後のUI非表示遅延（ミリ秒） */
+  SCROLL_RESTORE_UI_DELAY: 700,
+  /** ページフェッチ後の待機時間（ミリ秒） */
+  PAGE_FETCH_WAIT: 100,
+} as const;
+
+// スクロール関連
+export const SCROLL = {
+  /** スクロール保存のしきい値（px） */
+  MIN_SCROLL_SAVE_THRESHOLD: 50,
+  /** スクロール復元データの有効期限（分） */
+  RESTORE_DATA_EXPIRY_MINUTES: 30,
+  /** ヘッダーオフセット（px） */
+  HEADER_OFFSET_PX: 8,
+} as const;
 export const MAX_SUMMARY_LENGTH = 200;
 
 export const GEMINI_API = {


### PR DESCRIPTION
## 概要
記事詳細ページから記事一覧に戻る際のスクロール位置復元機能が、初回アクセス時に正常動作しない問題を修正しました。

## 問題の詳細
- **事象**: 60件目の記事から詳細ページへ遷移し、「記事一覧に戻る」で戻った際、初回はスクロール位置が復元されない
- **原因**: 無限スクロールのデータロードとスクロール復元のタイミング競合

## 実装内容

### 1. 記事インデックスベースの復元方式
- sessionStorageに記事のインデックス（何番目の記事か）を追加保存
- 必要なページ数を自動計算: `Math.ceil((articleIndex + 1) / ITEMS_PER_PAGE)`
- 最大10ページまでの制限でパフォーマンス問題を回避

### 2. 自動ページフェッチ機能
```typescript
// 必要なページまで自動的にフェッチ
while (currentLoadedPages < requiredPages && hasNextPage) {
  await fetchNextPage();
  currentLoadedPages++;
  setCurrentPage(currentLoadedPages);
}
```

### 3. UI/UX改善
- プログレッシブローディング表示
- ページ数と推定記事数の表示
- キャンセルボタンの提供

## テスト結果
✅ **E2Eテスト**: 全370テスト合格
- scroll-restoration.spec.ts: 完全合格
- 初回アクセス時でも正しく復元されることを確認

✅ **ビルドテスト**: 成功（34.4秒）
✅ **Lintテスト**: エラー・警告なし

## 変更ファイル
- `app/components/home/home-client-infinite.tsx`: 記事インデックス保存機能追加
- `app/hooks/use-scroll-restoration.ts`: 自動ページフェッチ機能実装
- `app/components/common/scroll-restoration-loading.tsx`: UI改善

## 関連ドキュメント
- 調査結果: `.claude/docs/investigate/investigate_1758495017034_scroll-restoration-bug.md`
- 実装計画: `.claude/docs/plan/plan_1758495224944_scroll-restoration-fix.md`
- 実装詳細: `.claude/docs/implement/implement_1758495877253_scroll-restoration-improvement.md`

## 確認方法
1. ブラウザキャッシュをクリア
2. 記事一覧で60件目まで無限スクロール
3. 記事をクリックして詳細ページへ
4. 「記事一覧に戻る」をクリック
5. スクロール位置が自動復元されることを確認

Fixes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 復元前に必要ページを事前取得して複数ページにまたがるスクロール位置をより正確に復元。復元中は進捗表示と整合。
  * 読み込みUIを強化し、進捗文言を「記事を読み込んでいます（現在/目標）」に変更。ページ数に応じて概算件数を表示。
  * ページサイズやタイミング等の設定を集中管理する定数を導入。

* **バグ修正**
  * 記事クリック時の保存データに記事インデックスと総件数を追加し、復元位置のズレを軽減。
  * 保存処理の失敗（例: プライベートブラウジング）を安全に扱う保護を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->