### PR TITLE
fix: Prisma要約生成クエリエラーの修正

### DIFF
--- a/scripts/scheduled/manage-summaries.ts
+++ b/scripts/scheduled/manage-summaries.ts
@@ -403,13 +403,10 @@ async function checkNewArticles(options?: Options): Promise<boolean> {
         ]
       },
       {
-        // createdAtがある場合は優先、なければpublishedAtを使用
+        // createdAtまたはpublishedAtが1時間以内
         OR: [
           { createdAt: { gte: oneHourAgo } },
-          {
-            createdAt: null,
-            publishedAt: { gte: oneHourAgo }
-          }
+          { publishedAt: { gte: oneHourAgo } }
         ]
       }
     ]


### PR DESCRIPTION
## 概要
GitHub Actionsでの要約生成処理で発生していたPrismaクエリエラーを修正しました。

## 問題
- `manage-summaries.ts`の`checkNewArticles`関数でPrismaClientValidationError発生
- エラー: `Argument 'createdAt' is missing`
- 原因: `createdAt: null`という無効な条件を指定していた

## 修正内容
- `createdAt: null`の条件を削除
- スキーマ上`createdAt`はNOT NULL制約があるため、null条件は不要

### 変更前
```typescript
OR: [
  { createdAt: { gte: oneHourAgo } },
  {
    createdAt: null,  // ← 無効な条件
    publishedAt: { gte: oneHourAgo }
  }
]
```

### 変更後
```typescript
OR: [
  { createdAt: { gte: oneHourAgo } },
  { publishedAt: { gte: oneHourAgo } }
]
```

## テスト結果
- ✅ ローカル環境での動作確認完了
- ✅ クエリエラーが解消
- ✅ 要約生成処理が正常動作

## 影響範囲
- 影響ファイル: `scripts/scheduled/manage-summaries.ts`のみ
- 他の処理への影響: なし
- データベースへの影響: なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - なし
- リファクタリング
  - 新着記事チェックの条件を単純化（createdAt もしくは publishedAt が直近1時間）。可読性と一貫性を向上し、外部仕様や挙動への影響はありません。
- ドキュメント
  - 条件式の意図に合わせてコメントを更新し、説明を明確化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->