### PR TITLE
fix: support Grafana Cloud OTEL header format

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -32,10 +32,14 @@ const parseHeaders = () => {
   try {
     return JSON.parse(raw) as Record<string, string>;
   } catch (error) {
-    console.warn(logNamespace, 'Failed to parse OTEL_EXPORTER_OTLP_HEADERS; ignoring value', {
-      error,
+    const headers: Record<string, string> = {};
+    raw.split(',').forEach((pair) => {
+      const [key, ...valueParts] = pair.split('=');
+      if (key && valueParts.length > 0) {
+        headers[key.trim()] = valueParts.join('=').trim();
+      }
     });
-    return undefined;
+    return Object.keys(headers).length > 0 ? headers : undefined;
   }
 };
 


### PR DESCRIPTION
## Summary

Fix `OTEL_EXPORTER_OTLP_HEADERS` parsing to support Grafana Cloud's `key=value` format.

## Problem

Grafana Cloud provides headers in `key=value` format:
```
Authorization=Basic MTowNz...
```

But `instrumentation.ts` only supported JSON format, causing parse errors:
```
[otel] Failed to parse OTEL_EXPORTER_OTLP_HEADERS; ignoring value
SyntaxError: Unexpected token 'A', "Authorizat"... is not valid JSON
```

## Solution

Update `parseHeaders()` to support both formats:
- **JSON format**: `{"Authorization":"Bearer token"}` (New Relic, manual config)
- **key=value format**: `Authorization=Bearer token` (Grafana Cloud)

## Changes

- `instrumentation.ts`: Enhance `parseHeaders()` with fallback to key=value parsing

## Testing

**Local**:
```bash
# Test with Grafana Cloud headers
OTEL_EXPORTER_OTLP_HEADERS="Authorization=Basic ..." npm run dev
# No parse errors in console
```

**Production**:
1. Set Grafana Cloud env vars in Vercel
2. Deploy
3. Verify traces in Grafana Cloud

## Related

- Fixes issue discovered during Phase 1.5 (Grafana Cloud integration)
- Enables Vercel free plan users to use Grafana Cloud (no Marketplace Pro plan required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ヘッダー設定の解釈を改善。JSON解析に失敗した場合でも、カンマ区切りのkey=value形式を自動読み取りし、可能な範囲で有効なヘッダーを適用します。不要な警告ログが減り、設定の互換性と安定性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->