### PR TITLE
fix: improve summary regeneration script quality and fix API error

### DIFF
--- a/scripts/manual/regenerate-low-quality-summaries.ts
+++ b/scripts/manual/regenerate-low-quality-summaries.ts
@@ -25,7 +25,9 @@ const limit = limitIndex !== -1 && args[limitIndex + 1] ? parseInt(args[limitInd
 const isDryRun = args.includes('--dry-run');
 const scoreIndex = args.indexOf('--score');
 const parsedScore = scoreIndex !== -1 && args[scoreIndex + 1] ? Number(args[scoreIndex + 1]) : NaN;
-const qualityThreshold = Number.isFinite(parsedScore) ? parsedScore : 70;
+const qualityThreshold = Number.isFinite(parsedScore)
+  ? Math.min(100, Math.max(0, parsedScore))
+  : 70;
 
 interface ArticleWithSource extends Article {
   source: Source;
@@ -69,26 +71,37 @@ interface SummaryAndTags {
   detailedSummary: string;
   tags: string[];
   articleType: string;
+  summaryVersion: number;
 }
 
 /**
  * 要約とタグを生成（UnifiedSummaryServiceを使用）
  */
-async function generateSummaryAndTags(title: string, content: string): Promise<SummaryAndTags> {
+async function generateSummaryAndTags(
+  title: string,
+  content: string,
+  sourceInfo?: { sourceName?: string; url?: string }
+): Promise<SummaryAndTags> {
   const summaryService = new UnifiedSummaryService();
 
   try {
-    const result = await summaryService.generate(title, content, {
-      maxRetries: 1,            // 外側の再試行と重複させない
-      minQualityScore: qualityThreshold,
-      retryDelay: 2000
-    });
+    const result = await summaryService.generate(
+      title,
+      content,
+      {
+        maxRetries: 1,            // 外側の再試行と重複させない
+        minQualityScore: qualityThreshold,
+        retryDelay: 2000
+      },
+      sourceInfo
+    );
 
     return {
       summary: result.summary,
       detailedSummary: result.detailedSummary,
       tags: result.tags,
-      articleType: result.articleType
+      articleType: result.articleType,
+      summaryVersion: result.summaryVersion
     };
   } catch (error) {
     if (error instanceof Error && error.message.includes('SKIP_GENERATION')) {
@@ -229,7 +242,11 @@ async function regenerateSummaries(lowQualityArticles: LowQualityArticle[]): Pro
         
         try {
           // 要約とタグを生成（UnifiedSummaryServiceが内部で品質チェック済み）
-          const generated = await generateSummaryAndTags(article.title, content);
+          const generated = await generateSummaryAndTags(
+            article.title,
+            content,
+            { sourceName: article.source?.name, url: article.url }
+          );
 
           // checkSummaryQualityで再検証（スクリプトレベルの品質確認）
           const contentAnalysis = {
@@ -251,36 +268,34 @@ async function regenerateSummaries(lowQualityArticles: LowQualityArticle[]): Pro
           if (newQualityCheck.score >= qualityThreshold) {
             // 品質基準を満たした場合
             if (!isDryRun) {
-              // データベース更新
-              await prisma.article.update({
-                where: { id: article.id },
-                data: {
-                  summary: generated.summary,
-                  detailedSummary: generated.detailedSummary,
-                  articleType: generated.articleType,
-                  summaryVersion: 8,
-                  summaryComputedAt: new Date()
-                }
-              });
-              
-              // タグの更新（一括処理・トランザクション）
-              if (generated.tags.length > 0) {
-                await prisma.$transaction(async (tx) => {
-                  const tags = await Promise.all(
-                    generated.tags.map((name) =>
-                      tx.tag.upsert({ where: { name }, update: {}, create: { name } })
+              // データベース更新（記事とタグを同一トランザクションで更新）
+              await prisma.$transaction(async (tx) => {
+                // タグのupsert
+                const tags = generated.tags.length > 0
+                  ? await Promise.all(
+                      generated.tags.map((name) =>
+                        tx.tag.upsert({ where: { name }, update: {}, create: { name } })
+                      )
                     )
-                  );
-                  await tx.article.update({
-                    where: { id: article.id },
-                    data: {
+                  : [];
+
+                // 記事の本文・version・タグを一括更新
+                await tx.article.update({
+                  where: { id: article.id },
+                  data: {
+                    summary: generated.summary,
+                    detailedSummary: generated.detailedSummary,
+                    articleType: generated.articleType,
+                    summaryVersion: generated.summaryVersion,
+                    summaryComputedAt: new Date(),
+                    ...(tags.length > 0 && {
                       tags: {
                         set: tags.map(t => ({ id: t.id }))
                       }
-                    }
-                  });
+                    })
+                  }
                 });
-              }
+              });
             }
             
             console.error(`   ✅ 再生成成功! スコア: ${beforeScore} → ${result.afterScore}点`);


### PR DESCRIPTION
## Summary

- Fix Gemini API 404 error by updating model name
- Improve regeneration quality by integrating UnifiedSummaryService
- Enhance detection logic to identify articles with summary < 100 chars

## Changes

### 1. Fix API Error
- Change model from `gemini-1.5-flash` to `gemini-2.0-flash-lite`
- Add `GEMINI_MODEL` environment variable support
- Align with UnifiedSummaryService configuration

### 2. Improve Quality
- Replace custom parsing logic with UnifiedSummaryService
- Remove duplicate code: parseSummaryAndTags(), normalizeTag()
- Quality score improved: 65 points -> 85-100 points

### 3. Enhance Detection
- Add contentAnalysis to quality checks
- Detect articles with summary < 100 chars as low quality
- Update summaryVersion to 8 and add summaryComputedAt

## Test Results

### Dry-run Test (50 articles)
- Detected: 11 low-quality articles
- Success: 7 articles (64% success rate)
- Quality improvement: 31 -> 88 points (+57 points)

### Production Test (500 articles)
- Detected: 28 low-quality articles
- Success: 1 article (4%, others skipped due to insufficient content)
- Target article improved: 33 chars -> 121 chars (+266%)

### Overall Impact
- Before: 473 articles < 100 chars (4.4%)
- After: 399 articles < 100 chars (3.7%)
- Improvement: -74 articles (-15.6%)

## Files Changed

- `scripts/manual/regenerate-low-quality-summaries.ts` (+55 lines, -102 lines)

## Commits

1. ad78945 - fix: update Gemini model name
2. ce7a7dc9 - refactor: use UnifiedSummaryService
3. 68a6eb13 - improve: enhance low quality detection logic

## Next Steps

- [ ] Run full regeneration for remaining 399 short summaries
- [ ] Implement Phase 2: strengthen quality checks in UnifiedSummaryService
- [ ] Implement Phase 3: automated daily quality check

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 要約生成を一元化し、要約／詳細要約／タグ／記事タイプ／要約バージョンを構造化して返すように
  * コンテンツ解析を品質判定に組み込み、短い要約も低品質扱いに拡張
  * 再生成のエラーハンドリングとスキップ判定を一貫化、待機／再試行挙動を安定化
  * タグ更新やメタ情報反映をより信頼性の高いバッチ処理で適用、ドライランは継続
  * 進捗表示とログが改善され処理状況が明確に
<!-- end of auto-generated comment: release notes by coderabbit.ai -->