### PR TITLE
fix(e2e): resolve flaky URL parameter tests

### DIFF
--- a/app/components/common/filters.tsx
+++ b/app/components/common/filters.tsx
@@ -209,8 +209,10 @@ export function Filters({ sources, initialSourceIds }: FiltersProps) {
     // 即座に状態を更新（UIの反応性を保つ）
     setSelectedSources(sourceIds);
 
-    // URL構築（即座に実行してアンマウント時のキャンセルを防ぐ）
-    const params = new URLSearchParams(searchParams.toString());
+    // URL構築: Use live location to avoid stale searchParams snapshot
+    const params = typeof window !== 'undefined'
+      ? new URLSearchParams(window.location.search)
+      : new URLSearchParams(searchParams.toString());
 
     // Remove old params
     params.delete('sourceId');

--- a/app/components/common/search-box.tsx
+++ b/app/components/common/search-box.tsx
@@ -71,14 +71,28 @@ export function SearchBox() {
     }
   }, [debouncedQuery, isComposing, handleSearch, searchParams]);
 
-  const handleClear = () => {
+  const handleClear = async () => {
     isInternalUpdate.current = true;
     setQuery('');
-    
+
     const params = new URLSearchParams(searchParams.toString());
     params.delete('search');
     params.delete('page');
-    router.push(`/?${params.toString()}`);
+
+    // Canonical URL builder: push "/" when no params remain
+    const nextUrl = params.toString() ? `/?${params.toString()}` : '/';
+    router.push(nextUrl);
+
+    // Update cookie with null to clear stored search
+    try {
+      await fetch('/api/filter-preferences', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ search: null }),
+      });
+    } catch {
+      // Silent fail
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary

Fix two flaky E2E tests caused by stale searchParams snapshots and empty query string handling in Next.js 15.

## Issues Fixed

### 1. Search Clear Regression (search-clear.spec.ts)
**Error**: `expect(page).not.toHaveURL(/search=/)`
**Root Cause**: `router.push('/?')` in Next.js 15 keeps previous query string
**Fix**: 
- Use canonical URL builder: `/?${params}` or `/`
- Send `search: null` to cookie API to clear stored value

### 2. Source Filter Race Condition (source-filter-cookie.spec.ts)
**Error**: `[waitForUrlParam] Timeout exceeded (15000ms)`
**Root Cause**: searchParams hook holds stale snapshot during rapid operations
**Fix**:
- Use `window.location.search` for live URL state
- Avoid React cache during rapid filter changes

## Changes

- `app/components/common/search-box.tsx`: Canonical URL builder + cookie null
- `app/components/common/filters.tsx`: Live location instead of cached searchParams

## Test Results (Local)

- search-clear.spec.ts: 2/3 passed (1 flaky Firefox)
- source-filter-cookie.spec.ts: 11/12 passed (1 failed Firefox)

**Note**: Chromium tests passed. Firefox issues may be browser-specific timing.

## Root Cause

React `useSearchParams()` hook caches URL state, causing race conditions when:
1. `router.push()` executes before next render
2. Rapid operations (select all → deselect all)
3. Empty query strings treated as current location

## Related

- #168: filters: execute router.push immediately
- #167: e2e: apply SPA navigation pattern

Generated with Claude Code (https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 検索フィルター機能でURLパラメータの更新がブラウザの現在地をより正確に反映するように改善しました
* 検索条件をクリアする際の動作が最適化され、設定がより確実に削除されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->