### PR TITLE
Potential fix for code scanning alert no. 76: Replacement of a substring with itself

### DIFF
--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -39,7 +39,7 @@ export function formatDateWithTime(date: Date | string): string {
   });
 
   // "2025/10/03 14:06" の形式に整形
-  return formatted.replace(/\//g, '/').replace(/\s+/g, ' ');
+  return formatted.replace(/\s+/g, ' ');
 }
 
 export function parseRSSDate(dateString: string): Date {


### PR DESCRIPTION
Potential fix for [https://github.com/pawafulu7/techtrend/security/code-scanning/76](https://github.com/pawafulu7/techtrend/security/code-scanning/76)

To fix the problem, remove the redundant `.replace(/\//g, '/')` from line 42. This operation is a no-op and does nothing—it leaves the string unchanged. The only effective transformation should be the whitespace normalization via `.replace(/\s+/g, ' ')`. Removing the redundant replace does not change the existing functionality, as it never affected the output.

Change only line 42 of `lib/utils/date.ts`, deleting the unnecessary `.replace(/\//g, '/')`, so that only the whitespace normalization remains.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- リファクタリング
  - 日付と時刻の表示整形ロジックを簡素化し、冗長な処理を削除しました。
  - 表示結果や動作に変更はなく、軽微なパフォーマンス向上と可読性の改善が見込まれます。
  - ユーザーへの影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->