### PR TITLE
fix(fetcher): skip existing URLs before arXiv enrichment

### DIFF
--- a/__tests__/fetchers/arxiv-ai.test.ts
+++ b/__tests__/fetchers/arxiv-ai.test.ts
@@ -1,5 +1,13 @@
-import { ArxivAIFetcher } from '@/lib/fetchers/ai/arxiv-ai';
 import { Source } from '@prisma/client';
+
+// Mock Prisma client
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    article: {
+      findMany: jest.fn(),
+    },
+  },
+}));
 
 // Mock p-limit
 jest.mock('p-limit', () => {
@@ -22,6 +30,12 @@ jest.mock('@/lib/enrichers/arxiv-ai', () => ({
   })),
 }));
 
+// Import after mocks are set up
+import { ArxivAIFetcher } from '@/lib/fetchers/ai/arxiv-ai';
+import { prisma } from '@/lib/prisma';
+
+const mockedPrisma = jest.mocked(prisma, true);
+
 describe('ArxivAIFetcher', () => {
   let fetcher: ArxivAIFetcher;
   let mockSource: Source;
@@ -38,6 +52,10 @@ describe('ArxivAIFetcher', () => {
     };
 
     fetcher = new ArxivAIFetcher(mockSource);
+
+    // Reset prisma mock - default to empty (no existing articles)
+    mockedPrisma.article.findMany.mockReset();
+    mockedPrisma.article.findMany.mockResolvedValue([]);
   });
 
   describe('detectCategory', () => {
@@ -402,6 +420,126 @@ describe('ArxivAIFetcher', () => {
         'https://arxiv.org/images/paper-thumbnail.png'
       );
       expect(mockEnrich).toHaveBeenCalledWith('https://arxiv.org/abs/2312.99999');
+    });
+
+    it('should skip articles with existing URLs in database', async () => {
+      const mockItems = [
+        {
+          title: 'Existing Paper',
+          link: 'https://arxiv.org/abs/2312.11111',
+          pubDate: new Date().toISOString(),
+          categories: ['cs.AI'],
+        },
+        {
+          title: 'New Paper',
+          link: 'https://arxiv.org/abs/2312.22222',
+          pubDate: new Date().toISOString(),
+          categories: ['cs.LG'],
+        },
+      ];
+      const mockParseURL = jest.fn().mockResolvedValue({ items: mockItems });
+      (fetcher as any).parser.parseURL = mockParseURL;
+
+      // Mock existing article in database
+      mockedPrisma.article.findMany.mockResolvedValue([
+        { url: 'https://arxiv.org/abs/2312.11111' },
+      ]);
+
+      const result = await fetcher.fetch();
+
+      // Only the new paper should be processed
+      expect(result.articles).toHaveLength(1);
+      expect(result.articles[0].url).toBe('https://arxiv.org/abs/2312.22222');
+      expect(result.articles[0].title).toBe('New Paper');
+    });
+
+    it('should skip all articles when all URLs exist in database', async () => {
+      const mockItems = [
+        {
+          title: 'Existing Paper 1',
+          link: 'https://arxiv.org/abs/2312.11111',
+          pubDate: new Date().toISOString(),
+          categories: ['cs.AI'],
+        },
+        {
+          title: 'Existing Paper 2',
+          link: 'https://arxiv.org/abs/2312.22222',
+          pubDate: new Date().toISOString(),
+          categories: ['cs.LG'],
+        },
+      ];
+      const mockParseURL = jest.fn().mockResolvedValue({ items: mockItems });
+      (fetcher as any).parser.parseURL = mockParseURL;
+
+      // All articles exist in database
+      mockedPrisma.article.findMany.mockResolvedValue([
+        { url: 'https://arxiv.org/abs/2312.11111' },
+        { url: 'https://arxiv.org/abs/2312.22222' },
+      ]);
+
+      const result = await fetcher.fetch();
+
+      expect(result.articles).toHaveLength(0);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should process all articles when database is empty', async () => {
+      const mockItems = [
+        {
+          title: 'New Paper 1',
+          link: 'https://arxiv.org/abs/2312.33333',
+          pubDate: new Date().toISOString(),
+          categories: ['cs.AI'],
+        },
+        {
+          title: 'New Paper 2',
+          link: 'https://arxiv.org/abs/2312.44444',
+          pubDate: new Date().toISOString(),
+          categories: ['cs.LG'],
+        },
+      ];
+      const mockParseURL = jest.fn().mockResolvedValue({ items: mockItems });
+      (fetcher as any).parser.parseURL = mockParseURL;
+
+      // No existing articles in database
+      mockedPrisma.article.findMany.mockResolvedValue([]);
+
+      const result = await fetcher.fetch();
+
+      expect(result.articles).toHaveLength(2);
+    });
+
+    it('should query database with correct URL filter', async () => {
+      const mockItems = [
+        {
+          title: 'Paper 1',
+          link: 'https://arxiv.org/abs/2312.55555',
+          pubDate: new Date().toISOString(),
+        },
+        {
+          title: 'Paper 2',
+          link: 'https://arxiv.org/abs/2312.66666',
+          pubDate: new Date().toISOString(),
+        },
+      ];
+      const mockParseURL = jest.fn().mockResolvedValue({ items: mockItems });
+      (fetcher as any).parser.parseURL = mockParseURL;
+      mockedPrisma.article.findMany.mockResolvedValue([]);
+
+      await fetcher.fetch();
+
+      // Verify prisma was called with correct parameters
+      expect(mockedPrisma.article.findMany).toHaveBeenCalledWith({
+        where: {
+          url: {
+            in: [
+              'https://arxiv.org/abs/2312.55555',
+              'https://arxiv.org/abs/2312.66666',
+            ],
+          },
+        },
+        select: { url: true },
+      });
     });
   });
 });

--- a/lib/fetchers/ai/arxiv-ai.ts
+++ b/lib/fetchers/ai/arxiv-ai.ts
@@ -9,6 +9,7 @@ import { parseRSSDate } from '@/lib/utils/date';
 import logger from '@/lib/logger';
 import { ArxivAIEnricher } from '@/lib/enrichers/arxiv-ai';
 import { RSSItem } from '@/lib/types/rss';
+import { prisma } from '@/lib/prisma';
 
 export class ArxivAIFetcher extends BaseFetcher {
   private parser: Parser;
@@ -65,11 +66,29 @@ export class ArxivAIFetcher extends BaseFetcher {
 
       logger.info(`arXiv AI: RSSフィードから ${feed.items.length} 件取得`);
 
-      // Filter items (date, validity, deduplication)
+      // Get existing URLs from database (to skip enrichment for already saved articles)
+      const feedUrls = feed.items
+        .map((item) => (item as RSSItem).link)
+        .filter((url): url is string => !!url);
+
+      const existingArticles = await prisma.article.findMany({
+        where: {
+          url: { in: feedUrls }
+        },
+        select: { url: true }
+      });
+      const existingUrlSet = new Set(existingArticles.map((a) => a.url));
+
+      logger.info(`arXiv AI: DB既存URL ${existingUrlSet.size} 件を除外`);
+
+      // Filter items (date, validity, deduplication, existing URL)
       const validItems: RSSItem[] = [];
 
       for (const item of feed.items as RSSItem[]) {
         if (!item.title || !item.link) continue;
+
+        // Skip existing URLs (before expensive enrichment)
+        if (existingUrlSet.has(item.link)) continue;
 
         // Extract arXiv ID for deduplication (handles versioning)
         const arxivId = this.extractArxivId(item.link);
@@ -86,7 +105,7 @@ export class ArxivAIFetcher extends BaseFetcher {
         validItems.push(item);
       }
 
-      logger.info(`arXiv AI: フィルタ後 ${validItems.length} 件`);
+      logger.info(`arXiv AI: フィルタ後 ${validItems.length} 件（新規のみ）`);
 
       // Parallel enrichment with p-limit
       const limit = pLimit(this.ENRICHMENT_CONCURRENCY);


### PR DESCRIPTION
## Summary
- Add pre-enrichment DB check to filter out already-saved articles
- Reduces processing from 400-800 to ~50-100 new articles per run
- Fixes 10-minute timeout issue caused by re-enriching existing articles
- Expected runtime: ~1-2 minutes (down from 10+ minutes with timeouts)

## Implementation Details
- Query DB with `prisma.article.findMany({ where: { url: { in: feedUrls } } })` before enrichment loop
- Create Set of existing URLs for O(1) lookup
- Skip articles with existing URLs before expensive HTML fetch/parse
- Feed batch size: 400-800 URLs; IN clause within PostgreSQL limits
- Article.url has @unique constraint (auto-indexed) - efficient query

## Test Results
- File: `__tests__/fetchers/arxiv-ai.test.ts`
- 36 tests passing (4 new unit tests added)
- New test scenarios:
  - Skip articles with existing URLs in database
  - Skip all articles when all URLs exist
  - Process all articles when database is empty
  - Verify correct query parameters to prisma
- Type check and lint passing

## Migration/Data
- No schema changes required
- No data migration needed
- Existing Article.url unique constraint already in place

## Checklist
- [x] Tests passing
- [x] Type check passing
- [x] Lint passing
- [ ] Manual verification: run scheduler and confirm reduced processing count in logs

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * データベースで既に存在する記事のURLを事前に確認し、重複処理を防ぐ機能を追加しました。RSS記事の処理前にデータベースをチェックし、既存の記事をスキップすることで、処理効率が向上します。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->