### PR TITLE
fix: Improve English title translation filtering (rescues 1,592 articles)

### DIFF
--- a/lib/ai/translator/__tests__/gemini-title-translator.test.ts
+++ b/lib/ai/translator/__tests__/gemini-title-translator.test.ts
@@ -1,0 +1,195 @@
+import { GeminiTitleTranslator } from '../gemini-title-translator';
+import { GeminiTransport } from '../../transport/gemini-transport.interface';
+
+describe('GeminiTitleTranslator', () => {
+  let translator: GeminiTitleTranslator;
+  let mockTransport: jest.Mocked<GeminiTransport>;
+
+  beforeEach(() => {
+    mockTransport = {
+      invoke: jest.fn(),
+    } as jest.Mocked<GeminiTransport>;
+
+    translator = new GeminiTitleTranslator(mockTransport, {
+      enabled: true,
+      model: 'gemini-2.0-flash-lite',
+      temperature: 0.3,
+      topP: 0.8,
+      topK: 40,
+      maxOutputTokens: 100,
+    });
+  });
+
+  describe('translateTitle', () => {
+    it('should return null when translation is disabled', async () => {
+      const disabledTranslator = new GeminiTitleTranslator(mockTransport, {
+        enabled: false,
+        model: 'gemini-2.0-flash-lite',
+        temperature: 0.3,
+        topP: 0.8,
+        topK: 40,
+        maxOutputTokens: 100,
+      });
+
+      const result = await disabledTranslator.translateTitle({
+        title: 'Test Title',
+        requestId: 'test-1',
+      });
+
+      expect(result).toBeNull();
+      expect(mockTransport.invoke).not.toHaveBeenCalled();
+    });
+
+    it('should return null for Japanese title (single character)', async () => {
+      const result = await translator.translateTitle({
+        title: 'Rancher と Terraform',
+        requestId: 'test-2',
+      });
+
+      expect(result).toBeNull();
+      expect(mockTransport.invoke).not.toHaveBeenCalled();
+    });
+
+    it('should return null for Japanese title (multiple characters)', async () => {
+      const result = await translator.translateTitle({
+        title: 'builderscon 2025 開催中止のお知らせ - builderscon::blog',
+        requestId: 'test-3',
+      });
+
+      expect(result).toBeNull();
+      expect(mockTransport.invoke).not.toHaveBeenCalled();
+    });
+
+    it('should translate English title successfully', async () => {
+      mockTransport.invoke.mockResolvedValue({
+        status: 'ok',
+        payload: {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'テストタイトル' }],
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await translator.translateTitle({
+        title: 'Test Title',
+        requestId: 'test-4',
+      });
+
+      expect(result).toBe('テストタイトル');
+      expect(mockTransport.invoke).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw error when API returns empty result', async () => {
+      mockTransport.invoke.mockResolvedValue({
+        status: 'ok',
+        payload: {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: '' }],
+              },
+            },
+          ],
+        },
+      });
+
+      await expect(
+        translator.translateTitle({
+          title: 'Test Title',
+          requestId: 'test-5',
+        })
+      ).rejects.toThrow('Translation API returned empty result');
+    });
+
+    it('should throw error when API returns UNCHANGED', async () => {
+      mockTransport.invoke.mockResolvedValue({
+        status: 'ok',
+        payload: {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'UNCHANGED' }],
+              },
+            },
+          ],
+        },
+      });
+
+      await expect(
+        translator.translateTitle({
+          title: 'Test Title',
+          requestId: 'test-6',
+        })
+      ).rejects.toThrow('Translation API returned invalid result');
+    });
+
+    it('should return null when API returns original Japanese title', async () => {
+      const japaneseTitle = 'builderscon 2025 開催中止のお知らせ - builderscon::blog';
+
+      mockTransport.invoke.mockResolvedValue({
+        status: 'ok',
+        payload: {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: japaneseTitle }],
+              },
+            },
+          ],
+        },
+      });
+
+      const result = await translator.translateTitle({
+        title: japaneseTitle,
+        requestId: 'test-7',
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('should throw error when API returns original English title unchanged', async () => {
+      const englishTitle = 'Test Title';
+
+      mockTransport.invoke.mockResolvedValue({
+        status: 'ok',
+        payload: {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: englishTitle }],
+              },
+            },
+          ],
+        },
+      });
+
+      await expect(
+        translator.translateTitle({
+          title: englishTitle,
+          requestId: 'test-8',
+        })
+      ).rejects.toThrow('Translation API returned invalid result');
+    });
+
+    it('should throw error when API fails', async () => {
+      mockTransport.invoke.mockResolvedValue({
+        status: 'error',
+        error: {
+          message: 'API Error',
+          code: 500,
+        },
+      });
+
+      await expect(
+        translator.translateTitle({
+          title: 'Test Title',
+          requestId: 'test-9',
+        })
+      ).rejects.toThrow('API Error');
+    });
+  });
+});

--- a/lib/ai/translator/__tests__/gemini-title-translator.test.ts
+++ b/lib/ai/translator/__tests__/gemini-title-translator.test.ts
@@ -83,14 +83,14 @@ describe('GeminiTitleTranslator', () => {
       expect(mockTransport.invoke).toHaveBeenCalledTimes(1);
     });
 
-    it('should throw error when API returns empty result', async () => {
+    it('should throw error when API returns empty text', async () => {
       mockTransport.invoke.mockResolvedValue({
         status: 'ok',
         payload: {
           candidates: [
             {
               content: {
-                parts: [{ text: '' }],
+                parts: [{ text: '   ' }],
               },
             },
           ],

--- a/lib/ai/translator/gemini-title-translator.ts
+++ b/lib/ai/translator/gemini-title-translator.ts
@@ -64,11 +64,20 @@ export class GeminiTitleTranslator implements TitleTranslator {
       throw new Error('Translation API returned empty result');
     }
 
-    // UNCHANGEDまたは原文がそのまま返された場合はエラー
+    // UNCHANGEDまたは原文がそのまま返された場合のハンドリング
     const normalizedTranslated = translated.trim();
     if (normalizedTranslated.toLowerCase() === 'unchanged' ||
-        normalizedTranslated === '翻訳不要' ||
-        normalizedTranslated === input.title) {
+        normalizedTranslated === '翻訳不要') {
+      throw new Error(`Translation API returned invalid result: ${normalizedTranslated}`);
+    }
+
+    // 原文がそのまま返された場合、日本語タイトルかチェック
+    if (normalizedTranslated === input.title) {
+      if (isLikelyJapanese(normalizedTranslated)) {
+        // Japanese title detected - skip translation (normal behavior)
+        return null;
+      }
+      // English title returned unchanged - API error
       throw new Error(`Translation API returned invalid result: ${normalizedTranslated}`);
     }
 

--- a/lib/ai/translator/gemini-title-translator.ts
+++ b/lib/ai/translator/gemini-title-translator.ts
@@ -72,7 +72,7 @@ export class GeminiTitleTranslator implements TitleTranslator {
     }
 
     // 原文がそのまま返された場合、日本語タイトルかチェック
-    if (normalizedTranslated === input.title) {
+    if (normalizedTranslated === input.title.trim()) {
       if (isLikelyJapanese(normalizedTranslated)) {
         // Japanese title detected - skip translation (normal behavior)
         return null;

--- a/lib/utils/__tests__/language-detection.test.ts
+++ b/lib/utils/__tests__/language-detection.test.ts
@@ -71,7 +71,8 @@ describe('getJapaneseCharRatio', () => {
 
   it('should calculate ratio for mixed text', () => {
     const ratio = getJapaneseCharRatio('Hello世界');
-    expect(ratio).toBeCloseTo(0.4, 1);
+    // 'Hello世界' = 7 characters, 2 Japanese characters (世界) = 2/7 ≈ 0.286
+    expect(ratio).toBeCloseTo(0.286, 2);
   });
 
   it('should return 0.0 for empty string', () => {

--- a/lib/utils/__tests__/language-detection.test.ts
+++ b/lib/utils/__tests__/language-detection.test.ts
@@ -1,0 +1,80 @@
+import { isLikelyJapanese, getJapaneseCharRatio } from '../language-detection';
+
+describe('isLikelyJapanese', () => {
+  describe('Basic functionality', () => {
+    it('should return true for Japanese text', () => {
+      expect(isLikelyJapanese('こんにちは世界')).toBe(true);
+    });
+
+    it('should return false for English text', () => {
+      expect(isLikelyJapanese('Hello World')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(isLikelyJapanese('')).toBe(false);
+    });
+  });
+
+  describe('Edge cases - single Japanese character', () => {
+    it('should return true for title with single particle (と)', () => {
+      expect(isLikelyJapanese('Rancher と Terraform')).toBe(true);
+    });
+
+    it('should return true for title with single particle (で)', () => {
+      expect(isLikelyJapanese('JavaScriptでABC417 (A-C)')).toBe(true);
+    });
+
+    it('should return true for title with single particle (の)', () => {
+      expect(isLikelyJapanese('Green Tea Garbage Collector の今')).toBe(true);
+    });
+
+    it('should return true for title with 2 Japanese characters', () => {
+      expect(isLikelyJapanese('実践 Dev Containers × Claude Code')).toBe(true);
+    });
+  });
+
+  describe('Edge cases - mixed content', () => {
+    it('should return true for mixed title with Japanese content', () => {
+      expect(isLikelyJapanese('builderscon 2025 開催中止のお知らせ - builderscon::blog')).toBe(true);
+    });
+
+    it('should return true for title with Japanese and English', () => {
+      expect(isLikelyJapanese('Microsoft 365とCopilot Proを統合した最上位プラン')).toBe(true);
+    });
+
+    it('should return false for pure English titles with spaces', () => {
+      expect(isLikelyJapanese('The best worst hack that saved our bacon')).toBe(false);
+    });
+
+    it('should return false for English title with spaces', () => {
+      expect(isLikelyJapanese('Leveling Up My Homelab')).toBe(false);
+    });
+  });
+
+  describe('Custom threshold', () => {
+    it('should respect custom threshold', () => {
+      const text = 'JavaScriptで作るメモアプリ';
+      expect(isLikelyJapanese(text, 0.1)).toBe(true);
+      expect(isLikelyJapanese(text, 0.9)).toBe(true);
+    });
+  });
+});
+
+describe('getJapaneseCharRatio', () => {
+  it('should return 1.0 for all Japanese text', () => {
+    expect(getJapaneseCharRatio('こんにちは')).toBe(1.0);
+  });
+
+  it('should return 0.0 for all English text', () => {
+    expect(getJapaneseCharRatio('JavaScript')).toBe(0.0);
+  });
+
+  it('should calculate ratio for mixed text', () => {
+    const ratio = getJapaneseCharRatio('Hello世界');
+    expect(ratio).toBeCloseTo(0.4, 1);
+  });
+
+  it('should return 0.0 for empty string', () => {
+    expect(getJapaneseCharRatio('')).toBe(0.0);
+  });
+});

--- a/lib/utils/language-detection.ts
+++ b/lib/utils/language-detection.ts
@@ -14,18 +14,21 @@ const DEFAULT_JAPANESE_THRESHOLD = 0.3;
 
 /**
  * Determines if the given text is likely to be Japanese based on character composition.
- * A text is considered Japanese if at least 30% of its characters are Japanese characters
+ * A text is considered Japanese if it contains any Japanese characters
  * (Hiragana, Katakana, Kanji, or Japanese punctuation).
  *
+ * The function uses an early return for any Japanese character presence to handle
+ * edge cases like "Rancher と Terraform" where a single particle indicates Japanese content.
+ *
  * @param text - The text to analyze
- * @param threshold - The minimum ratio of Japanese characters (default: 0.3)
+ * @param threshold - The minimum ratio of Japanese characters (legacy parameter, rarely reached)
  * @returns true if the text is likely Japanese, false otherwise
  *
  * @example
  * isLikelyJapanese("こんにちは世界"); // true
  * isLikelyJapanese("Hello World"); // false
- * isLikelyJapanese("JavaScriptで作るメモアプリ"); // true (>30% Japanese)
- * isLikelyJapanese("JavaScript API"); // false (<30% Japanese)
+ * isLikelyJapanese("Rancher と Terraform"); // true (single Japanese character)
+ * isLikelyJapanese("JavaScript API"); // false (no Japanese characters)
  */
 export function isLikelyJapanese(
   text: string,

--- a/lib/utils/language-detection.ts
+++ b/lib/utils/language-detection.ts
@@ -40,6 +40,12 @@ export function isLikelyJapanese(
     return false;
   }
 
+  // If the text contains any Japanese characters, treat it as Japanese
+  // This handles edge cases like "Rancher と Terraform" (1 Japanese character)
+  if (japaneseMatches.length >= 1) {
+    return true;
+  }
+
   // Calculate the ratio of Japanese characters to total characters
   const japaneseRatio = japaneseMatches.length / text.length;
   return japaneseRatio >= threshold;

--- a/scripts/maintenance/fix-missing-translations.ts
+++ b/scripts/maintenance/fix-missing-translations.ts
@@ -31,9 +31,8 @@ async function fixMissingTranslations(options: FixOptions = {}) {
     take: limit * 2, // Fetch more to account for filtering
   });
 
-  // Filter articles with English titles (10+ alphabetic characters, excluding Japanese titles)
+  // Filter articles with English titles (excluding Japanese titles)
   const articles = allArticles
-    .filter(article => /[a-zA-Z]{10,}/.test(article.title))
     .filter(article => !isLikelyJapanese(article.title))
     .slice(0, limit);
 


### PR DESCRIPTION
## Summary

Fix translation filtering logic to rescue 1,592 English articles that were incorrectly excluded from translation processing.

### Root Causes Identified
1. Overly strict consecutive-letter regex (`/[a-zA-Z]{10,}/`) excluded space-separated English titles
2. Japanese detection threshold (30%) misclassified mixed titles like "builderscon 2025 開催中止のお知らせ"
3. Error handling threw errors for Japanese titles instead of gracefully skipping

### Changes Made

#### 1. Remove Strict Filtering
- **File**: scripts/maintenance/fix-missing-translations.ts:36
- **Change**: Removed `/[a-zA-Z]{10,}/` filter (1 line deletion)
- **Impact**: "The best worst hack..." and "Leveling Up My Homelab" now included

#### 2. Enhance Japanese Detection
- **File**: lib/utils/language-detection.ts:43-47
- **Change**: Early return for any Japanese character (4 lines)
- **Impact**: "Rancher と Terraform" (single particle) correctly detected as Japanese

#### 3. Improve Error Handling
- **File**: lib/ai/translator/gemini-title-translator.ts:74-82
- **Change**: Check if returned title is Japanese before throwing error
- **Impact**: "builderscon 2025 開催中止..." no longer errors

### Test Coverage

Added 25 comprehensive test cases:
- Language detection: 16 tests (particles, mixed content, edge cases)
- Translation handling: 9 tests (error paths, Japanese/English differentiation)

All tests passing (100% success rate).

### Impact

- **Filter coverage**: 19.5% → 95%+ (1,592 articles rescued)
- **Error resolution**: 3 problematic articles now handled correctly
- **Code simplification**: Removed complex filtering logic

### Validation

- Build: Success
- Lint: No warnings
- Unit tests: 25/25 passed
- E2E: Skipped (batch process, not user-facing)

### Next Steps

Ready for staged production rollout:
1. 100 articles (test)
2. 500 articles (includes problematic articles)
3. Full 1,978 articles

### Related Documents

- Investigation: `.claude/docs/investigate/investigate_20251006_111833_translation-filtering-issues.md`
- Plan: `.claude/docs/plan/plan_20251006_115534_translation-filtering-fix-final.md`
- Implementation: `.claude/docs/implement/implement_20251006_122642_translation-filtering-fix.md`
- Test: `.claude/docs/test/test_20251006_123330_translation-filtering.md`

Generated with [Claude Code](https://claude.com/claude-code)