### PR TITLE
fix: improve SummaryPostProcessor regex to handle multi-colon and half-width colon bullets

### DIFF
--- a/lib/ai/service/__tests__/post-processor.test.ts
+++ b/lib/ai/service/__tests__/post-processor.test.ts
@@ -126,6 +126,27 @@ describe('SummaryPostProcessor', () => {
       expect(result).not.toMatch(/：\s*\n/);
     });
 
+    it('should merge bullet headers that end with a half-width colon', () => {
+      const input = '・タグ:\n内容が次の行にある';
+      const result = processor.cleanupDetailedSummary(input);
+
+      expect(result).toBe('・タグ: 内容が次の行にある');
+    });
+
+    it('should merge headers that contain additional colons inside the title', () => {
+      const input = '・顧客固有のセキュリティ：動的ベースライン：\n説明テキスト';
+      const result = processor.cleanupDetailedSummary(input);
+
+      expect(result).toBe('・顧客固有のセキュリティ：動的ベースライン： 説明テキスト');
+    });
+
+    it('should merge continuation lines for alternate bullet markers', () => {
+      const input = '- 補足情報:\n追加の説明\n- 次の項目: そのまま';
+      const result = processor.cleanupDetailedSummary(input);
+
+      expect(result).toBe('- 補足情報: 追加の説明\n- 次の項目: そのまま');
+    });
+
     it('should not affect normal bullets with content on same line', () => {
       const input = '・項目名： 内容が同じ行にある';
       const result = processor.cleanupDetailedSummary(input);

--- a/lib/ai/service/post-processor.ts
+++ b/lib/ai/service/post-processor.ts
@@ -17,15 +17,23 @@ export class SummaryPostProcessor implements PostProcessor {
       .filter((line) => line.length > 0 && line !== '・');
 
     // Defensive processing: merge bullet headers with continuation lines
+    const bulletLinePattern = /^(?:・|[-*•]|\d+[\.．、)]|[A-Za-z]\)|\([0-9]+\)|\([a-z]\))/i;
+    const hasTrailingColon = (value: string) => /[:：]\s*$/.test(value);
+    const isBulletLine = (value: string) => bulletLinePattern.test(value);
+
     const normalized: string[] = [];
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      // If a bullet line ends with colon and next line is not a bullet, merge them
-      if (/^・[^：\n]+：\s*$/.test(line) &&
-          i + 1 < lines.length &&
-          !/^・/.test(lines[i + 1])) {
-        normalized.push(line + ' ' + lines[i + 1]);
-        i++; // Skip the next line
+      const nextLine = lines[i + 1] ?? '';
+
+      if (
+        hasTrailingColon(line) &&
+        isBulletLine(line) &&
+        i + 1 < lines.length &&
+        !isBulletLine(nextLine)
+      ) {
+        normalized.push(`${line.replace(/\s+$/, '')} ${nextLine}`);
+        i++; // Skip the next line because it has been merged
       } else {
         normalized.push(line);
       }

--- a/scripts/maintenance/backfill-cleanup-detailed-summary.ts
+++ b/scripts/maintenance/backfill-cleanup-detailed-summary.ts
@@ -1,0 +1,83 @@
+import { PrismaClient } from '@prisma/client';
+import { SummaryPostProcessor } from '@/lib/ai/service/post-processor';
+
+const prisma = new PrismaClient();
+const processor = new SummaryPostProcessor();
+
+async function backfillCleanup() {
+  try {
+    console.log('=== DetailedSummary Cleanup Backfill ===\n');
+    
+    // 1. 対象記事を取得
+    const articles = await prisma.$queryRaw<Array<{ id: string; detailedSummary: string }>>`
+      SELECT id, "detailedSummary"
+      FROM "Article"
+      WHERE "summaryVersion" = 8
+      AND "detailedSummary" ~ '(^|\\n)(?:・|[-*•]|\\d+[\\).．、])[^\\n]*[:：]\\s*\\n(?!\\s*(?:・|[-*•]|\\d+[\\).．、]))'
+    `;
+    
+    console.log(`対象記事: ${articles.length}件\n`);
+    
+    if (articles.length === 0) {
+      console.log('処理対象の記事がありません。');
+      return;
+    }
+    
+    // 2. 各記事を処理
+    let processed = 0;
+    for (const article of articles) {
+      const before = article.detailedSummary;
+      const after = processor.cleanupDetailedSummary(article.detailedSummary);
+      
+      // 変更がある場合のみ更新
+      if (before !== after) {
+        await prisma.article.update({
+          where: { id: article.id },
+          data: { detailedSummary: after }
+        });
+        
+        processed++;
+        console.log(`${processed}/${articles.length} 処理: ${article.id}`);
+      } else {
+        console.log(`スキップ: ${article.id} (変更なし)`);
+      }
+    }
+    
+    console.log(`\n完了: ${processed}件を更新しました`);
+    
+    // 3. 検証
+    const remaining = await prisma.$queryRaw<Array<{ count: bigint }>>`
+      SELECT COUNT(*) as count
+      FROM "Article"
+      WHERE "summaryVersion" = 8
+      AND "detailedSummary" ~ '(^|\\n)(?:・|[-*•]|\\d+[\\).．、])[^\\n]*[:：]\\s*\\n(?!\\s*(?:・|[-*•]|\\d+[\\).．、]))'
+    `;
+    
+    const remainingCount = Number(remaining[0].count);
+    console.log(`\n検証: 残り改行パターン = ${remainingCount}件 (期待値: 0)`);
+    
+    if (remainingCount === 0) {
+      console.log('✓ バックフィル成功！');
+    } else {
+      console.log('⚠ まだ改行パターンが残っています');
+    }
+    
+  } catch (error) {
+    console.error('エラー:', error);
+    throw error;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// 直接実行された場合
+if (require.main === module) {
+  backfillCleanup()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}
+
+export { backfillCleanup };


### PR DESCRIPTION
## Summary

SummaryPostProcessor.cleanupDetailedSummary()の正規表現バグを修正し、既存の283件の改行パターン記事をバックフィル処理しました。

## Root Cause

**問題の正規表現** (lib/ai/service/post-processor.ts:24):
```typescript
/^・[^：\n]+：\s*$/
```

**問題点**:
1. `[^：]` が多重コロンヘッダー（`・header：sub-header：`）を除外
2. `：`のみが半角コロン`:`を除外
3. `^・`のみが他の箇条書き記号（`-`, `*`, `•`）を除外

**影響**: 283件の記事で`・項目名:\n内容`形式が残り、UI表示が崩れていました。

## Changes

### 1. 正規表現の改善

- 半角・全角コロン両対応（`:`, `：`）
- 多重コロン対応（`[^：]`を`.*`に変更）
- 他の箇条書き記号対応（`-`, `*`, `•`, 数字等）
- ヘルパー関数追加で可読性向上

### 2. テストケース追加

- 半角コロンのマージテスト
- 多重コロンのマージテスト
- 他の箇条書き記号のマージテスト
- **全27テスト成功**

### 3. バックフィル実行

- 283件の改行パターン記事を修正
- `SummaryPostProcessor.cleanupDetailedSummary()`で再処理
- **検証: 改行パターン = 0件**

## Impact

- **修正前**: 283件（1.7%）が改行パターンで表示崩れ
- **修正後**: 0件、全て正常表示
- **既存への影響**: なし（全27テスト成功で確認済み）

## Example

**記事ID**: cmi5848ak008qten917tuxjl1

**Before**:
```
・NTFの概要と定義:
NTFは、非負の要素を持つテンソルを...
```

**After**:
```
・NTFの概要と定義: NTFは、非負の要素を持つテンソルを...
```

## Test Plan

- [x] Unit tests: 27/27 passed
- [x] Type check: passed
- [x] Lint: passed
- [x] Security audit: 0 vulnerabilities
- [x] Build: passed
- [x] Backfill verification: 283 articles fixed, 0 remaining
- [x] Sample article display: verified correct

## Related

- Investigation: `.claude/docs/investigate/investigate_20251119_090411_699_article-summary-display-issue.md`
- Plan: `.claude/docs/plan/plan_20251119_091439_282_fix-post-processor-regex.md`
- Implementation: `.claude/docs/implement/implement_20251119_213245_413_fix-post-processor-regex.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 要約データのクリーンアップ処理を改善し、箇条書き形式の正規化ロジックを強化

* **テスト**
  * 要約クリーンアップ機能の検証テストを追加

* **Chores**
  * データベース保守用のバックフィルスクリプトを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->