### PR TITLE
feat: improve graph label readability and NEW badge (Phase 1)

### DIFF
--- a/app/articles/[id]/graph/page.tsx
+++ b/app/articles/[id]/graph/page.tsx
@@ -282,18 +282,27 @@ ${node.summary ? `\n${node.summary.substring(0, 70)}...` : ''}
 
           // Draw NEW badge for articles within 24 hours (non-center only)
           if (!isCenter) {
-            const date = new Date(node.publishedAt);
-            if (!isNaN(date.getTime())) {
-              const diffHours = Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60));
-              if (diffHours < 24) {
-                ctx.save();
-                const badgeRadius = Math.min(radius * 0.45, 6 / globalScale);
-                const badgeOffset = radius * 0.7;
-                ctx.fillStyle = '#EF4444'; // Red
-                ctx.beginPath();
-                ctx.arc(node.x + badgeOffset, node.y - badgeOffset, badgeRadius, 0, 2 * Math.PI);
-                ctx.fill();
-                ctx.restore();
+            // Skip badge for very small nodes to avoid overwhelming them
+            const screenRadius = radius * globalScale;
+            if (screenRadius >= 8) {
+              // Ensure publishedAt has timezone info (append 'Z' if missing)
+              const publishedAtNormalized = node.publishedAt.endsWith('Z')
+                ? node.publishedAt
+                : node.publishedAt + 'Z';
+              const timestamp = Date.parse(publishedAtNormalized);
+
+              if (!isNaN(timestamp)) {
+                const diffHours = Math.floor((Date.now() - timestamp) / (1000 * 60 * 60));
+                if (diffHours < 24) {
+                  ctx.save();
+                  const badgeRadius = 6 / globalScale;
+                  const badgeOffset = radius * 0.7;
+                  ctx.fillStyle = '#EF4444'; // Red
+                  ctx.beginPath();
+                  ctx.arc(node.x + badgeOffset, node.y - badgeOffset, badgeRadius, 0, 2 * Math.PI);
+                  ctx.fill();
+                  ctx.restore();
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary

- Improve label readability with black outline (works across all backgrounds)
- Increase link contrast from 0.4 to 0.6 for better visibility
- Add NEW badge (red dot) for articles published within 24 hours
- Update legend to explain NEW badge meaning
- **Note**: E2E visual regression tests deferred due to Docker read-only mount issue (see Test Results)

## Implementation Details

**File**: `app/articles/[id]/graph/page.tsx` ([Changes: lines 297, 283-299, 301-315, 377-383](https://github.com/pawafulu7/techtrend/blob/feature/graph-visual-phase1/app/articles/%5Bid%5D/graph/page.tsx))

### 1. Label Outline
- Uses `strokeText` + `fillText` with clamped `lineWidth` (max 3px) to prevent halos on high-DPI displays
- Black outline + white text for readability across all backgrounds
- Performance: Adds one extra Canvas draw call per label (minimal impact with current node limit of 8)

### 2. NEW Badge
- Red dot badge for articles within 24 hours (client-side calculation: `Date.now() - publishedAt`)
- Badge size scales dynamically: `Math.min(radius * 0.45, 6 / globalScale)` to avoid overwhelming small nodes
- Positioned at node top-right (`radius * 0.7`)

### 3. Link Contrast
- Alpha increased from 0.4 to 0.6 for improved visibility
- Avoids competing with node fills (stays below 0.7 threshold)

### 4. Legend Update
- Added "NEW Badge (red dot)" with explanation "Published within 24 hours"
- Helps users interpret the new visual element

## Test Results

### Verification (All Passed)
- Lint: PASSED (2s)
- Type-check: PASSED (20s)
- Security audit: PASSED (5s)
- Build: PASSED (42s)

Total verification time: 69 seconds

### E2E Tests
E2E visual regression tests were **deferred** due to Docker read-only mount constraints (`__tests__/` mounted as `:ro`).

**Reason**: Playwright cannot create snapshot directories in read-only mounts. Existing `visual-regression.spec.ts` works because baseline images were pre-generated on host.

**Resolution**: Manual visual verification required for this PR. E2E setup will be addressed in separate task.

## Related Documents

- Investigation: `.claude/docs/investigate/investigate_20251114_163606_928_graph-visual-enhancements.md`
- Plan: `.claude/docs/plan/plan_20251114_164137_022_graph-visual-phase1.md`
- Implementation: `.claude/docs/implement/implement_20251114_190124_850_graph-visual-phase1.md`

## Next Steps

- **Phase 2**: UX improvements (tooltip positioning, category legend expansion, depth-2 node differentiation)
- **Phase 3**: Structural changes (responsive design, performance optimization, accessibility - separate Epic)

## Checklist

- [x] Lint passing
- [x] Type-check passing
- [x] Security audit passing
- [x] Build passing
- [x] Documentation updated
- [x] No breaking changes
- [ ] Manual visual verification (graph page with fresh articles)
- [ ] E2E visual regression (deferred - Docker read-only issue)

---

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 24時間以内に公開された（非センター）記事を示す「NEW」バッジをグラフ上に表示
  * ノードに赤い円形バッジを描画して新着を視覚的に強調
  * ラベル表示で安全なプレフィックス除去を維持しつつ、可読性向上のため黒い外枠を追加

* **UI改善**
  * グラフのリンク色の不透明度を0.4から0.6に上げ視認性を向上
  * 凡例に「NEW」バッジの説明ブロックと対応エントリを追加し、24時間基準を明記
<!-- end of auto-generated comment: release notes by coderabbit.ai -->