### PR TITLE
fix: upgrade nodemailer to v7.0.7 to resolve security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "next-themes": "^0.4.6",
         "node-cron": "^4.2.1",
         "node-fetch": "^3.3.2",
-        "nodemailer": "^6.10.1",
+        "nodemailer": "^7.0.7",
         "pino": "^9.9.5",
         "pino-pretty": "^13.1.1",
         "react": "19.1.0",
@@ -12350,9 +12350,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.9.tgz",
+      "integrity": "sha512-9/Qm0qXIByEP8lEV2qOqcAW7bRpL8CR9jcTwk3NBnHJNmP9fIJ86g2fgmIXqHY+nj55ZEMwWqYAT2QTDpRUYiQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "next-themes": "^0.4.6",
     "node-cron": "^4.2.1",
     "node-fetch": "^3.3.2",
-    "nodemailer": "^6.10.1",
+    "nodemailer": "^7.0.7",
     "pino": "^9.9.5",
     "pino-pretty": "^13.1.1",
     "react": "19.1.0",
@@ -230,5 +230,8 @@
     "undici": "^7.16.0",
     "web-streams-polyfill": "^4.2.0",
     "whatwg-fetch": "^3.6.20"
+  },
+  "overrides": {
+    "nodemailer": "^7.0.7"
   }
 }


### PR DESCRIPTION
## Summary

Upgrade nodemailer from v6.10.1 to v7.0.7 to resolve Dependabot alert #7 (GHSA-mm7p-fcc7-pg87).

## Security Issue

- **Vulnerability**: GHSA-mm7p-fcc7-pg87 (Medium severity, CVSS 5.5)
- **Issue**: Email address parser incorrectly handles quoted local-parts containing @
- **Impact**: Potential email misrouting to unintended domains
- **Fix**: Upgrade to nodemailer >= 7.0.7

## Changes

- Update nodemailer dependency from ^6.10.1 to ^7.0.7
- Add npm overrides to force v7.0.7 across all dependencies
- All transitive dependencies now use nodemailer@7.0.9

## Technical Details

### Dependency Resolution
```
techtrend@0.1.0
├─┬ @auth/prisma-adapter → nodemailer@7.0.9
├─┬ next-auth → nodemailer@7.0.9
└── nodemailer@7.0.9
```

### API Compatibility
- createTransport(): Full compatibility
- sendMail(): Full compatibility  
- getTestMessageUrl(): Full compatibility

### Code Changes
- No code modifications required
- All existing implementations work as-is with v7

## Test Results

### Build & Lint
- Build: PASS (30.8s)
- Lint: PASS (0 errors, 0 warnings)

### Unit & Integration Tests
- Test Suites: 110 passed
- Tests: 1598 passed, 110 skipped
- Time: 211.1s

### E2E Tests
- Tests: 335 passed, 61 skipped
- Time: 6.1 minutes
- Browsers: Chromium, Firefox, WebKit (all PASS)

### Security
- npm audit: 0 vulnerabilities
- Dependabot alert #7: Will be resolved

## Documentation

- Investigation: .claude/docs/investigate/investigate_20251010_113338_dependabot-7.md
- Implementation Plan: .claude/docs/plan/plan_20251010_113802_nodemailer-upgrade.md
- Implementation Report: .claude/docs/implement/implement_20251010_114413_nodemailer-upgrade.md
- Test Report: .claude/docs/test/test_20251010_122741_nodemailer-upgrade.md

## Risk Assessment

- Technical Risk: Low (API fully compatible)
- Business Risk: None (internal package update only)
- Rollback: Easy (single commit revert)

## References

- [GHSA-mm7p-fcc7-pg87](https://github.com/nodemailer/nodemailer/security/advisories/GHSA-mm7p-fcc7-pg87)
- [Nodemailer v7.0.7 Release](https://github.com/nodemailer/nodemailer/commit/1150d99fba77280df2cfb1885c43df23109a8626)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - 依存関係: nodemailer を ^6.10.1 から ^7.0.7 に更新
  - 依存固定: overrides に nodemailer (^7.0.7) を追加
  - ユーザー向けの機能・UIの変更はありません

<!-- end of auto-generated comment: release notes by coderabbit.ai -->