### PR TITLE
fix(scheduler): improve exit condition to handle skipped articles correctly

### DIFF
--- a/__tests__/scripts/scheduled/manage-summaries.test.ts
+++ b/__tests__/scripts/scheduled/manage-summaries.test.ts
@@ -187,4 +187,46 @@ describe('manage-summaries script', () => {
       expect(mockPrisma.$disconnect).toHaveBeenCalled();
     });
   });
+
+  describe('exit code conditions', () => {
+    it('should exit 0 when all articles are skipped (processed=0)', async () => {
+      mockManager.generateSummaries.mockResolvedValue({ generated: 0, errors: 0, skipped: 50 });
+      process.argv = ['node', 'script.ts', 'generate'];
+
+      const { main } = await import('@/scripts/scheduled/manage-summaries');
+      await main();
+
+      expect(process.exitCode).toBeUndefined(); // Success
+    });
+
+    it('should exit 1 when all processed articles fail (generated=0, errors>0)', async () => {
+      mockManager.generateSummaries.mockResolvedValue({ generated: 0, errors: 5, skipped: 45 });
+      process.argv = ['node', 'script.ts', 'generate'];
+
+      const { main } = await import('@/scripts/scheduled/manage-summaries');
+      await main();
+
+      expect(process.exitCode).toBe(1);
+    });
+
+    it('should exit 0 on partial success (generated>0, errors>0)', async () => {
+      mockManager.generateSummaries.mockResolvedValue({ generated: 3, errors: 2, skipped: 45 });
+      process.argv = ['node', 'script.ts', 'generate'];
+
+      const { main } = await import('@/scripts/scheduled/manage-summaries');
+      await main();
+
+      expect(process.exitCode).toBeUndefined(); // Success
+    });
+
+    it('should handle skipped being undefined', async () => {
+      mockManager.generateSummaries.mockResolvedValue({ generated: 0, errors: 0 }); // no skipped field
+      process.argv = ['node', 'script.ts', 'generate'];
+
+      const { main } = await import('@/scripts/scheduled/manage-summaries');
+      await main();
+
+      expect(process.exitCode).toBeUndefined(); // Success
+    });
+  });
 });

--- a/scripts/scheduled/manage-summaries.ts
+++ b/scripts/scheduled/manage-summaries.ts
@@ -203,11 +203,20 @@ async function main() {
     console.error(`   スキップ: ${result.skipped ?? 0} (content missing/too short)`);
     console.error(`   エラー: ${result.errors}`);
 
-    // エラー終了条件: 全記事がエラーの場合のみexit 1（一部成功なら正常終了）
-    // スキップは正常扱い
-    if (result.errors > 0 && result.generated === 0) {
-      console.error('\n[WARN] All articles failed to generate summaries');
+    // 実際に処理を試みた件数（スキップを除く）
+    const processed = result.generated + result.errors;
+
+    // 終了条件の判定
+    if (processed === 0) {
+      // 処理対象が0件の場合は成功終了（スキップのみなら正常）
+      console.error('\n[INFO] No articles to process (all skipped). Exiting successfully.');
+    } else if (result.generated === 0) {
+      // 処理対象があったが全て失敗した場合のみexit 1
+      console.error('\n[WARN] All processed articles failed to generate summaries');
       process.exitCode = 1;
+    } else if (result.errors > 0) {
+      // 一部成功・一部失敗は警告のみ（正常終了）
+      console.error(`\n[WARN] Partial success: ${result.generated} generated, ${result.errors} failed, ${result.skipped ?? 0} skipped`);
     }
   } catch (error) {
     console.error('実行エラー:', error);


### PR DESCRIPTION
## Summary
- Fix GHA workflow exit condition in `manage-summaries.ts` to distinguish between "all skipped" and "all failed" scenarios
- Calculate `processed = generated + errors` (skips excluded) and use it for exit decisions
- Exit 0 when all articles are skipped (no content), exit 1 only when all processed articles fail

## Implementation Details

Modified exit condition logic at `scripts/scheduled/manage-summaries.ts` (L206-220):

| Condition | Exit Code | Behavior |
|-----------|-----------|----------|
| `processed === 0` | 0 (success) | All articles skipped - normal |
| `generated === 0 && processed > 0` | 1 (failure) | All attempts failed |
| `errors > 0 && generated > 0` | 0 (success) | Partial success with warning log |

**Note**: Warnings are logged to stderr (`console.error`) but do not affect exit code. GHA job status reflects only exit code.

Added 4 test cases for exit code conditions in `__tests__/scripts/scheduled/manage-summaries.test.ts`:
- All skipped (processed=0) -> exit 0
- All failed (generated=0, errors>0) -> exit 1
- Partial success (generated>0, errors>0) -> exit 0
- Skipped field undefined -> exit 0

## Test Results
- 15/15 tests passing
- All exit code condition scenarios covered

## Checklist
- [x] Tests passing
- [x] No breaking changes
- [x] Verified with Docker build

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * スクリプトの終了コード動作を検証する包括的なテストスイートを追加

* **バグ修正**
  * 処理状況に基づいた終了コード割り当てロジックを改善
  * エラーハンドリング時の終了コード処理を強化

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->