### PR TITLE
feat(enricher): add arXiv HTML fulltext extraction for improved summaries

### DIFF
--- a/__tests__/enrichers/arxiv-ai.test.ts
+++ b/__tests__/enrichers/arxiv-ai.test.ts
@@ -103,6 +103,8 @@ describe('ArxivAIEnricher', () => {
         { url: 'https://arxiv.org/html/2412.01234v1', expected: '2412.01234' },
         { url: 'https://www.arxiv.org/abs/2312.12345', expected: '2312.12345' },
         { url: 'https://arxiv.org/abs/2401.00001?context=cs.AI', expected: '2401.00001' },
+        // arXiv: prefix format in URL (e.g., search results, external references)
+        { url: 'https://arxiv.org/search?query=arXiv:2412.01234', expected: '2412.01234' },
       ];
 
       test.each(testCases)('$url -> $expected', ({ url, expected }) => {
@@ -190,6 +192,22 @@ describe('ArxivAIEnricher', () => {
 
       // Should fallback to main/article extraction, but since there's none, returns empty
       expect(content).toBe('');
+    });
+
+    test('falls back to main/article when no target sections exist', () => {
+      // Long enough content (>500 chars) in article without section tags
+      const longContent = 'This is the main article content that discusses various topics. '.repeat(20);
+      const htmlWithArticle = `
+        <article>
+          <h1>Paper Title</h1>
+          <p>${longContent}</p>
+        </article>
+      `;
+      const content = extractContent(htmlWithArticle);
+
+      // Should extract content from article as fallback
+      expect(content.length).toBeGreaterThan(500);
+      expect(content).toContain('main article content');
     });
 
     test('enforces maximum content length', () => {
@@ -297,10 +315,17 @@ describe('ArxivAIEnricher', () => {
     });
 
     test('returns null for non-arXiv URLs', async () => {
+      // Mock to ensure test is deterministic (no actual network request)
+      // enrichFromAbstract is called as fallback, but fails to extract content
+      const mockFetch = jest.fn().mockRejectedValue(new Error('Network error'));
+      jest.spyOn(BaseContentEnricher.prototype, 'fetchWithRetry').mockImplementation(mockFetch);
+
       const result = await enricher.enrich('https://example.com/paper');
 
-      // Should return null because canHandle returns false (ID extraction fails)
+      // Should return null because enrichFromAbstract fails
       expect(result).toBeNull();
+      // Verify mock was called (via enrichFromAbstract fallback)
+      expect(mockFetch).toHaveBeenCalled();
     });
   });
 

--- a/lib/enrichers/arxiv-ai.ts
+++ b/lib/enrichers/arxiv-ai.ts
@@ -46,9 +46,10 @@ export class ArxivAIEnricher extends BaseContentEnricher {
         const htmlContent = await this.fetchAndExtractHtmlVersion(arxivId);
         if (htmlContent) {
           // HTML版から取得成功 - メタデータを追加して返却
-          // 抄録ページからメタデータのみ取得
+          // 抄録ページからメタデータのみ取得（入力URLがpdf/htmlの場合に備えてabs URLを明示構築）
           try {
-            const absHtml = await this.fetchWithRetry(url);
+            const absUrl = `https://arxiv.org/abs/${arxivId}`;
+            const absHtml = await this.fetchWithRetry(absUrl);
             const metadata = this.extractMetadata(absHtml);
             const thumbnail = this.extractThumbnail(absHtml);
             const content = metadata ? `${metadata}\n\n${htmlContent}` : htmlContent;
@@ -391,9 +392,9 @@ export class ArxivAIEnricher extends BaseContentEnricher {
         text = text.replace(/(\[MATH\]\s*)+/g, '[MATH] ');
         text = text.replace(/\s+/g, ' ').trim();
 
-        // 長さ制限
+        // 長さ制限（ワード境界で切断してマルチバイト文字の破損を防止）
         if (text.length > maxTotalLength) {
-          text = text.substring(0, maxTotalLength) + '...';
+          text = this.truncateAtWordBoundary(text, maxTotalLength);
         }
 
         if (text.length > 500) {
@@ -403,5 +404,26 @@ export class ArxivAIEnricher extends BaseContentEnricher {
     }
 
     return contents.join('\n\n');
+  }
+
+  /**
+   * ワード境界でテキストを切断（マルチバイト文字の破損を防止）
+   */
+  private truncateAtWordBoundary(text: string, maxLength: number): string {
+    if (text.length <= maxLength) {
+      return text;
+    }
+
+    // maxLength位置より前の最後のスペースを探す
+    const truncated = text.substring(0, maxLength);
+    const lastSpaceIndex = truncated.lastIndexOf(' ');
+
+    // スペースが見つかれば、そこで切断
+    if (lastSpaceIndex > maxLength * 0.8) {
+      return truncated.substring(0, lastSpaceIndex) + '...';
+    }
+
+    // スペースが見つからないか、あまりにも前方の場合は単純切断
+    return truncated + '...';
   }
 }


### PR DESCRIPTION
## Summary
- Add HTML (experimental) version extraction for arXiv papers to get full paper content instead of abstracts only
- New papers (2024+) now extract ~26K-31K chars of full content vs ~1.5K char abstracts
- Fallback to abstract-based extraction for older papers without HTML version

## Implementation Details

### New Methods
- `extractArxivIdFromUrl()`: Parse arXiv paper IDs from various URL patterns (/abs/, /pdf/, /html/, arXiv:)
- `fetchAndExtractHtmlVersion()`: Fetch HTML version from `https://arxiv.org/html/{id}v1`
- `extractFullContent()`: Extract target sections using cheerio, process math elements, limit content length
- Modified `enrich()` to try HTML version first, fallback to existing abstract-based extraction

### Section Extraction
Target sections (case-insensitive heading match):
- abstract, introduction, method, methodology, approach
- results, experiments, evaluation
- conclusion, discussion, summary

Fallback: If no target sections found, extract from `main`, `article`, or `.content` containers.

### Content Processing
- Math elements (`<math>`, `.MathJax`) replaced with `[MATH]` placeholder
- Script/style/nav/footer elements removed
- Content limited to 32K chars (~8K tokens) by section order
- Consecutive `[MATH]` placeholders consolidated

### Error Handling
- HTTP 404: Fallback to abstract-based extraction (logged as DEBUG)
- Network errors: Fallback to abstract-based extraction
- Uses existing `fetchWithRetry` for rate limiting and retry logic

### Known Limitations
- HTML version hardcodes `v1` - later versions not attempted
- Legacy arXiv IDs (e.g., `hep-th/`, `math/`) not supported
- Math-heavy papers may have many `[MATH]` tokens

## Test Results
- 39 new test cases covering URL validation, ID extraction, HTML parsing, integration tests
- All 165 enricher tests passing
- Type check passing

### End-to-end Verification
| Paper | Content Source | Chars | Summary |
|-------|---------------|-------|---------|
| MSME (2512.04492) | HTML version | 26,408 | Generated |
| Llama 2 (2307.09288) | Fallback (abstract) | 1,881 | Generated |

## Checklist
- [x] Tests passing (39 new + 165 total enricher tests)
- [x] Type check passing
- [x] No breaking changes (existing articles unaffected)
- [x] Fallback ensures backward compatibility

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * arXiv論文のHTML版から導入・方法・結果・結論等を抽出し、利用可能な場合は抄録やメタデータ（タイトル、著者、arXiv ID、カテゴリ、サムネ等）と組み合わせて詳細なコンテンツを返す機能を追加。HTML取得失敗時は抄録ベースへ自動フォールバック。数学表記を[MATH]に置換し長さを制限。

* **テスト**
  * 多様なURLパターンの判定、ID抽出、HTML抽出の正規化と長さ制限、フォールバック経路、HTMLサニタイズとXSS対策を含む包括的なテストを追加。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->