### PR TITLE
fix(pm2): add embedding recovery env vars to scheduler

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -19,7 +19,9 @@ module.exports = {
         FETCHER_TIMEOUT_MS: process.env.FETCHER_TIMEOUT_MS || '60000', // Per-source fetch timeout (ms)
         SKIP_POST_SAVE_ENRICHMENT: '0', // Enable post-save enrichment (required for embedding job enqueue)
         POST_SAVE_ENRICH_TIMEOUT_MS: '10000', // Post-save enrichment timeout (10s)
-        POST_SAVE_ENRICH_SLEEP_MS: '0' // No sleep between enrichments (was 2000ms)
+        POST_SAVE_ENRICH_SLEEP_MS: '0', // No sleep between enrichments (was 2000ms)
+        EMBEDDING_STUCK_THRESHOLD_MINUTES: process.env.EMBEDDING_STUCK_THRESHOLD_MINUTES || '30', // Stuck job detection threshold
+        EMBEDDING_RECOVERY_BATCH_LIMIT: process.env.EMBEDDING_RECOVERY_BATCH_LIMIT || '100' // Max jobs to reset per recovery run
       },
       error_file: 'logs/scheduler-error.log',
       out_file: 'logs/scheduler-out.log',


### PR DESCRIPTION
## Summary

- Add `EMBEDDING_STUCK_THRESHOLD_MINUTES` and `EMBEDDING_RECOVERY_BATCH_LIMIT` environment variables to techtrend-scheduler PM2 config

## Background

PR #298 で追加したembedding自動リカバリ機能の環境変数をecosystem.config.jsに追加し忘れていました。

## Changes

| 環境変数 | デフォルト | 説明 |
|----------|-----------|------|
| `EMBEDDING_STUCK_THRESHOLD_MINUTES` | 30 | スタック判定の閾値（分） |
| `EMBEDDING_RECOVERY_BATCH_LIMIT` | 100 | 1回あたりの最大リセット件数 |

## Test plan

- [x] PM2 reload で環境変数が設定されることを確認
- [x] `pm2 env 1 | grep EMBEDDING_` で値を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **設定**
  * techtrend-scheduler アプリに2つの新しい環境変数を追加しました：EMBEDDING_STUCK_THRESHOLD_MINUTES（デフォルト値：30）およびEMBEDDING_RECOVERY_BATCH_LIMIT（デフォルト値：100）。これらの設定により、埋め込み処理の動作をカスタマイズできるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->