### PR TITLE
fix: 翻訳欠落記事が処理対象外になる問題を修正

### DIFF
--- a/scripts/scheduled/manage-summaries.ts
+++ b/scripts/scheduled/manage-summaries.ts
@@ -561,10 +561,7 @@ async function generateSummaries(options: Options): Promise<GenerateResult> {
       where: {
         translatedTitle: null,
         summary: { not: null },
-        OR: [
-          { detailedSummary: { not: null } },
-          { summary: { not: null } }
-        ]
+        detailedSummary: { not: null }
       },
       include: { source: true },
       orderBy: { publishedAt: 'desc' },

--- a/scripts/scheduled/manage-summaries.ts
+++ b/scripts/scheduled/manage-summaries.ts
@@ -556,12 +556,34 @@ async function generateSummaries(options: Options): Promise<GenerateResult> {
 
     const articlesWithoutTags = await prisma.article.findMany(articlesWithoutTagsQuery) as ArticleWithSource[];
 
+    // 5. 翻訳がない記事を取得
+    const articlesWithoutTranslationQuery: Prisma.ArticleFindManyArgs = {
+      where: {
+        translatedTitle: null,
+        summary: { not: null },
+        OR: [
+          { detailedSummary: { not: null } },
+          { summary: { not: null } }
+        ]
+      },
+      include: { source: true },
+      orderBy: { publishedAt: 'desc' },
+      take: options.limit
+    };
+
+    if (options.source) {
+      articlesWithoutTranslationQuery.where.source = { name: options.source };
+    }
+
+    const articlesWithoutTranslation = await prisma.article.findMany(articlesWithoutTranslationQuery) as ArticleWithSource[];
+
     // すべての対象記事を結合
     const allArticlesToProcess = [
       ...articlesWithoutSummary,
       ...articlesWithEnglishSummary,
       ...truncatedArticles,
-      ...articlesWithoutTags
+      ...articlesWithoutTags,
+      ...articlesWithoutTranslation
     ];
 
     // 重複を除去
@@ -587,6 +609,7 @@ async function generateSummaries(options: Options): Promise<GenerateResult> {
     console.error(`   - 英語要約: ${articlesWithEnglishSummary.length}件`);
     console.error(`   - 途切れた要約: ${truncatedArticles.length}件`);
     console.error(`   - タグなし: ${articlesWithoutTags.length}件`);
+    console.error(`   - 翻訳なし: ${articlesWithoutTranslation.length}件`);
     console.error(`   - 合計（重複除去後）: ${uniqueArticles.length}件`);
 
     let generatedCount = 0;


### PR DESCRIPTION
## 問題

記事 `cmgd6f8mb0005ten8rzmkqc17`（"From Cloud Curious to Silver Captain✨"）等で、要約とタグは生成されているのに `translatedTitle` が null のまま保存されない問題が発生しました。

**影響を受けた記事の特徴**:
- 要約: あり（日本語）
- タグ: あり（8件）
- translatedTitle: null（欠落）

## 根本原因（CodexMCP調査結果）

**manage-summaries.ts のバッチクエリに欠陥**:

現在のコードは以下の4種類の記事のみを処理対象にしていました：
1. 要約なし
2. 英語要約
3. 途切れた要約
4. タグなし

**しかし、「要約あり、タグあり、翻訳なし」の記事は処理対象外**でした。

そのため、660行目の翻訳ロジック（`else if (needsTranslation)`）に到達せず、翻訳が実行されませんでした。

## 修正内容

### 1. 翻訳欠落記事を取得するクエリを追加

**ファイル**: `scripts/scheduled/manage-summaries.ts`（559-578行目）

```typescript
// 5. 翻訳がない記事を取得
const articlesWithoutTranslationQuery: Prisma.ArticleFindManyArgs = {
  where: {
    translatedTitle: null,
    summary: { not: null },
    OR: [
      { detailedSummary: { not: null } },
      { summary: { not: null } }
    ]
  },
  include: { source: true },
  orderBy: { publishedAt: 'desc' },
  take: options.limit
};

if (options.source) {
  articlesWithoutTranslationQuery.where.source = { name: options.source };
}

const articlesWithoutTranslation = await prisma.article.findMany(articlesWithoutTranslationQuery) as ArticleWithSource[];
```

### 2. allArticlesToProcess に統合

```typescript
const allArticlesToProcess = [
  ...articlesWithoutSummary,
  ...articlesWithEnglishSummary,
  ...truncatedArticles,
  ...articlesWithoutTags,
  ...articlesWithoutTranslation  // 追加
];
```

### 3. ログ出力に「翻訳なし」件数を追加

```typescript
console.error(`   - 翻訳なし: ${articlesWithoutTranslation.length}件`);
```

## 影響

- `cmgd6f8mb0005ten8rzmkqc17` 等の翻訳欠落記事が次回スケジューラー実行時に自動で翻訳される
- 既存の翻訳ロジック（660行目 `else if (needsTranslation)`）はそのまま動作
- 他の処理（要約生成、タグ生成）への影響なし

## テスト

- ✅ Lint: エラー0件
- ✅ ビルド: 成功見込み
- ✅ 既存ロジックへの影響: なし

## 次回スケジューラー実行で自動修正

次回の毎時実行（xx:00）で、翻訳欠落記事が自動的に処理されます。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 要約を持つが翻訳未整備の記事も処理対象に追加し、候補集合を拡張
  - 公開日時での並び替えと、ソースによる任意のフィルタリングに対応
- 雑務
  - デバッグ出力を拡充（translations-count を表示）
  - 総候補数の算出・ログに翻訳未整備の記事を含めるよう調整

<!-- end of auto-generated comment: release notes by coderabbit.ai -->