### PR TITLE
feat(ui): modernize AI search status displays with CardV2 (PR3/3)

### DIFF
--- a/__tests__/components/agent-loading-state.test.tsx
+++ b/__tests__/components/agent-loading-state.test.tsx
@@ -35,11 +35,19 @@ describe('AgentLoadingState', () => {
     expect(status).toHaveAttribute('aria-busy', 'true');
   });
 
-  test('displays 6 skeleton lines', () => {
+  test('displays 4 skeleton lines', () => {
     const { container } = render(<AgentLoadingState />);
 
     const skeletonLines = container.querySelectorAll('.animate-pulse');
-    expect(skeletonLines.length).toBeGreaterThanOrEqual(6);
+    expect(skeletonLines.length).toBe(4);
+  });
+
+  test('is wrapped in CardV2 ghost variant', () => {
+    render(<AgentLoadingState />);
+
+    const card = screen.getByTestId('agent-loading-state');
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveClass('border-none', 'shadow-none');
   });
 
   test('displays loading message', () => {

--- a/app/search/agent/_components/agent-answer-panel.tsx
+++ b/app/search/agent/_components/agent-answer-panel.tsx
@@ -136,7 +136,7 @@ export function AgentAnswerPanel({ result, partialText, isStreaming, onFeedback 
     <CardV2 variant="hover" className="p-6" role="article" aria-labelledby="answer-heading" data-testid="agent-result-card">
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-2">
-          <h2 id="answer-heading" className="text-lg font-semibold">
+          <h2 id="answer-heading" className="text-xl md:text-2xl font-semibold">
             AI回答
           </h2>
           {result?.cached && (
@@ -190,17 +190,23 @@ export function AgentAnswerPanel({ result, partialText, isStreaming, onFeedback 
       )}
 
       {showEmptyState && (
-        <div className="bg-muted/50 border rounded-md p-6 text-center" role="status" aria-live="polite">
-          <h3 className="text-lg font-semibold mb-2">
+        <CardV2
+          variant="ghost"
+          className="py-6 md:py-8 text-center"
+          role="status"
+          aria-live="polite"
+          data-testid="agent-empty-state"
+        >
+          <h3 className="text-xl md:text-2xl font-semibold mb-2">
             {result?.fallback
               ? '関連する記事が見つかりませんでした'
               : '該当する記事が見つかりませんでした'}
           </h3>
           <p className="text-sm text-muted-foreground mb-4">以下を試してみてください:</p>
           <ul className="text-sm text-muted-foreground mb-4 text-left max-w-md mx-auto space-y-1">
-            <li>• キーワードをより具体的にする（例: &quot;React&quot; → &quot;React 19のServer Components&quot;）</li>
-            <li>• 技術名やバージョンを追加する</li>
-            <li>• 検索期間を調整する</li>
+            <li>- キーワードをより具体的にする（例: &quot;React&quot; → &quot;React 19のServer Components&quot;）</li>
+            <li>- 技術名やバージョンを追加する</li>
+            <li>- 検索期間を調整する</li>
           </ul>
           <div className="flex gap-2 justify-center">
             {/* shadcn/ui ButtonをasChildで維持: ButtonV2がasChildプロップをサポートしていないため */}
@@ -208,7 +214,7 @@ export function AgentAnswerPanel({ result, partialText, isStreaming, onFeedback 
               <Link href="/search">通常検索を試す</Link>
             </Button>
           </div>
-        </div>
+        </CardV2>
       )}
 
       {!showEmptyState && (

--- a/app/search/agent/_components/agent-error-display.tsx
+++ b/app/search/agent/_components/agent-error-display.tsx
@@ -2,6 +2,7 @@
 
 import { AlertTriangle, RefreshCw, LogIn } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { CardV2 } from '@/components/ui-v2/card-v2';
 import { useRouter } from 'next/navigation';
 import type { AgentSearchError } from '@/lib/hooks/useAgentSearch';
 
@@ -21,7 +22,7 @@ export function AgentErrorDisplay({ error, onRetry }: AgentErrorDisplayProps) {
           message: 'AI検索を使用するにはログインが必要です。',
           action: (
             <Button onClick={() => router.push('/auth/login?callbackUrl=/search/agent')}>
-              <LogIn className="h-4 w-4 mr-2" />
+              <LogIn className="h-4 w-4 mr-2" aria-hidden="true" />
               ログイン
             </Button>
           ),
@@ -34,7 +35,7 @@ export function AgentErrorDisplay({ error, onRetry }: AgentErrorDisplayProps) {
             : '少し時間を置いてから再試行してください。',
           action: onRetry && (
             <Button onClick={onRetry} disabled={!!error.retryAfter}>
-              <RefreshCw className="h-4 w-4 mr-2" />
+              <RefreshCw className="h-4 w-4 mr-2" aria-hidden="true" />
               再試行
             </Button>
           ),
@@ -51,7 +52,7 @@ export function AgentErrorDisplay({ error, onRetry }: AgentErrorDisplayProps) {
           message: 'サーバーで問題が発生しました。しばらくしてから再試行してください。',
           action: onRetry && (
             <Button onClick={onRetry}>
-              <RefreshCw className="h-4 w-4 mr-2" />
+              <RefreshCw className="h-4 w-4 mr-2" aria-hidden="true" />
               再試行
             </Button>
           ),
@@ -62,7 +63,7 @@ export function AgentErrorDisplay({ error, onRetry }: AgentErrorDisplayProps) {
           message: 'リクエストがタイムアウトしました。ネットワーク接続を確認してください。',
           action: onRetry && (
             <Button onClick={onRetry}>
-              <RefreshCw className="h-4 w-4 mr-2" />
+              <RefreshCw className="h-4 w-4 mr-2" aria-hidden="true" />
               再試行
             </Button>
           ),
@@ -73,7 +74,7 @@ export function AgentErrorDisplay({ error, onRetry }: AgentErrorDisplayProps) {
           message: 'ネットワーク接続を確認してください。',
           action: onRetry && (
             <Button onClick={onRetry}>
-              <RefreshCw className="h-4 w-4 mr-2" />
+              <RefreshCw className="h-4 w-4 mr-2" aria-hidden="true" />
               再試行
             </Button>
           ),
@@ -84,7 +85,7 @@ export function AgentErrorDisplay({ error, onRetry }: AgentErrorDisplayProps) {
           message: error.message || '不明なエラーが発生しました。',
           action: onRetry && (
             <Button onClick={onRetry}>
-              <RefreshCw className="h-4 w-4 mr-2" />
+              <RefreshCw className="h-4 w-4 mr-2" aria-hidden="true" />
               再試行
             </Button>
           ),
@@ -95,15 +96,30 @@ export function AgentErrorDisplay({ error, onRetry }: AgentErrorDisplayProps) {
   const { title, message, action } = getErrorMessage();
 
   return (
-    <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-6">
-      <div className="flex items-start gap-4">
-        <AlertTriangle className="h-6 w-6 text-destructive flex-shrink-0 mt-0.5" />
-        <div className="flex-1">
-          <h3 className="text-lg font-semibold text-destructive mb-2">{title}</h3>
-          <p className="text-sm text-destructive/80 mb-4">{message}</p>
-          {action}
-        </div>
+    <CardV2
+      variant="ghost"
+      className="py-6 md:py-8 border-2 border-[var(--tt-color-negative)]"
+      role="alert"
+      aria-live="assertive"
+      data-testid="agent-error-display"
+    >
+      <div className="mx-auto max-w-xl flex flex-col items-center text-center gap-3">
+        <AlertTriangle
+          className="h-8 w-8 text-destructive"
+          aria-hidden="true"
+        />
+        <h3 className="text-xl md:text-2xl font-semibold text-destructive">
+          {title}
+        </h3>
+        <p className="text-sm text-destructive/80">
+          {message}
+        </p>
+        {action && (
+          <div className="mt-2">
+            {action}
+          </div>
+        )}
       </div>
-    </div>
+    </CardV2>
   );
 }

--- a/app/search/agent/_components/agent-loading-state.tsx
+++ b/app/search/agent/_components/agent-loading-state.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { CardV2 } from '@/components/ui-v2/card-v2';
+import { cn } from '@/lib/utils';
+
 const DOT_ANIMATION_DELAYS = [0, 150, 300];
 
 interface AgentLoadingStateProps {
@@ -8,7 +11,14 @@ interface AgentLoadingStateProps {
 
 export function AgentLoadingState({ className }: AgentLoadingStateProps) {
   return (
-    <div className={className} role="status" aria-live="polite" aria-busy="true">
+    <CardV2
+      variant="ghost"
+      className={cn('py-6 md:py-8 text-center', className)}
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      data-testid="agent-loading-state"
+    >
       <div className="flex items-center justify-center gap-3 mb-4">
         <div className="flex items-center gap-2">
           <div className="flex gap-1">
@@ -29,12 +39,10 @@ export function AgentLoadingState({ className }: AgentLoadingStateProps) {
 
       <div className="space-y-3">
         <div className="h-4 bg-muted rounded animate-pulse" style={{ width: '90%' }} />
-        <div className="h-4 bg-muted rounded animate-pulse" style={{ width: '85%' }} />
-        <div className="h-4 bg-muted rounded animate-pulse" style={{ width: '70%' }} />
-        <div className="h-4 bg-muted rounded animate-pulse mt-6" style={{ width: '40%' }} />
-        <div className="h-4 bg-muted rounded animate-pulse" style={{ width: '95%' }} />
-        <div className="h-4 bg-muted rounded animate-pulse" style={{ width: '80%' }} />
+        <div className="h-4 bg-muted rounded animate-pulse" style={{ width: '75%' }} />
+        <div className="h-4 bg-muted rounded animate-pulse" style={{ width: '60%' }} />
+        <div className="h-4 bg-muted rounded animate-pulse" style={{ width: '40%' }} />
       </div>
-    </div>
+    </CardV2>
   );
 }

--- a/app/search/agent/_components/agent-sample-queries.tsx
+++ b/app/search/agent/_components/agent-sample-queries.tsx
@@ -13,7 +13,7 @@ export function AgentSampleQueries({ onSelectQuery, className, queries }: AgentS
   if (queries && queries.length > 0) {
     return (
       <div className={className}>
-        <div className="flex flex-wrap gap-2 justify-center max-w-3xl mx-auto">
+        <div className="flex flex-wrap gap-4 justify-center max-w-3xl mx-auto">
           {queries.map((query, index) => (
             <Button
               key={`${query}-${index}`}
@@ -44,7 +44,7 @@ export function AgentSampleQueries({ onSelectQuery, className, queries }: AgentS
 
   return (
     <div className={className}>
-      <div className="space-y-3 max-w-3xl mx-auto">
+      <div className="space-y-4 max-w-3xl mx-auto">
         {CATEGORY_ORDER.map((category) => {
           const categoryQueries = groupedQueries[category];
           if (!categoryQueries || categoryQueries.length === 0) return null;
@@ -54,7 +54,7 @@ export function AgentSampleQueries({ onSelectQuery, className, queries }: AgentS
               <p className="text-xs text-muted-foreground mb-1.5 text-center" data-testid="category-label">
                 {CATEGORY_LABELS[category]}
               </p>
-              <div className="flex flex-wrap gap-2 justify-center">
+              <div className="flex flex-wrap gap-4 justify-center">
                 {categoryQueries.map((query) => (
                   <Button
                     key={query.id}


### PR DESCRIPTION
## Summary
- Convert loading, error, and empty states to CardV2 ghost variant for unified design system
- Unify spacing (gap-4, space-y-4) and typography (text-xl md:text-2xl) across AI search components
- Add comprehensive ARIA attributes for improved accessibility

## Changes

### Phase 1: AgentLoadingState CardV2化
- Wrap in CardV2 with `variant="ghost"`
- Add ARIA status attributes: `role="status"`, `aria-live="polite"`, `aria-busy="true"`
- Reduce skeleton lines from 6 to 4 for cleaner UI

### Phase 2: AgentErrorDisplay CardV2化
- Center-aligned CardV2 layout with `border-[var(--tt-color-negative)]`
- Add `role="alert"`, `aria-live="assertive"` for error notifications
- Add `aria-hidden="true"` to all icons (7 error patterns covered)

### Phase 3: Empty state CardV2化
- Wrap AgentAnswerPanel's empty state in CardV2 ghost variant
- Add `data-testid="agent-empty-state"` for testing
- Responsive typography: `text-xl md:text-2xl`

### Phase 4: Spacing/Typography統一
- Unify gaps in AgentSampleQueries: `gap-2` → `gap-4`
- Unify spacing: `space-y-3` → `space-y-4`
- AI回答 heading: `text-lg` → `text-xl md:text-2xl`

## Technical Notes
- `border-negative` class doesn't exist; used design token `--tt-color-negative` directly
- ButtonV2 doesn't support `asChild` prop; maintained shadcn Button for Link components

## Test Plan
- [x] Unit tests: all 35 tests passed
  - agent-loading-state.test.tsx: 7/7
  - agent-error-display.test.tsx: 6/6
  - agent-answer-panel.test.tsx: 16/16
  - agent-sample-queries.test.tsx: 6/6
- [x] E2E tests: agent-search.spec.ts 34 passed
- [x] Lint: passed
- [x] Type-check: passed

## Related
- Prerequisite: #239 (CardV2 base), #240 (AgentAnswerPanel CardV2)
- Part of AI Search UI Improvement series (PR3/3)

## UI/UX Review
- UI/UX Review Document: `.claude/docs/plan/20251125_151414_ai-search-ui-pr3_ui-ux-review/ui-ux-review.md`
- frontend-architect approval: ✅
- Accessibility review: ✅ (ARIA attributes added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * エラー表示のレイアウトを改善しました
  * アクセシビリティ機能を強化しました（ARIA属性の追加）

* **スタイル**
  * ローディング状態のUIを更新しました
  * 回答パネルのヘッダーサイズを拡大しました
  * 要素間のスペーシングを調整しました
  * サンプルクエリの表示を改善しました

* **テスト**
  * ローディング状態の検証テストを更新しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->