### PR TITLE
fix(enricher): fetch thumbnail from HTML when oEmbed lacks thumbnail_url

### DIFF
--- a/__tests__/lib/enrichers/speakerdeck.test.ts
+++ b/__tests__/lib/enrichers/speakerdeck.test.ts
@@ -162,5 +162,75 @@ describe('SpeakerDeckEnricher', () => {
       expect(result).not.toBeNull();
       expect(result?.content).toContain('Slides: 42');
     });
+
+    it('should fetch thumbnail from HTML when oEmbed has no thumbnail_url', async () => {
+      // oEmbed succeeds but without thumbnail_url
+      const oEmbedResponse = {
+        type: 'rich',
+        version: '1.0',
+        title: 'Presentation Without Thumbnail',
+        author_name: 'Author',
+        provider_name: 'Speaker Deck',
+        html: '<iframe></iframe>',
+        width: 710,
+        height: 400,
+        // thumbnail_url is intentionally missing
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => oEmbedResponse,
+      });
+
+      // HTML fetch for thumbnail
+      const htmlResponse = `
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta property="og:image" content="https://files.speakerdeck.com/presentations/abc/slide_0.jpg">
+        </head>
+        <body></body>
+        </html>
+      `;
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: async () => htmlResponse,
+      });
+
+      const result = await enricher.enrich(testUrl);
+
+      expect(result).not.toBeNull();
+      expect(result?.content).toContain('Presentation Without Thumbnail');
+      expect(result?.thumbnail).toBe('https://files.speakerdeck.com/presentations/abc/slide_0.jpg');
+    });
+
+    it('should return null thumbnail when HTML fetch fails after oEmbed success', async () => {
+      // oEmbed succeeds but without thumbnail_url
+      const oEmbedResponse = {
+        type: 'rich',
+        version: '1.0',
+        title: 'Presentation Without Thumbnail',
+        author_name: 'Author',
+        provider_name: 'Speaker Deck',
+        html: '<iframe></iframe>',
+        width: 710,
+        height: 400,
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => oEmbedResponse,
+      });
+
+      // HTML fetch fails
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await enricher.enrich(testUrl);
+
+      expect(result).not.toBeNull();
+      expect(result?.content).toContain('Presentation Without Thumbnail');
+      expect(result?.thumbnail).toBeNull();
+    });
   });
 });

--- a/lib/enrichers/speakerdeck.ts
+++ b/lib/enrichers/speakerdeck.ts
@@ -34,16 +34,31 @@ export class SpeakerDeckEnricher extends BaseContentEnricher {
 
   async enrich(url: string): Promise<EnrichedContent | null> {
     try {
-      // Strategy 1: Try oEmbed API first (most reliable)
+      // Strategy 1: Try oEmbed API first (most reliable for content)
       const oEmbedData = await this.fetchOEmbed(url);
 
       if (oEmbedData) {
         const content = this.buildContentFromOEmbed(oEmbedData, url);
-        const thumbnail = oEmbedData.thumbnail_url || null;
+        let thumbnail = oEmbedData.thumbnail_url || null;
+
+        // oEmbedにthumbnailがない場合はHTMLから取得
+        if (!thumbnail) {
+          try {
+            logger.debug({ url }, '[SpeakerDeckEnricher] oEmbed has no thumbnail, fetching from HTML');
+            const html = await this.fetchWithRetry(url);
+            thumbnail = this.extractThumbnail(html);
+          } catch (htmlError) {
+            logger.debug(
+              { error: htmlError, url },
+              '[SpeakerDeckEnricher] Failed to fetch thumbnail from HTML'
+            );
+            // HTMLフェッチ失敗時は無視（contentは取得済み）
+          }
+        }
 
         if (this.isContentSufficient(content, 50)) {
           logger.debug(
-            { url, contentLength: content.length, source: 'oembed' },
+            { url, contentLength: content.length, source: 'oembed', hasThumbnail: !!thumbnail },
             '[SpeakerDeckEnricher] Enrichment succeeded via oEmbed'
           );
           return { content, thumbnail };

--- a/scripts/manual/update-speakerdeck-thumbnails.ts
+++ b/scripts/manual/update-speakerdeck-thumbnails.ts
@@ -121,13 +121,16 @@ async function updateSpeakerDeckThumbnails(): Promise<UpdateResult> {
   };
 
   try {
-    // Speaker Deck記事を取得
+    // Speaker Deck記事を取得（URLベースでフィルタ、はてなブックマーク経由も対象）
     const articles = await prisma.article.findMany({
       where: {
-        source: {
-          name: 'Speaker Deck'
+        url: {
+          contains: 'speakerdeck.com'
         },
-        thumbnail: null  // サムネイルが未設定のもののみ
+        OR: [
+          { thumbnail: null },
+          { thumbnail: '' }
+        ]
       },
       include: {
         source: true
@@ -196,11 +199,11 @@ async function updateSpeakerDeckThumbnails(): Promise<UpdateResult> {
       }
     }
 
-    // サムネイルが既に設定されている記事の確認
+    // サムネイルが既に設定されている記事の確認（URLベース）
     const articlesWithThumbnail = await prisma.article.count({
       where: {
-        source: {
-          name: 'Speaker Deck'
+        url: {
+          contains: 'speakerdeck.com'
         },
         thumbnail: {
           not: null


### PR DESCRIPTION
## Summary
- Fixed Speaker Deck thumbnail missing issue affecting 26 articles (3% of 888 total, 10% of Hatena-sourced articles)
- Root cause: oEmbed API returns HTTP 200 with valid content but without `thumbnail_url` field
- Solution: Fall back to HTML scraping for `og:image` when oEmbed succeeds but lacks thumbnail
- Updated repair script to use URL-based filtering (catches Hatena bookmark sourced articles)

## Implementation Details
- Modified `SpeakerDeckEnricher.enrich` method in `lib/enrichers/speakerdeck.ts`
  - When oEmbed returns success without `thumbnail_url`, fetch HTML page and extract `og:image`
  - Added try-catch for HTML fetch failures (graceful degradation - content still returned)
  - Added debug-level logging via pino logger for thumbnail fetch attempts
- Updated `scripts/manual/update-speakerdeck-thumbnails.ts`
  - Changed from source name-based to URL-based filtering (`url CONTAINS 'speakerdeck.com'`)
  - Prior filtering missed Hatena bookmark sourced articles with Speaker Deck URLs

## Test Results
- 9 tests passed in `__tests__/lib/enrichers/speakerdeck.test.ts`
- Added 2 new test cases:
  - `should fetch thumbnail from HTML when oEmbed has no thumbnail_url` (success path)
  - `should return null thumbnail when HTML fetch fails after oEmbed success` (failure path)

## Checklist
- [x] Tests passing (9/9)
- [x] No breaking changes
- [ ] Data backfill: Run repair script in production to fix existing 26 articles (follow-up)

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * SpeakerDeckコンテンツのサムネイル取得機能を向上 - メタデータにサムネイルが含まれていない場合、ウェブページから自動的に取得するようになりました

* **テスト**
  * SpeakerDeckエンリッチャーのサムネイル取得フォールバック機能とエラーハンドリングのテストを追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->