### PR TITLE
fix(rag): preserve original query in abbreviation expansion

### DIFF
--- a/__tests__/lib/rag/abbreviations.test.ts
+++ b/__tests__/lib/rag/abbreviations.test.ts
@@ -46,24 +46,24 @@ describe('expandQueryWithDictionary', () => {
   });
 
   describe('Token match (expand individual tokens)', () => {
-    it('should expand "CTO role"', () => {
-      expect(expandQueryWithDictionary('CTO role')).toBe('Chief Technology Officer role');
+    it('should expand "CTO role" and preserve original', () => {
+      expect(expandQueryWithDictionary('CTO role')).toBe('CTO Chief Technology Officer role');
     });
 
-    it('should expand "SRE practices"', () => {
-      expect(expandQueryWithDictionary('SRE practices')).toBe('Site Reliability Engineering practices');
+    it('should expand "SRE practices" and preserve original', () => {
+      expect(expandQueryWithDictionary('SRE practices')).toBe('SRE Site Reliability Engineering practices');
     });
 
-    it('should expand "API design patterns"', () => {
-      expect(expandQueryWithDictionary('API design patterns')).toBe('Application Programming Interface design patterns');
+    it('should expand "API design patterns" and preserve original', () => {
+      expect(expandQueryWithDictionary('API design patterns')).toBe('API Application Programming Interface design patterns');
     });
 
-    it('should expand multiple abbreviations', () => {
-      expect(expandQueryWithDictionary('SRE and DevOps')).toBe('Site Reliability Engineering and Development and Operations');
+    it('should expand multiple abbreviations and preserve originals', () => {
+      expect(expandQueryWithDictionary('SRE and DevOps')).toBe('SRE Site Reliability Engineering and DevOps Development and Operations');
     });
 
-    it('should preserve case for non-abbreviations', () => {
-      expect(expandQueryWithDictionary('CTO responsibilities')).toBe('Chief Technology Officer responsibilities');
+    it('should preserve case and expand "CTO responsibilities"', () => {
+      expect(expandQueryWithDictionary('CTO responsibilities')).toBe('CTO Chief Technology Officer responsibilities');
     });
   });
 

--- a/lib/rag/abbreviations.ts
+++ b/lib/rag/abbreviations.ts
@@ -171,7 +171,10 @@ export function expandQueryWithDictionary(query: string): string {
     const expandedTokens = tokens.map(token => {
       // Preserve original case for non-abbreviations
       const upper = token.toUpperCase();
-      return TECH_ABBREVIATIONS[upper] || token;
+      const expansion = TECH_ABBREVIATIONS[upper];
+
+      // Preserve original + expansion for better matching
+      return expansion ? `${token} ${expansion}` : token;
     });
 
     // Only use expansion if at least one token was expanded


### PR DESCRIPTION
## Summary
Critical fix for AI search accuracy regression. Preserves original abbreviation when expanding queries.

## Problem
- "CTO 役割" was expanded to "Chief Technology Officer 役割"
- Original "CTO" term was lost during expansion
- Articles containing "CTO" had low similarity scores with expanded query
- Result: **0 results for abbreviation-based queries**

## Root Cause (CodexMCP Analysis)
Token replacement in `expandQueryWithDictionary()` was discarding the original abbreviation, causing semantic mismatch with article content that uses the abbreviation.

## Solution
Preserve both original and expanded terms:
- Before: "CTO 役割" → "Chief Technology Officer 役割"
- After: "CTO 役割" → "**CTO** Chief Technology Officer 役割"

This allows semantic matching with both:
- Articles using "CTO" (original term)
- Articles using "Chief Technology Officer" (expanded term)

## Changes
- `lib/rag/abbreviations.ts`: Preserve original in token expansion
  - Change: `${token} ${expansion}` instead of just `expansion`
- `__tests__/lib/rag/abbreviations.test.ts`: Update expected values

## Test Plan
- [x] All 27 tests passing
- [x] Build successful
- [x] Lint passing
- [x] Backward compatible (no API changes)

## Impact
- Fixes: 0-result issue for abbreviation queries
- Improves: Semantic matching for mixed-term queries
- Maintains: Benefits of query expansion

## Related
- Original implementation: PR #177
- CodexMCP root cause analysis

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- クエリ展開機能が改善されました。検索クエリ内の略語が検出された場合、元のトークンを保持したままその後に展開形を追加するように動作が変更されました。ユーザーは検索時により完全で正確な情報を得られるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->