### PR TITLE
fix(content): backfill + self-healing for null articles

### DIFF
--- a/scripts/maintenance/re-enrich-publickey-nulls.ts
+++ b/scripts/maintenance/re-enrich-publickey-nulls.ts
@@ -58,8 +58,13 @@ interface Options {
 // 進捗を読み込み
 function loadProgress(): Progress {
   if (fs.existsSync(PROGRESS_FILE)) {
-    const data = fs.readFileSync(PROGRESS_FILE, 'utf-8');
-    return JSON.parse(data);
+    try {
+      const data = fs.readFileSync(PROGRESS_FILE, 'utf-8');
+      return JSON.parse(data);
+    } catch (error) {
+      console.error(`⚠️ 進捗ファイルの読み込みに失敗しました: ${error instanceof Error ? error.message : String(error)}`);
+      console.error('新しい進捗で開始します');
+    }
   }
   return {
     processedIds: [],
@@ -135,6 +140,8 @@ async function enrichWithRetry(
   return null;
 }
 
+let currentProgress: Progress | null = null;
+
 async function main() {
   const options = parseArgs();
 
@@ -153,7 +160,7 @@ async function main() {
   console.error('');
 
   const factory = new ContentEnricherFactory();
-  const progress = loadProgress();
+  const progress = currentProgress = loadProgress();
   const processedIdsSet = new Set(progress.processedIds);
 
   // Publickey sourceを取得
@@ -193,14 +200,22 @@ async function main() {
     return;
   }
 
-  // stats.total を初回のみ設定、2回目以降は再計算
-  if (progress.stats.processed === 0) {
-    progress.stats.total = articles.length;
-  } else {
-    progress.stats.total = progress.stats.processed + articles.length;
+  // stats.total を初回のみDB問い合わせで設定（真の総数を取得）
+  if (progress.stats.total === 0) {
+    const totalCount = await prisma.article.count({
+      where: {
+        sourceId: publickeySource.id,
+        OR: [
+          { content: null },
+          { content: '' },
+        ],
+      },
+    });
+    progress.stats.total = totalCount;
   }
 
-  console.error(`対象記事数: ${articles.length}件\n`);
+  console.error(`対象記事数（今回）: ${articles.length}件`);
+  console.error(`対象記事数（全体）: ${progress.stats.total}件\n`);
 
   let batchCount = 0;
 
@@ -221,7 +236,8 @@ async function main() {
             where: { id: article.id },
             data: {
               content: enriched.content,
-              thumbnail: enriched.thumbnail || article.thumbnail,
+              thumbnail: enriched.thumbnail ?? article.thumbnail,
+              contentUpdatedAt: new Date(),
               updatedAt: new Date(),
             },
           });
@@ -309,6 +325,10 @@ async function main() {
 // SIGINT handling
 process.on('SIGINT', () => {
   console.error('\n\nReceived SIGINT, saving progress...');
+  if (currentProgress) {
+    saveProgress(currentProgress);
+    console.error('Progress saved successfully');
+  }
   process.exit(0);
 });
 

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -192,7 +192,8 @@ async function processSource({
 
         if (existing) {
           // content=null/empty の場合は更新を許可（全ソース共通の自己修復メカニズム）
-          if (!existing.content || existing.content.length === 0) {
+          if ((!existing.content || existing.content.length === 0) &&
+              article.content && article.content.length > 0) {
             await prisma.article.update({
               where: { id: existing.id },
               data: {


### PR DESCRIPTION
## Summary
- Fix 54 Publickey articles with null content (50% of corpus)
- Add backfill script for data preservation (vs deletion)
- Implement self-healing mechanism in scheduler for all sources

## Problem
Investigation revealed 54 Publickey articles stuck with `content=null` due to:
1. RSS content occasionally missing (0 chars)
2. Fetcher enrichment logic added in c476d890 (working correctly)
3. Scheduler duplicate check skips existing URLs unconditionally, treating URL presence as success even when content is null
4. Result: frozen legacy data, existing articles with null content never reprocessed

Root cause: `scripts/scheduled/collect-feeds.ts:186-193` bails on first URL match, even when content is null.

## Implementation Details

### Phase 1: Backfill Script (Data Preservation)
**File**: `scripts/maintenance/re-enrich-publickey-nulls.ts` (new, 326 lines)

**Features**:
- Progress persistence with resumable processing (Set for O(1) lookup)
- Retry logic with exponential backoff (3 attempts, network errors only)
- CLI options: `--dry-run`, `--delay-ms`, `--batch-sleep-ms`, `--limit`
- Rate limiting: 2s between articles + 10s batch pause (RSS throttling)
- Failed articles tracking for manual review (no auto-deletion)
- SIGINT handling for safe interruption

**Why backfill vs deletion**:
- Publickey RSS feed retention period unknown
- 54 articles x $0.01/req = minimal API cost
- Future regression guardrail (reusable for similar issues)

### Phase 2: Scheduler Self-Healing (Root Fix - Affects All Sources)
**File**: `scripts/scheduled/collect-feeds.ts` (+27/-6 lines)

**Changes**:
1. Add `updated` field to `CollectResult` and `ProcessSourceResult` interfaces
2. Update duplicate check logic (lines 193-210):
   - Detect `content=null/empty` in existing articles
   - Call `prisma.article.update` with new content, thumbnail, contentUpdatedAt, updatedAt
   - Use nullish coalescing (`??`) for thumbnail to handle empty strings
   - Log "content補完" for monitoring
3. Add `updatedCount` to final summary logs

**Benefits**:
- Applies to all sources (Zenn, InfoQ, etc.)
- Minimal performance impact (UPDATE only when content empty)
- Preserves canonical data (title, publishedAt, tagNames)
- Signals downstream jobs via contentUpdatedAt

## Verification
- Lint: PASSED
- Type-check: PASSED
- Security audit: PASSED (0 vulnerabilities)
- Build: PASSED
- Self-healing behavior: Verified by scheduler logic review

## Observability
New log line for monitoring:
- `既存記事を更新（content補完）: [title]...`
- Watch for spikes in "content補完" events via scheduler logs

## CodexMCP Recommendations Implemented
- Use Set for O(1) processedIds lookup
- Filter processed IDs in Prisma query
- Select only needed fields to reduce memory
- Batch sleep pattern for rate limiting
- Export failures instead of auto-deletion
- Update contentUpdatedAt to signal downstream jobs
- Consistent logging (console.error for stderr)
- Interface extension for proper stats tracking

## Post-Merge Action Required
- [ ] Run backfill script: `npx tsx scripts/maintenance/re-enrich-publickey-nulls.ts`
- [ ] Verify: SQL check `content=null` count for Publickey = 0
- [ ] Monitor: Watch scheduler logs for "content補完" events

## Related
- Investigation: .claude/docs/investigate/investigate_20251111_011943_066_publickey-content-null-backfill.md
- Plan: .claude/docs/plan/plan_20251111_074109_186_publickey-content-null-backfill.md
- Implementation: .claude/docs/implement/implement_20251111_075056_038_publickey-content-null-backfill.md

Generated with Claude Code (https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 空または null の記事コンテンツを外部ソースから再取得して補完する再エンリッチメント機能を追加。進行状況の保存、リトライ／バックオフ、バッチ処理、中断時の復帰をサポートします。
  * フィード収集で「更新」された記事を集計・報告する仕組みを追加し、収集結果のログや集計に反映されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->