### PR TITLE
feat(ui): add translation badge for auto-translated articles

### DIFF
--- a/__tests__/components/ArticleCard.test.tsx
+++ b/__tests__/components/ArticleCard.test.tsx
@@ -486,6 +486,73 @@ describe('ArticleCard', () => {
     });
   });
 
+  describe('TranslationBadge display logic', () => {
+    it('displays translation badge when article has translatedTitle', () => {
+      const translatedArticle = createMockArticleWithRelations({
+        article: {
+          title: 'Original English Title',
+          translatedTitle: '翻訳された日本語タイトル',
+        },
+      });
+
+      renderWithProviders(<ArticleCard article={translatedArticle} />);
+
+      // TranslationBadgeが表示される
+      expect(screen.getByText('自動翻訳')).toBeInTheDocument();
+      // 翻訳タイトルが表示される（元タイトルではなく）
+      expect(screen.getByText('翻訳された日本語タイトル')).toBeInTheDocument();
+    });
+
+    it('does not display translation badge when translatedTitle is null', () => {
+      const nonTranslatedArticle = createMockArticleWithRelations({
+        article: {
+          title: 'Japanese Article Title',
+          translatedTitle: null,
+        },
+      });
+
+      renderWithProviders(<ArticleCard article={nonTranslatedArticle} />);
+
+      // TranslationBadgeが表示されない
+      expect(screen.queryByText('自動翻訳')).not.toBeInTheDocument();
+      // 元タイトルが表示される
+      expect(screen.getByText('Japanese Article Title')).toBeInTheDocument();
+    });
+
+    it('does not display translation badge when translatedTitle is undefined', () => {
+      renderWithProviders(<ArticleCard article={mockArticle} />);
+
+      // mockArticleにはtranslatedTitleがない
+      expect(screen.queryByText('自動翻訳')).not.toBeInTheDocument();
+    });
+
+    it('translation badge has correct accessibility attributes', () => {
+      const translatedArticle = createMockArticleWithRelations({
+        article: {
+          translatedTitle: 'Translated Title',
+        },
+      });
+
+      renderWithProviders(<ArticleCard article={translatedArticle} />);
+
+      const badge = screen.getByText('自動翻訳');
+      expect(badge).toHaveAttribute('aria-label', 'この記事は英語から自動翻訳されています');
+      expect(badge).toHaveAttribute('title', 'この記事は英語から自動翻訳されています');
+    });
+
+    it('translation badge has data-testid for integration testing', () => {
+      const translatedArticle = createMockArticleWithRelations({
+        article: {
+          translatedTitle: 'Translated Title',
+        },
+      });
+
+      renderWithProviders(<ArticleCard article={translatedArticle} />);
+
+      expect(screen.getByTestId('translation-badge')).toBeInTheDocument();
+    });
+  });
+
   describe('qualityScore display logic', () => {
     it('displays summary for low quality score articles instead of thumbnail', () => {
       const lowQualityArticle = createMockArticleWithRelations({

--- a/__tests__/components/ui/translation-badge.test.tsx
+++ b/__tests__/components/ui/translation-badge.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { TranslationBadge } from '@/components/ui/translation-badge';
+
+describe('TranslationBadge', () => {
+  it('renders with correct text', () => {
+    render(<TranslationBadge />);
+    expect(screen.getByText('自動翻訳')).toBeInTheDocument();
+  });
+
+  it('has correct aria-label for accessibility', () => {
+    render(<TranslationBadge />);
+    const badge = screen.getByLabelText('この記事は英語から自動翻訳されています');
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('has correct title attribute for tooltip', () => {
+    render(<TranslationBadge />);
+    const badge = screen.getByTitle('この記事は英語から自動翻訳されています');
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    render(<TranslationBadge className="custom-class" />);
+    const badge = screen.getByText('自動翻訳');
+    expect(badge).toHaveClass('custom-class');
+  });
+
+  it('passes through additional props', () => {
+    render(<TranslationBadge data-testid="test-badge" />);
+    expect(screen.getByTestId('test-badge')).toBeInTheDocument();
+  });
+
+  it('has correct styling for light mode', () => {
+    render(<TranslationBadge />);
+    const badge = screen.getByText('自動翻訳');
+    // Check for blue color classes
+    expect(badge).toHaveClass('bg-blue-50');
+    expect(badge).toHaveClass('text-blue-700');
+    expect(badge).toHaveClass('border-blue-200');
+  });
+
+  it('has dark mode classes', () => {
+    render(<TranslationBadge />);
+    const badge = screen.getByText('自動翻訳');
+    // Check for dark mode classes
+    expect(badge).toHaveClass('dark:bg-blue-950');
+    expect(badge).toHaveClass('dark:text-blue-400');
+    expect(badge).toHaveClass('dark:border-blue-800');
+  });
+});

--- a/app/articles/[id]/page.tsx
+++ b/app/articles/[id]/page.tsx
@@ -188,6 +188,22 @@ export default async function ArticlePage({ params, searchParams }: PageProps) {
             </CardHeader>
 
             <CardContent className="space-y-4 !-mt-4">
+              {/* Translation notice for translated articles */}
+              {article.translatedTitle && (
+                <div
+                  role="note"
+                  className="flex items-center gap-2 px-4 py-2 bg-blue-50 border-l-4 border-blue-400 dark:bg-blue-950/30 dark:border-blue-600 rounded-sm"
+                  data-testid="translation-notice"
+                >
+                  <svg className="w-4 h-4 text-blue-600 dark:text-blue-400 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                    <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+                  </svg>
+                  <p className="text-sm text-blue-700 dark:text-blue-300">
+                    このタイトルと要約は英語記事から自動翻訳されています
+                  </p>
+                </div>
+              )}
+
               {/* スライドサービスまたは短い記事の場合はサムネイル表示、それ以外は詳細要約表示 */}
               {(isSlideService || isShortArticle) && article.thumbnail ? (
                 <>

--- a/app/components/article/card.tsx
+++ b/app/components/article/card.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils';
 import { FavoriteButton } from '@/app/components/article/favorite-button';
 import { ShareButton } from '@/app/components/article/share-button';
 import { OptimizedImage } from '@/app/components/common/optimized-image';
+import { TranslationBadge } from '@/components/ui/translation-badge';
 
 export function ArticleCard({
   article,
@@ -193,6 +194,9 @@ export function ArticleCard({
                     <span className={cn("w-2 h-2 rounded-full shrink-0", sourceColor.dot)} aria-hidden="true" />
                     {article.companyName ?? article.source.name}
                   </BadgeV2>
+                )}
+                {article.translatedTitle && (
+                  <TranslationBadge data-testid="translation-badge" />
                 )}
               </div>
               <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">

--- a/app/components/article/list-item.tsx
+++ b/app/components/article/list-item.tsx
@@ -10,6 +10,7 @@ import { getSourceColor } from '@/lib/utils/source-colors';
 import type { ArticleListItemProps } from '@/types/components';
 import { cn } from '@/lib/utils';
 import { FavoriteButton } from '@/components/article/favorite-button';
+import { TranslationBadge } from '@/components/ui/translation-badge';
 
 export function ArticleListItem({
   article,
@@ -99,6 +100,9 @@ export function ArticleListItem({
                 <Eye className="h-3 w-3 mr-0.5" />
                 未読
               </Badge>
+            )}
+            {article.translatedTitle && (
+              <TranslationBadge className="flex-shrink-0" />
             )}
             <h3 className="text-sm font-medium line-clamp-1 text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400">
               {article.translatedTitle || article.title}

--- a/app/components/article/related-articles.tsx
+++ b/app/components/article/related-articles.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { LinkIcon, TrendingUp, ChevronDown, ChevronUp, Network } from 'lucide-react';
+import { TranslationBadge } from '@/components/ui/translation-badge';
 import { formatDate } from '@/lib/utils/date';
 import { useRelatedArticles } from '@/hooks/use-related-articles';
 
@@ -137,6 +138,9 @@ export function RelatedArticles({
                       <TrendingUp className="h-3 w-3 mr-0.5" />
                       New
                     </Badge>
+                  )}
+                  {article.translatedTitle && (
+                    <TranslationBadge className="text-xs h-5" />
                   )}
                 </div>
 

--- a/app/components/popular/PopularArticles.tsx
+++ b/app/components/popular/PopularArticles.tsx
@@ -13,6 +13,7 @@ import { cn } from '@/lib/utils';
 import type { ArticleWithRelations } from '@/types/models';
 import { RankBadge } from './rank-badge';
 import { TrendIndicator } from './trend-indicator';
+import { TranslationBadge } from '@/components/ui/translation-badge';
 import { ScoreTooltip } from './score-tooltip';
 import { ShareButton } from './share-button';
 import { PresetFilters, type PeriodType, type MetricType } from './preset-filters';
@@ -138,6 +139,9 @@ export function PopularArticles({
                     </p>
                     <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
                       <span>{article.source.name}</span>
+                      {article.translatedTitle && (
+                        <TranslationBadge className="text-xs" />
+                      )}
                       <span aria-hidden="true">-</span>
                       <span>{formatDate(article.publishedAt)}</span>
                     </div>
@@ -238,6 +242,9 @@ export function PopularArticles({
                       <Badge variant="secondary" className="text-xs">
                         {article.source.name}
                       </Badge>
+                      {article.translatedTitle && (
+                        <TranslationBadge className="text-xs" />
+                      )}
                       {article.difficulty && (
                         <Badge
                           variant="outline"

--- a/app/digest/page.tsx
+++ b/app/digest/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { CalendarIcon, TrendingUpIcon, TagIcon, RefreshCwIcon, ExternalLinkIcon, ChevronRightIcon } from 'lucide-react';
+import { TranslationBadge } from '@/components/ui/translation-badge';
 
 interface DigestArticle {
   id: string;
@@ -234,6 +235,9 @@ export default function DigestPage() {
                     <Badge variant="outline" className="text-xs">
                       {article.source.name}
                     </Badge>
+                    {article.translatedTitle && (
+                      <TranslationBadge className="text-xs" />
+                    )}
                     {article.tags?.slice(0, 3).map((tag) => (
                       <Badge key={tag.name} variant="secondary" className="text-xs">
                         {tag.name}

--- a/components/recommendation/recommendation-card.tsx
+++ b/components/recommendation/recommendation-card.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Calendar, Star, Tag } from 'lucide-react';
+import { TranslationBadge } from '@/components/ui/translation-badge';
 import { formatDate } from '@/lib/utils/date';
 import { getSourceColor } from '@/lib/utils/source-colors';
 import { cn } from '@/lib/utils';
@@ -26,12 +27,17 @@ export function RecommendationCard({ article, showReasons = true }: Recommendati
     <Card className="hover:shadow-lg transition-shadow duration-200" data-testid="recommendation-card">
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between mb-2">
-          <Badge 
-            variant="secondary" 
-            className={cn("text-xs font-medium", sourceColor.tag)}
-          >
-            {article.sourceName}
-          </Badge>
+          <div className="flex items-center gap-2">
+            <Badge
+              variant="secondary"
+              className={cn("text-xs font-medium", sourceColor.tag)}
+            >
+              {article.sourceName}
+            </Badge>
+            {article.translatedTitle && (
+              <TranslationBadge className="text-xs" />
+            )}
+          </div>
           <div className="flex items-center gap-2">
             <div className="flex items-center gap-1">
               <Star className="h-3 w-3 text-yellow-500" />

--- a/components/ui/translation-badge.tsx
+++ b/components/ui/translation-badge.tsx
@@ -1,0 +1,31 @@
+import { BadgeV2 } from '@/components/ui-v2/badge-v2';
+import { cn } from '@/lib/utils';
+
+interface TranslationBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  className?: string;
+}
+
+/**
+ * TranslationBadge - Displays a badge indicating the article is auto-translated
+ *
+ * Usage: Show this badge when article.translatedTitle exists
+ * Example: {article.translatedTitle && <TranslationBadge />}
+ */
+export function TranslationBadge({ className, ...props }: TranslationBadgeProps) {
+  return (
+    <BadgeV2
+      variant="outline"
+      className={cn(
+        'text-xs',
+        'bg-blue-50 text-blue-700 border-blue-200 hover:bg-blue-100',
+        'dark:bg-blue-950 dark:text-blue-400 dark:border-blue-800 dark:hover:bg-blue-900',
+        className
+      )}
+      aria-label="この記事は英語から自動翻訳されています"
+      title="この記事は英語から自動翻訳されています"
+      {...props}
+    >
+      自動翻訳
+    </BadgeV2>
+  );
+}


### PR DESCRIPTION
## Summary
- Add TranslationBadge component to indicate when article titles/summaries are auto-translated from English
- Display badge across all article views (cards, lists, detail pages, recommendations)
- Help users set expectations before visiting original English articles

## Implementation Details
- Created reusable TranslationBadge component with WCAG-compliant accessibility (aria-label, title)
- Blue accent color scheme with dark mode support
- Badge displays when `article.translatedTitle` exists
- Added to 7 components: ArticleCard, ArticleListItem, ArticleDetail, RelatedArticles, PopularArticles, DigestPage, RecommendationCard
- Skipped agent-answer-panel.tsx (inline markdown links would be visually cluttered)

## Test Results
- TranslationBadge unit tests: 7 tests passed
- ArticleCard integration tests: 5 new tests added, 33 total tests passed
- Type check: Passed
- Lint: Passed (1 pre-existing warning)
- Build: Passed

## UX Principles Applied
- Framing effect: "自動翻訳" label sets expectations
- Progressive disclosure: Badge in lists, detailed notice on detail page
- Visual hierarchy: Lower priority than NEW/未読 badges

## Checklist
- [x] Tests passing
- [x] Type check passing
- [x] Build verified
- [x] WCAG accessibility attributes added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 自動翻訳された記事に対して、翻訳バッジを表示するようになりました。バッジは記事カード、リスト、ランキング、推奨記事など複数の箇所に表示されます。

* **テスト**
  * 翻訳バッジのコンポーネント機能とアクセシビリティを検証するテストスイートを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->