### PR TITLE
fix(fetchers): add robust thumbnail URL validation in DocswellFetcher

### DIFF
--- a/__tests__/fetchers/docswell.test.ts
+++ b/__tests__/fetchers/docswell.test.ts
@@ -128,6 +128,18 @@ describe('DocswellFetcher', () => {
         const url = 'file:///etc/passwd';
         expect(validateThumbnailUrl(url)).toBeUndefined();
       });
+
+      it('should reject vbscript: URLs', () => {
+        const url = 'vbscript:msgbox("XSS")';
+        expect(validateThumbnailUrl(url)).toBeUndefined();
+      });
+
+      it('should reject uppercase protocol variants', () => {
+        expect(validateThumbnailUrl('JAVASCRIPT:alert(1)')).toBeUndefined();
+        expect(validateThumbnailUrl('JavaScript:alert(1)')).toBeUndefined();
+        expect(validateThumbnailUrl('VBSCRIPT:msgbox("XSS")')).toBeUndefined();
+        expect(validateThumbnailUrl('DATA:image/png;base64,xyz')).toBeUndefined();
+      });
     });
 
     describe('invalid URLs - host rejection', () => {
@@ -403,7 +415,8 @@ describe('DocswellFetcher', () => {
     });
 
     it('should handle fetch errors gracefully', async () => {
-      (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+      // Use mockRejectedValue (not Once) to handle retry attempts
+      (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
 
       const result = await fetcher.fetch();
 

--- a/lib/fetchers/docswell.ts
+++ b/lib/fetchers/docswell.ts
@@ -59,9 +59,10 @@ export class DocswellFetcher extends BaseFetcher {
     const trimmedUrl = url.trim();
     if (!trimmedUrl || trimmedUrl.length > 2048) return undefined;
 
-    // Reject dangerous protocols
-    if (trimmedUrl.startsWith('javascript:') || trimmedUrl.startsWith('data:') || 
-        trimmedUrl.startsWith('blob:') || trimmedUrl.startsWith('file:')) {
+    // Reject dangerous protocols (case-insensitive early check; URL class normalizes later)
+    const lowerUrl = trimmedUrl.toLowerCase();
+    if (lowerUrl.startsWith('javascript:') || lowerUrl.startsWith('data:') ||
+        lowerUrl.startsWith('vbscript:') || lowerUrl.startsWith('blob:') || lowerUrl.startsWith('file:')) {
       return undefined;
     }
 
@@ -218,16 +219,16 @@ export class DocswellFetcher extends BaseFetcher {
       // 一時的に閲覧数フィルタリングを無効化してテスト
       // 後でRSSパーサーのカスタムフィールドを修正する必要がある
       
-      // サムネイルを取得
+      // サムネイルを取得（検証済みURLのみ使用）
       let thumbnail: string | undefined;
       const thumbnailElement = (item as DocswellRSSItem)['media:thumbnail'];
       if (thumbnailElement) {
         if (typeof thumbnailElement === 'string') {
-          thumbnail = thumbnailElement;
+          thumbnail = this.validateThumbnailUrl(thumbnailElement);
         } else if (thumbnailElement.$ && thumbnailElement.$.url) {
-          thumbnail = thumbnailElement.$.url;
+          thumbnail = this.validateThumbnailUrl(thumbnailElement.$.url);
         } else if (thumbnailElement.url) {
-          thumbnail = thumbnailElement.url;
+          thumbnail = this.validateThumbnailUrl(thumbnailElement.url);
         }
       }
       
@@ -242,7 +243,7 @@ export class DocswellFetcher extends BaseFetcher {
         publishedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
         author: author,
         tags: this.extractTags(item.title + ' ' + (item.contentSnippet || '')),
-        thumbnail: typeof thumbnail === 'string' ? thumbnail : undefined,
+        thumbnail,
       });
       
       processedCount++;


### PR DESCRIPTION
## Summary
- DocswellフェッチャーにサムネイルURL検証を追加し、不正データ（"1K Views"等のテキスト）の保存を防止
- 許可ホスト名リスト、プロトコル検証、画像拡張子検証による多層防御を実装
- 52件の包括的なテストケースを追加

## Changes
### lib/fetchers/docswell.ts
- `ALLOWED_THUMBNAIL_HOSTS`: 許可ホスト名リスト（docswell.com, www.docswell.com, bcdn.docswell.com）
- `ALLOWED_IMAGE_PATTERN`: 画像拡張子正規表現（jpg, jpeg, png, webp, gif）
- `validateThumbnailUrl()`: URL検証メソッド
  - 危険プロトコル拒否（javascript:, data:, blob:, file:）
  - HTTPS強制
  - userinfo拒否（username/password付きURL）
  - URL長制限（2048文字）
- `findValidThumbnailImg()`: 複合戦略によるサムネイル取得
  1. alt="slide-thumbnail"を優先
  2. フォールバック: 最初の有効な画像

### __tests__/fetchers/docswell.test.ts
- 52件のテストケース（validateThumbnailUrl: 36件、findValidThumbnailImg: 14件、fetch: 2件）

## Root Cause
2025-12-06 11:57にDocswellサイトが一時的に異常HTMLを返し、3件の記事に"1K Views"等のテキストがサムネイルとして保存された。

## Test plan
- [x] `npm run docker:test:file` - 52/52テストパス
- [x] `npm run type-check` - 型エラーなし
- [x] `npm run lint` - エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **テスト**
  * 記事サムネイル処理の包括的なテストスイートを追加しました（URL検証、HTML解析、さまざまなエッジケースを網羅）。

* **改善**
  * サムネイル検証と抽出のロジックを強化し、プロトコル正規化・ホスト許可・拡張子/幅パラメータの検査などで堅牢性とセキュリティを向上。
  * RSS由来のサムネイル処理も正規化・検証されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->