### PR TITLE
feat(ui): modernize AI search interface with CardV2 design system (PR1/3)

### DIFF
--- a/app/search/agent/_components/agent-search-client.tsx
+++ b/app/search/agent/_components/agent-search-client.tsx
@@ -76,12 +76,12 @@ export function AgentSearchClient() {
     <div>
       <CardV2
         variant="default"
-        className="bg-(--tt-color-surface-muted) shadow-[var(--tt-shadow-card-rest)] p-6 mb-6"
+        className="bg-[var(--tt-color-surface-muted)] shadow-[var(--tt-shadow-card-rest)] p-6 mb-6"
         data-testid="agent-search-card"
       >
         <div className="text-center mb-4">
           <h1 className="text-2xl font-heading mb-2">AI記事検索</h1>
-          <p className="text-sm text-(--tt-color-text-muted)">
+          <p className="text-sm text-[color:var(--tt-color-text-muted)]">
             AIがTechTrendの記事を横断検索し、要約と参考リンクで回答します。気になるテーマを自然言語で質問してください。
           </p>
         </div>
@@ -98,11 +98,11 @@ export function AgentSearchClient() {
           <ButtonV2
             variant="ghost"
             size="sm"
-            className="w-full justify-center gap-2"
+            className="w-full justify-center gap-2 data-[state=open]:text-primary"
             data-testid="agent-sample-query-trigger"
           >
             <span className="text-sm">よくある質問を見る</span>
-            <ChevronDown className="h-4 w-4 transition-transform duration-200" />
+            <ChevronDown className="h-4 w-4 transition-transform duration-200 data-[state=open]:rotate-180" />
           </ButtonV2>
         </CollapsibleTrigger>
         <CollapsibleContent className="mt-4">


### PR DESCRIPTION
## Summary

AI記事検索画面のUI/UX改善 - 第1弾: 検索セクション + サンプルクエリのCardV2化

既存のデザインシステム（CardV2, BadgeV2, ButtonV2, Design Tokens）を適用し、トップ画面・詳細画面と同様のモダン化を実現します。

### 変更内容

#### 検索エリアのCardV2化
- CardV2でラップし、淡いサーフェス背景でセクション分離
- デザイントークン適用（`font-heading`, `text-muted`, `surface-muted`）
- 見出しサイズ調整（`text-3xl` → `text-2xl`、24-28px範囲に統一）
- 中央寄せレイアウトで視覚的ヒエラルキーを明確化

#### サンプルクエリのCardV2化
- CollapsibleトリガーをButtonV2に変更（`variant="ghost"`）
- サンプルクエリコンテンツをCardV2でラップ（`variant="ghost"`）
- アイコン追加でインタラクションを明示

#### E2Eテスト対応
- data-testid属性追加（`agent-search-card`, `agent-sample-query-trigger`）
- 既存のroleベースセレクタは変更不要（互換性維持）

### デザインコンセプト

**「記事が主役」「ミニマル」** をキープしつつ、余白・コントラスト・カードで情報を整理するモダン化

- Hero sectionなし（過去のフィードバックを尊重）
- Primary色は控えめに使用
- デザイントークンで一貫性を確保

### 技術詳細

- CardV2 variant="default" + カスタムclassNameでsurface-muted背景を実現
- ButtonV2 variant="ghost"でゴーストボタン（ホバー時のみ背景表示）
- 既存機能（Streaming UI、検索履歴、サンプルクエリ）は全て維持

### テスト結果

- ✅ Lint: 成功（警告1件は別ファイルの既存問題）
- ✅ Build: 成功
- ✅ E2E: 全36テスト通過（2テストスキップ）

### 関連PR

これは3部作の第1弾です:
- **PR1/3** (このPR): 検索セクション + サンプルクエリのCardV2化
- PR2/3 (次): 結果カードのCardV2移行
- PR3/3 (最終): ステータス統一 + 余白/Typography調整

### 実装計画・記録

- 実装計画: `.claude/docs/plan/plan_20251125_121126_456_ai-search-ui-improvement.md`
- 実装記録: `.claude/docs/implement/implement_20251125_123339_845_ai-search-ui-pr1.md`

Generated with Claude Code (https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **スタイル**
  * エージェント検索のビジュアルを刷新。ヘッダーをカード状コンテナでまとめ、タイポグラフィーとテキスト色を調整して視認性を向上しました。
  * 操作ボタンの外観と開閉時の挙動を改善し、より一貫した見た目と操作感を提供します。
  * サンプルクエリ群を淡いカード内に配置し、コンテンツの区切りと読みやすさを向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->