### PR TITLE
fix: Next.js 15で動的ルートパラメータをPromiseとして処理するよう修正

### DIFF
--- a/__tests__/api/digest/[week]/route.test.ts
+++ b/__tests__/api/digest/[week]/route.test.ts
@@ -101,7 +101,7 @@ describe('/api/digest/[week]', () => {
   describe('GET', () => {
     it('週次ダイジェストを取得する（キャッシュなし）', async () => {
       const request = new NextRequest('http://localhost/api/digest/2025-01-01');
-      const params = { week: '2025-01-01' };
+      const params = Promise.resolve({ week: '2025-01-01' });
 
       const response = await GET(request, { params });
 
@@ -121,7 +121,7 @@ describe('/api/digest/[week]', () => {
       mockCacheInstance.get.mockResolvedValue(mockDigest);
 
       const request = new NextRequest('http://localhost/api/digest/2025-01-01');
-      const params = { week: '2025-01-01' };
+      const params = Promise.resolve({ week: '2025-01-01' });
 
       const response = await GET(request, { params });
 
@@ -135,7 +135,7 @@ describe('/api/digest/[week]', () => {
 
     it('無効な日付形式でエラーを返す', async () => {
       const request = new NextRequest('http://localhost/api/digest/invalid-date');
-      const params = { week: 'invalid-date' };
+      const params = Promise.resolve({ week: 'invalid-date' });
 
       const response = await GET(request, { params });
 
@@ -153,7 +153,7 @@ describe('/api/digest/[week]', () => {
       mockGeneratorInstance.getWeeklyDigest.mockResolvedValue(null);
 
       const request = new NextRequest('http://localhost/api/digest/2025-01-01');
-      const params = { week: '2025-01-01' };
+      const params = Promise.resolve({ week: '2025-01-01' });
 
       const response = await GET(request, { params });
 
@@ -171,7 +171,7 @@ describe('/api/digest/[week]', () => {
       mockGeneratorInstance.getWeeklyDigest.mockRejectedValue(new Error('Database error'));
 
       const request = new NextRequest('http://localhost/api/digest/2025-01-01');
-      const params = { week: '2025-01-01' };
+      const params = Promise.resolve({ week: '2025-01-01' });
 
       const response = await GET(request, { params });
 
@@ -187,7 +187,7 @@ describe('/api/digest/[week]', () => {
       mockCacheInstance.get.mockRejectedValue(new Error('Cache error'));
 
       const request = new NextRequest('http://localhost/api/digest/2025-01-01');
-      const params = { week: '2025-01-01' };
+      const params = Promise.resolve({ week: '2025-01-01' });
 
       const response = await GET(request, { params });
 
@@ -202,7 +202,7 @@ describe('/api/digest/[week]', () => {
       mockCacheInstance.set.mockRejectedValue(new Error('Cache set error'));
 
       const request = new NextRequest('http://localhost/api/digest/2025-01-01');
-      const params = { week: '2025-01-01' };
+      const params = Promise.resolve({ week: '2025-01-01' });
 
       const response = await GET(request, { params });
 
@@ -214,7 +214,7 @@ describe('/api/digest/[week]', () => {
 
     it('異なる週の日付でも正しくキャッシュキーを生成する', async () => {
       const request = new NextRequest('http://localhost/api/digest/2025-02-15');
-      const params = { week: '2025-02-15' };
+      const params = Promise.resolve({ week: '2025-02-15' });
 
       const response = await GET(request, { params });
 

--- a/app/api/digest/[week]/route.ts
+++ b/app/api/digest/[week]/route.ts
@@ -19,10 +19,11 @@ const getCache = () => {
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { week: string } }
+  { params }: { params: Promise<{ week: string }> }
 ) {
   try {
-    const weekDate = new Date(params.week);
+    const { week } = await params;
+    const weekDate = new Date(week);
     
     if (isNaN(weekDate.getTime())) {
       return NextResponse.json(
@@ -34,7 +35,7 @@ export async function GET(
     // Generate cache key based on week start date
     const cacheInstance = getCache();
     const cacheKey = cacheInstance.generateCacheKey('weekly-digest', {
-      params: { week: params.week }
+      params: { week }
     });
 
     // Check cache first


### PR DESCRIPTION
## 概要
Next.js 15への移行に伴い、動的ルートのパラメータがPromiseになったことに対応しました。

## 問題
`/api/digest/[week]` エンドポイントで以下のエラーが発生していました：
```
Error: Route "/api/digest/[week]" used `params.week`. `params` should be awaited before using its properties.
```

## 変更内容
- `/api/digest/[week]` エンドポイントで`params`の型定義を`Promise<{ week: string }>`に変更
- `await`で`params`を解決してから使用するように修正
- テストファイルも同様にPromiseとして扱うよう更新

## 修正ファイル
- `app/api/digest/[week]/route.ts` - APIエンドポイントの修正（2箇所）
- `__tests__/api/digest/[week]/route.test.ts` - テストの修正（8箇所）

## テスト結果
✅ すべてのテストが成功
- 単体テスト: 8/8 パス
- 全体テスト: 1272/1319 パス（47スキップ）
- ビルド: 成功
- Lint: エラー・警告なし

## 影響範囲
- 直接影響: `/api/digest/[week]` エンドポイントのみ
- 間接影響: なし
- 他のAPIエンドポイント: 影響なし（動的パラメータを使用する他のエンドポイントは存在しない）

## Next.js 15の変更点
動的ルートパラメータがPromiseになった理由：
- パフォーマンス最適化
- 非同期データフェッチングの改善  
- React Server Componentsとの整合性

## 参考資料
- [Next.js 15 Migration Guide](https://nextjs.org/docs/app/api-reference/file-conventions/route#dynamic-routes)
- 関連Issue: #（該当なし）

## チェックリスト
- [x] コード変更の実装
- [x] テストの修正と実行
- [x] ビルドの確認
- [x] Lintの確認
- [x] ドキュメントの更新（`.claude/docs/`に記録）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- バグ修正
  - 週次ダイジェストAPIが非同期なルートパラメータを正しく処理するよう調整し、最新の実行環境との互換性と安定性を向上。レスポンス内容、ステータスコード、エラーメッセージに変更はありません。既存のキャッシュ動作や生成ロジックにも影響はありません。

- テスト
  - ルートパラメータの受け取り方式の変更に合わせてテストを更新し、期待値とエッジケース検証を維持。ユーザー向けの挙動は従来どおりです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->