### PR TITLE
fix(config): extend local timeout for arXiv parallel enrichment

### DIFF
--- a/ecosystem.local.config.js
+++ b/ecosystem.local.config.js
@@ -27,7 +27,8 @@ module.exports = {
         NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
         SKIP_POST_SAVE_ENRICHMENT: '0', // Enable post-save enrichment (required for Phase 2)
         COLLECT_FEEDS_CONCURRENCY: '5', // Parallel source processing (30min->10-15min)
-        FETCHER_TIMEOUT_MS: process.env.FETCHER_TIMEOUT_MS || '60000', // Per-source fetch timeout (ms)
+        FETCHER_TIMEOUT_MS: process.env.FETCHER_TIMEOUT_MS || '600000', // Per-source fetch timeout (10 min, extended for arXiv)
+        ARXIV_ENRICHMENT_CONCURRENCY: process.env.ARXIV_ENRICHMENT_CONCURRENCY || '5', // arXiv parallel enrichment
         POST_SAVE_ENRICH_TIMEOUT_MS: '10000', // Post-save enrichment timeout (10s)
         POST_SAVE_ENRICH_SLEEP_MS: '0' // No sleep between enrichments (was 2000ms)
       },


### PR DESCRIPTION
## Summary
- Increase `FETCHER_TIMEOUT_MS` from 60s to 600s (10 min) in local config
- Add `ARXIV_ENRICHMENT_CONCURRENCY` setting for parallel processing
- Sync with `ecosystem.config.js` settings from #309

## Problem
arXiv AI fetch has been failing since 2025-12-05 due to 60s timeout during parallel enrichment of 300-800 articles. The timeout setting in `ecosystem.local.config.js` was not updated when parallel optimization was implemented in #309.

## Root Cause
`ecosystem.config.js` was updated to 600s timeout, but `ecosystem.local.config.js` (used in dev environment) remained at 60s.

## Test plan
- [ ] Verify PM2 environment shows `FETCHER_TIMEOUT_MS: 600000`
- [ ] Verify arXiv AI fetch completes without timeout at next scheduled run (09:45 or 21:45 JST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * フェッチタイムアウトを600秒に延長しました。
  * arXiv並列処理の同時実行数を制御する新しい設定オプションを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->