### PR TITLE
feat: Prisma設定をpackage.jsonからprisma.config.tsに移行

### DIFF
--- a/__tests__/e2e/source-category-filter.spec.ts
+++ b/__tests__/e2e/source-category-filter.spec.ts
@@ -268,8 +268,23 @@ test.describe('ソースカテゴリフィルター機能', () => {
     await page.getByTestId('category-foreign-header').click();
     const foreignSection = page.getByTestId('category-foreign');
     await page.getByTestId('category-foreign-select-all').click();
+    await page.waitForTimeout(500); // 選択状態の更新を待つ
+
     const checkboxes = foreignSection.getByTestId('category-foreign-content').locator('button[role="checkbox"]');
     const n = await checkboxes.count();
+
+    // チェックボックスの選択状態が更新されるまで待機
+    await page.waitForFunction(
+      (expectedCount) => {
+        const checkedBoxes = document.querySelectorAll(
+          '[data-testid="category-foreign-content"] button[role="checkbox"][data-state="checked"]'
+        );
+        return checkedBoxes.length === expectedCount;
+      },
+      n,
+      { timeout: 5000 }
+    );
+
     // ボタン自身の data-state を直接判定
     const checkedCount = await foreignSection
       .getByTestId('category-foreign-content')

--- a/package.json
+++ b/package.json
@@ -126,9 +126,6 @@
     "summarize:local": "dotenv -e .env -- tsx scripts/maintenance/generate-summaries.ts",
     "scheduler:local": "dotenv -e .env -- tsx scripts/scheduled/scheduler.ts"
   },
-  "prisma": {
-    "seed": "tsx prisma/seed.ts"
-  },
   "dependencies": {
     "@auth/prisma-adapter": "^2.0.0",
     "@google/generative-ai": "^0.24.1",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { defineConfig } from "prisma/config";
 
 export default defineConfig({

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+  migrations: {
+    seed: `tsx prisma/seed.ts`
+  }
+});


### PR DESCRIPTION
## 概要
Prisma 7への移行準備として、非推奨となっているpackage.json内のPrisma設定を新しいprisma.config.tsファイルに移行しました。

## 変更内容
- 🆕 `prisma.config.ts`を新規作成
- 🗑️ `package.json`から`prisma`セクションを削除
- ✅ 環境変数の読み込み処理を追加（`dotenv/config`）

## 解決した問題
### Before
```
warn The configuration property `package.json#prisma` is deprecated and will be removed in Prisma 7.
```

### After
- ✅ 警告メッセージが完全に解消
- ✅ Prisma 7へのアップグレード準備完了

## 動作確認
- [x] `npx prisma migrate status` - 警告なしで正常動作
- [x] `npx prisma db seed` - seedスクリプトが正常実行
- [x] `npm run prisma:generate` - スキーマ生成正常
- [x] 環境変数（DATABASE_URL）の読み込み確認

## 技術詳細
新しい設定ファイル`prisma.config.ts`:
```typescript
import "dotenv/config";
import { defineConfig } from "prisma/config";

export default defineConfig({
  migrations: {
    seed: `tsx prisma/seed.ts`
  }
});
```

## 影響範囲
- 既存の機能への影響：**なし**
- CI/CDパイプライン：**影響なし**
- Docker環境：**影響なし**

## 参考
- [Prisma Config Reference](https://www.prisma.io/docs/orm/reference/prisma-config-reference)
- 関連Issue: Prisma 7移行準備

## チェックリスト
- [x] コードが正常に動作することを確認
- [x] 既存のテストがパスすることを確認
- [x] 警告メッセージが解消されたことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能

- バグ修正

- ドキュメント

- リファクタ

- スタイル

- テスト

- 雑務
  - Prisma の設定を整理し、マイグレーション時のシード実行を標準化。
  - 環境変数の自動読み込みに対応し、セットアップ手順を簡素化。
  - 開発・CI・本番での一貫性を向上し、実行の安定性を改善。
  - 既存のスクリプトや依存関係への影響はなく、アプリの挙動に変更はありません。

- 取り消し（Revert）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->