### PR TITLE
fix: apply postProcessSummaries to regeneration scripts

### DIFF
--- a/scripts/scheduled/regenerate-summaries.ts
+++ b/scripts/scheduled/regenerate-summaries.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 import { GeminiClient } from '../../lib/ai/gemini';
 import { validateSummary, validateDetailedSummary } from '../../lib/utils/summary-validator';
+import { postProcessSummaries } from '../../lib/utils/summary-post-processor';
 
 const prisma = new PrismaClient();
 
@@ -111,10 +112,12 @@ async function regenerateSummaries(options: RegenerationOptions = {}) {
         article.title,
         content
       );
-      
+
+      const processed = postProcessSummaries(result.summary, result.detailedSummary);
+
       // 要約の検証
-      const summaryValidation = validateSummary(result.summary);
-      const detailedValidation = validateDetailedSummary(result.detailedSummary);
+      const summaryValidation = validateSummary(processed.summary);
+      const detailedValidation = validateDetailedSummary(processed.detailedSummary);
       
       if (!summaryValidation.isValid) {
         console.warn('  ⚠️ 生成された要約に問題があります:', summaryValidation.errors);
@@ -128,8 +131,8 @@ async function regenerateSummaries(options: RegenerationOptions = {}) {
       await prisma.article.update({
         where: { id: article.id },
         data: {
-          summary: result.summary,
-          detailedSummary: result.detailedSummary,
+          summary: processed.summary,
+          detailedSummary: processed.detailedSummary,
           summaryVersion: { increment: 1 }
         }
       });
@@ -162,9 +165,9 @@ async function regenerateSummaries(options: RegenerationOptions = {}) {
           }
         }
       }
-      
+
       console.error('  ✅ 再生成完了');
-      console.error(`  新要約: ${result.summary.substring(0, 50)}...`);
+      console.error(`  新要約: ${processed.summary.substring(0, 50)}...`);
       successCount++;
       
     } catch (error) {

--- a/scripts/test/regenerate-moneyforward-v2.ts
+++ b/scripts/test/regenerate-moneyforward-v2.ts
@@ -3,6 +3,7 @@
 import { PrismaClient } from '@prisma/client';
 import { GeminiClient } from '../../lib/ai/gemini';
 import { generateUnifiedPrompt } from '../../lib/utils/article-type-prompts';
+import { postProcessSummaries } from '../../lib/utils/summary-post-processor';
 
 const prisma = new PrismaClient();
 
@@ -54,17 +55,17 @@ async function regenerateWithNewFormat() {
     const detailedResult = await gemini.generateDetailedSummary(article.title, article.content);
     console.error('✅ 詳細要約生成完了\n');
 
-    const detailedSummary = detailedResult.detailedSummary;
+    const processed = postProcessSummaries(summary, detailedResult.detailedSummary);
 
     // 詳細要約の形式確認
     console.error('📝 詳細要約プレビュー（最初の500文字）:');
-    console.error(detailedSummary.substring(0, 500));
+    console.error(processed.detailedSummary.substring(0, 500));
     console.error('...\n');
 
     // 固定項目が含まれていないか確認
-    const hasFixedItems = detailedSummary.includes('主要トピック') || 
-                         detailedSummary.includes('課題・問題点') ||
-                         detailedSummary.includes('技術的詳細');
+    const hasFixedItems = processed.detailedSummary.includes('主要トピック') || 
+                         processed.detailedSummary.includes('課題・問題点') ||
+                         processed.detailedSummary.includes('技術的詳細');
     
     if (hasFixedItems) {
       console.error('⚠️ 警告: 固定項目が検出されました。再生成が必要かもしれません。');
@@ -77,8 +78,8 @@ async function regenerateWithNewFormat() {
     const updated = await prisma.article.update({
       where: { id: articleId },
       data: {
-        summary,
-        detailedSummary,
+        summary: processed.summary,
+        detailedSummary: processed.detailedSummary,
         summaryVersion: 7, // 最新バージョン
         articleType: 'unified'
       }


### PR DESCRIPTION
## Summary

- Applied `postProcessSummaries` to all manual summary regeneration scripts
- Ensures `cleanupDetailedSummary` is consistently applied across all regeneration paths
- Prevents malformed format (colon + newline) from being saved to database

## Background

PR #233 introduced `cleanupDetailedSummary` to fix colon + newline formatting issues and integrated it into the main generation flow (`UnifiedSummaryService`). However, manual regeneration scripts were still calling Gemini API directly and saving results without cleanup.

## Implementation Details

### Changes

1. **regenerate-summaries.ts**
   - Added `postProcessSummaries` import
   - Process flow: generate -> cleanup -> validate -> save
   - Updated logging to use processed values

2. **regenerate-moneyforward-v2.ts**
   - Added `postProcessSummaries` import  
   - Process flow: generate -> cleanup -> save
   - Updated preview and validation to use processed values

### Processing Order

```
Gemini API
    ↓
postProcessSummaries (cleanup + bullet-period removal)
    ↓
validateSummary / validateDetailedSummary
    ↓
Database save
```

## Impact

### Coverage

All summary generation paths now apply cleanup:
- ✅ `UnifiedSummaryService` - Main generation (already had cleanup)
- ✅ `regenerate-summaries.ts` - Manual regeneration (now added)
- ✅ `regenerate-moneyforward-v2.ts` - Test regeneration (now added)
- ✅ `collect-feeds.ts` - Automated collection (uses postProcessSummaries)

### Prevention

Future executions of manual regeneration scripts will automatically:
- Merge colon + newline patterns into single-line format
- Remove trailing periods from bullet points
- Apply consistent formatting

## Test Results

✅ All verification checks passed:
- Lint: Passed (1 pre-existing warning unrelated to changes)
- Type check: Passed
- Security audit: 0 vulnerabilities  
- Build: Successful

## Related

- **Completes**: PR #233 (cleanup integration to automated paths)
- **Follows**: User feedback to ensure cleanup applies to ALL regeneration paths

## Checklist

- [x] Tests passing
- [x] Lint and type-check clean
- [x] Build successful
- [x] No breaking changes
- [x] All regeneration paths now apply cleanup consistently

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Chores**
  * 要約生成スクリプトの内部処理を改善。生成された要約に対して後処理ステップを追加し、データベース保存前にコンテンツの品質処理を強化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->