### PR TITLE
fix(ui): constrain thumbnail size in article detail page

### DIFF
--- a/app/articles/[id]/page.tsx
+++ b/app/articles/[id]/page.tsx
@@ -208,6 +208,8 @@ export default async function ArticlePage({ params, searchParams }: PageProps) {
               {(isSlideService || isShortArticle) && article.thumbnail ? (
                 <>
                   <div className="max-w-2xl mx-auto">
+                    {/* max-h-[480px] is a defensive constraint for oversized images.
+                        If max-w-2xl changes, adjust max-h to maintain 16:9 ratio. */}
                     <div className="relative aspect-video max-h-[480px] overflow-hidden rounded-lg bg-[var(--tt-color-surface-muted)]">
                       <OptimizedImage
                         src={article.thumbnail}


### PR DESCRIPTION
## Summary

- Thumbnail images for slide services (Speaker Deck, Docswell) and short articles were displaying too large on wide screens
- Added max-width (672px) and max-height (480px) constraints to thumbnail container
- Applied design tokens for consistent styling

## Implementation Details

### Problem
Thumbnail-only articles (slide services or articles under 500 characters) had oversized images that dominated the screen, with heights reaching ~877px on 1920px viewports.

### Solution
Modified `app/articles/[id]/page.tsx` (lines 208-221):
- Added `max-w-2xl mx-auto` wrapper for 672px max-width with center alignment
- Added `max-h-[480px]` to limit thumbnail height
- Changed background from `bg-gray-100 dark:bg-gray-800` to design token `bg-[var(--tt-color-surface-muted)]`
- Added `transition-opacity duration-200` for smooth fade-in
- Optimized `sizes` attribute to `"(max-width: 768px) 100vw, 672px"`

### Psychology Principles Applied
- Visual Hierarchy: Thumbnail as supplementary info, keeping title/meta as primary
- Cognitive Load: Reduced by constraining image size
- Progressive Disclosure: First view now shows both thumbnail and summary

## Test Results

- Lint: PASSED (0 errors, 1 warning - unrelated)
- Type-check: PASSED
- Security audit: 0 vulnerabilities
- Build: PASSED (75 pages generated)

## Checklist

- [x] Lint passing
- [x] Type-check passing
- [x] Build successful
- [x] Design tokens applied
- [ ] Visual verification pending

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * 記事のサムネイルを中央に整列し、最大幅を設けて表示を安定化しました。
  * サムネイルに高さの上限と滑らかなフェードイン効果を追加し、ビジュアルを向上しました。
  * 画像サイズのロジックを簡素化して、大きな画面での表示を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->