### PR TITLE
feat(personalization): add centroid computation service (PR 2/4)

### DIFF
--- a/__tests__/lib/personalization/centroid-service.test.ts
+++ b/__tests__/lib/personalization/centroid-service.test.ts
@@ -13,6 +13,7 @@ const mockPrisma = {
   },
   $queryRaw: jest.fn(),
   $executeRaw: jest.fn(),
+  $transaction: jest.fn((promises: Promise<unknown>[]) => Promise.all(promises)),
 };
 
 jest.mock('@/lib/prisma', () => ({
@@ -59,17 +60,19 @@ describe('CentroidService', () => {
       expect(results).toHaveLength(2);
       expect(results[0]).toEqual({
         categoryId: 'cat-1',
+        slug: 'frontend',
         success: true,
         sampleCount: 100,
       });
       expect(results[1]).toEqual({
         categoryId: 'cat-2',
+        slug: 'backend',
         success: true,
         sampleCount: 50,
       });
 
-      // Verify UPDATE was called for each category
-      expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(2);
+      // Verify transaction was called with updates
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
     });
 
     it('should not write to DB in dry run mode', async () => {
@@ -80,9 +83,10 @@ describe('CentroidService', () => {
 
       expect(results).toHaveLength(2);
       expect(results.every((r) => r.success)).toBe(true);
+      expect(results.every((r) => r.slug !== undefined)).toBe(true);
 
-      // Verify UPDATE was NOT called
-      expect(mockPrisma.$executeRaw).not.toHaveBeenCalled();
+      // Verify transaction was NOT called
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
     });
 
     it('should handle categories with no articles', async () => {
@@ -105,6 +109,7 @@ describe('CentroidService', () => {
       // cat-1 succeeded
       expect(results[0]).toEqual({
         categoryId: 'cat-1',
+        slug: 'frontend',
         success: true,
         sampleCount: 100,
       });
@@ -112,13 +117,14 @@ describe('CentroidService', () => {
       // cat-empty failed (no articles)
       expect(results[1]).toEqual({
         categoryId: 'cat-empty',
+        slug: 'empty',
         success: false,
         sampleCount: 0,
         error: 'No articles with embeddings found for this category',
       });
 
-      // UPDATE called only once (for cat-1)
-      expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
+      // Transaction called once (for cat-1 only)
+      expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/lib/personalization/centroid-service.ts
+++ b/lib/personalization/centroid-service.ts
@@ -33,6 +33,30 @@ const DEFAULT_OPTIONS: Required<CentroidComputeOptions> = {
 };
 
 // =============================================================================
+// Type Definitions for SQL Results
+// =============================================================================
+
+/** Raw result from pgvector centroid computation query */
+type RawCentroidRow = {
+  category_id: string;
+  centroid: string;
+  sample_count: bigint;
+};
+
+/** Normalized centroid row for application use */
+type NormalizedCentroidRow = {
+  categoryId: string;
+  centroid: string;
+  sampleCount: number;
+};
+
+/** Category with slug for result mapping */
+type CategoryWithSlug = {
+  id: string;
+  slug: string;
+};
+
+// =============================================================================
 // Centroid Service
 // =============================================================================
 
@@ -50,12 +74,14 @@ export class CentroidService {
 
   /**
    * Compute and update centroids for all active categories.
+   *
+   * Updates are performed within a transaction to ensure consistency.
+   * If any update fails, all changes are rolled back.
    */
   async computeAllCentroids(
     options: CentroidComputeOptions = {}
   ): Promise<CentroidComputationResult[]> {
     const opts = { ...DEFAULT_OPTIONS, ...options };
-    const results: CentroidComputationResult[] = [];
 
     logger.info(
       { embeddingKey: opts.embeddingKey, model: opts.model, version: opts.version, dryRun: opts.dryRun },
@@ -64,7 +90,7 @@ export class CentroidService {
 
     try {
       // Get all active categories
-      const categories = await this.db.interestCategory.findMany({
+      const categories: CategoryWithSlug[] = await this.db.interestCategory.findMany({
         where: { isActive: true },
         select: { id: true, slug: true },
       });
@@ -74,7 +100,10 @@ export class CentroidService {
       // Compute centroids using single efficient query
       const centroids = await this.computeCentroidsQuery(opts);
 
-      // Update each category
+      // Build results and prepare updates
+      const results: CentroidComputationResult[] = [];
+      const updates: Array<{ categoryId: string; centroid: string; slug: string }> = [];
+
       for (const category of categories) {
         const centroidData = centroids.find((c) => c.categoryId === category.id);
 
@@ -85,6 +114,7 @@ export class CentroidService {
           );
           results.push({
             categoryId: category.id,
+            slug: category.slug,
             success: false,
             sampleCount: 0,
             error: 'No articles with embeddings found for this category',
@@ -92,20 +122,46 @@ export class CentroidService {
           continue;
         }
 
-        if (!opts.dryRun) {
-          await this.updateCategoryCentroid(category.id, centroidData.centroid);
-        }
-
-        logger.info(
-          { categoryId: category.id, slug: category.slug, sampleCount: centroidData.sampleCount, dryRun: opts.dryRun },
-          'Category centroid computed'
-        );
+        updates.push({
+          categoryId: category.id,
+          centroid: centroidData.centroid,
+          slug: category.slug,
+        });
 
         results.push({
           categoryId: category.id,
+          slug: category.slug,
           success: true,
           sampleCount: centroidData.sampleCount,
         });
+      }
+
+      // Execute all updates in a transaction for consistency
+      if (!opts.dryRun && updates.length > 0) {
+        await this.db.$transaction(
+          updates.map((u) =>
+            this.db.$executeRaw`
+              UPDATE "InterestCategory"
+              SET
+                "centroidEmbedding" = ${u.centroid}::vector,
+                "centroidComputedAt" = NOW(),
+                "updatedAt" = NOW()
+              WHERE id = ${u.categoryId}
+            `
+          )
+        );
+
+        logger.info(
+          { updatedCount: updates.length },
+          'All category centroids updated in transaction'
+        );
+      }
+
+      for (const update of updates) {
+        logger.info(
+          { categoryId: update.categoryId, slug: update.slug, dryRun: opts.dryRun },
+          'Category centroid computed'
+        );
       }
 
       return results;
@@ -120,6 +176,11 @@ export class CentroidService {
 
   /**
    * Compute centroid for a single category.
+   *
+   * Note: Unlike computeAllCentroids which throws on error, this method
+   * catches exceptions and returns a Result object. This design makes it
+   * easier to handle from CLI tools where we want to report failures
+   * gracefully rather than crash the entire script.
    */
   async computeCategoryCentroid(
     categoryId: string,
@@ -184,14 +245,12 @@ export class CentroidService {
   private async computeCentroidsQuery(
     options: Required<CentroidComputeOptions>,
     categoryId?: string
-  ): Promise<Array<{ categoryId: string; centroid: string; sampleCount: number }>> {
+  ): Promise<NormalizedCentroidRow[]> {
     const categoryFilter = categoryId
       ? Prisma.sql`AND tcm."categoryId" = ${categoryId}`
       : Prisma.empty;
 
-    const result = await this.db.$queryRaw<
-      Array<{ category_id: string; centroid: string; sample_count: bigint }>
-    >`
+    const result = await this.db.$queryRaw<RawCentroidRow[]>`
       WITH article_embeddings AS (
         -- Get distinct articles per category with their embeddings
         SELECT DISTINCT ON (tcm."categoryId", ae."articleId")

--- a/lib/personalization/types.ts
+++ b/lib/personalization/types.ts
@@ -128,6 +128,7 @@ export interface CategoryCentroid {
  */
 export interface CentroidComputationResult {
   categoryId: string;
+  slug?: string;
   success: boolean;
   sampleCount?: number;
   error?: string;

--- a/scripts/personalization/compute-centroids.ts
+++ b/scripts/personalization/compute-centroids.ts
@@ -38,6 +38,18 @@ interface CLIOptions {
   statsOnly: boolean;
 }
 
+/**
+ * Require a value for an option, exit with error if missing
+ */
+function requireOptionValue(option: string, value: string | undefined): string {
+  if (!value || value.startsWith('-')) {
+    console.error(`Error: ${option} requires a value`);
+    printHelp();
+    process.exit(1);
+  }
+  return value;
+}
+
 function parseArgs(): CLIOptions {
   const args = process.argv.slice(2);
   const options: CLIOptions = {
@@ -59,21 +71,29 @@ function parseArgs(): CLIOptions {
         options.statsOnly = true;
         break;
       case '--category':
-        options.categoryId = args[++i];
+        options.categoryId = requireOptionValue('--category', args[++i]);
         break;
       case '--embedding-key':
-        options.embeddingKey = args[++i];
+        options.embeddingKey = requireOptionValue('--embedding-key', args[++i]);
         break;
       case '--model':
-        options.model = args[++i];
+        options.model = requireOptionValue('--model', args[++i]);
         break;
-      case '--version':
-        options.version = parseInt(args[++i], 10);
+      case '--version': {
+        const value = requireOptionValue('--version', args[++i]);
+        const parsed = parseInt(value, 10);
+        if (isNaN(parsed)) {
+          console.error(`Error: --version must be a number, got: ${value}`);
+          process.exit(1);
+        }
+        options.version = parsed;
         break;
+      }
       case '--help':
       case '-h':
         printHelp();
         process.exit(0);
+        break; // Explicit break to avoid fallthrough warning
       default:
         console.error(`Unknown option: ${arg}`);
         printHelp();
@@ -173,12 +193,7 @@ async function main(): Promise<void> {
       version: options.version,
     });
 
-    // Get category slugs for better output
-    const categories = await prisma.interestCategory.findMany({
-      select: { id: true, slug: true },
-    });
-    const slugMap = new Map(categories.map((c) => [c.id, c.slug]));
-
+    // Results now include slug, no need for separate query
     console.log('\nResults:');
     const successful = results.filter((r) => r.success);
     const failed = results.filter((r) => !r.success);
@@ -186,7 +201,7 @@ async function main(): Promise<void> {
     console.log(`  Successful: ${successful.length}/${results.length}`);
 
     for (const result of results) {
-      const slug = slugMap.get(result.categoryId) ?? 'unknown';
+      const slug = result.slug ?? 'unknown';
       const status = result.success ? '✓' : '✗';
       const samples = result.sampleCount ?? 0;
       console.log(`    ${status} ${slug}: ${samples} articles`);


### PR DESCRIPTION
## Summary

パーソナライゼーション機能のPR 2/4: Centroid計算サービスの実装

### 変更内容

- `CentroidService` クラスを追加
  - pgvectorの`AVG()`集約関数を使用した効率的なSQL計算
  - TagCategoryMapping → _ArticleToTag → ArticleEmbedding のJOIN
  - カテゴリ単位での記事重複排除（複数タグを持つ記事対応）
  - dry-runモード対応
  - 単一カテゴリ・全カテゴリ計算対応
- バッチスクリプト `compute-centroids.ts` を追加
  - `--dry-run`, `--category`, `--stats` オプション対応
- ユニットテスト（8テストケース）

### PR シリーズ

- [x] PR 1: DBスキーマ + 基本ファイル (#268)
- [x] **PR 2: Centroid計算サービス** (このPR)
- [ ] PR 3: フィルタリングサービス + APIエンドポイント
- [ ] PR 4: フロントエンドUIコンポーネント

### 技術詳細

```sql
-- Centroid計算クエリの概要
WITH article_embeddings AS (
  SELECT DISTINCT ON (tcm."categoryId", ae."articleId")
    tcm."categoryId", ae.embedding
  FROM "TagCategoryMapping" tcm
  JOIN "_ArticleToTag" at ON at."B" = tcm."tagId"
  JOIN "ArticleEmbedding" ae ON ae."articleId" = at."A"
  WHERE ae."embeddingKey" = 'summary'
)
SELECT category_id, AVG(embedding)::text as centroid, COUNT(*) as sample_count
FROM article_embeddings
GROUP BY category_id
```

### 使用方法

```bash
# 全カテゴリのcentroidを計算
npx tsx scripts/personalization/compute-centroids.ts

# dry-runモード（DB書き込みなし）
npx tsx scripts/personalization/compute-centroids.ts --dry-run

# 統計のみ表示
npx tsx scripts/personalization/compute-centroids.ts --stats
```

## Test plan

- [x] ユニットテスト通過（8/8）
- [x] TypeScriptエラーなし
- [x] ESLintエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * カテゴリーごとのセントロイド埋め込みを一括／単一で計算・更新できる機能を追加しました。
  * ドライラン、統計表示、埋め込みキーやモデル指定などのオプションを備えたコマンドラインツールを追加しました。
  * 計算結果にカテゴリ識別用のスラッグを含めるよう拡張しました。

* **テスト**
  * セントロイド計算処理の包括的なユニットテストを追加しました（成功・エラー・未サンプル・統計ケースなど）。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->