### PR TITLE
fix(fetcher): add 14 Japanese corporate blog mappings to createFetcher

### DIFF
--- a/__tests__/fetchers/create-fetcher.test.ts
+++ b/__tests__/fetchers/create-fetcher.test.ts
@@ -1,0 +1,80 @@
+import { Source } from '@prisma/client';
+import { createFetcher } from '../../lib/fetchers/index';
+
+// Mock rss-parser to prevent actual network calls
+jest.mock('rss-parser', () => {
+  return jest.fn().mockImplementation(() => ({
+    parseURL: jest.fn().mockResolvedValue({ items: [] }),
+  }));
+});
+
+// Mock node-fetch to prevent actual network calls
+jest.mock('node-fetch', () => jest.fn());
+
+describe('createFetcher - Japanese Corporate Tech Blogs', () => {
+  const createMockSource = (name: string, id: string, type: string = 'rss'): Source => ({
+    id,
+    name,
+    type,
+    url: `https://example.com/${id}/feed`,
+    enabled: true,
+    groupId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  describe('Individual Japanese corporate blog sources', () => {
+    it.each([
+      ['DeNA Engineering', 'dena_tech_blog', 'DeNAFetcher'],
+      ['SmartHR Tech Blog', 'smarthr_tech_blog', 'SmartHRFetcher'],
+      ['LY Corporation Tech Blog', 'lycorp_tech_blog', 'LYCorpFetcher'],
+      ['Mercari Engineering', 'mercari_tech_blog', 'MercariFetcher'],
+      ['Sansan Builders Box', 'sansan_tech_blog', 'SansanFetcher'],
+      ['ZOZO TECH BLOG', 'zozo_tech_blog', 'ZOZOFetcher'],
+      ['Hatena Developer Blog', 'hatena_tech_blog', 'HatenaFetcher'],
+      ['Money Forward Developers Blog', 'moneyforward_tech_blog', 'MoneyForwardFetcher'],
+      ['freee Developers Hub', 'freee_tech_blog', 'FreeeFetcher'],
+      ['Cookpad Tech Life', 'cookpad_tech_blog', 'CookpadFetcher'],
+      ['CyberAgent Developers Blog', 'cyberagent_tech_blog', 'CyberAgentFetcher'],
+      ['GMO Developers', 'gmo_tech_blog', 'GMOFetcher'],
+    ])('should create fetcher for "%s"', (name, id, expectedFetcherName) => {
+      const source = createMockSource(name, id);
+      const fetcher = createFetcher(source);
+
+      expect(fetcher).toBeDefined();
+      expect(fetcher.constructor.name).toBe(expectedFetcherName);
+    });
+
+    it('should create PepaboFetcher for Japanese source name', () => {
+      const source = createMockSource('ペパボテックブログ', 'pepabo_tech_blog');
+      const fetcher = createFetcher(source);
+
+      expect(fetcher).toBeDefined();
+      expect(fetcher.constructor.name).toBe('PepaboFetcher');
+    });
+  });
+
+  describe('Hatena Blog Dev (Corporate Tech Blog Aggregator)', () => {
+    it('should create HatenaBlogDevFetcher for source name in Japanese', () => {
+      const source = createMockSource('企業技術ブログ', 'hatena_blog_dev', 'SCRAPING');
+      const fetcher = createFetcher(source);
+
+      expect(fetcher).toBeDefined();
+      expect(fetcher.constructor.name).toBe('HatenaBlogDevFetcher');
+    });
+
+    it('should throw error for legacy source name "Hatena Blog Dev"', () => {
+      const source = createMockSource('Hatena Blog Dev', 'hatena_blog_dev_legacy', 'SCRAPING');
+
+      expect(() => createFetcher(source)).toThrow('Unsupported source: Hatena Blog Dev');
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should throw error for unknown source', () => {
+      const source = createMockSource('Unknown Corporate Blog', 'unknown_corp');
+
+      expect(() => createFetcher(source)).toThrow('Unsupported source: Unknown Corporate Blog');
+    });
+  });
+});

--- a/__tests__/fetchers/hatena-blog-dev.test.ts
+++ b/__tests__/fetchers/hatena-blog-dev.test.ts
@@ -14,7 +14,7 @@ describe('HatenaBlogDevFetcher', () => {
 
   const mockSource: Source = {
     id: 'hatena_blog_dev_test',
-    name: 'Hatena Blog Dev',
+    name: '企業技術ブログ',
     type: 'SCRAPING',
     url: 'https://hatena.blog/dev/entries',
     enabled: true,

--- a/lib/fetchers/index.ts
+++ b/lib/fetchers/index.ts
@@ -37,6 +37,21 @@ import { DeepMindBlogFetcher } from './deepmind-blog';
 import { HatenaBlogDevFetcher } from './hatena-blog-dev';
 import { DevelopersIOFetcher, getTagFromSourceName } from './developersio';
 
+// Japanese Corporate Tech Blog Fetchers
+import { DeNAFetcher } from './corporate-blogs/dena-fetcher';
+import { SmartHRFetcher } from './corporate-blogs/smarthr-fetcher';
+import { LYCorpFetcher } from './corporate-blogs/lycorp-fetcher';
+import { MercariFetcher } from './corporate-blogs/mercari-fetcher';
+import { SansanFetcher } from './corporate-blogs/sansan-fetcher';
+import { ZOZOFetcher } from './corporate-blogs/zozo-fetcher';
+import { HatenaFetcher } from './corporate-blogs/hatena-fetcher';
+import { MoneyForwardFetcher } from './corporate-blogs/moneyforward-fetcher';
+import { PepaboFetcher } from './corporate-blogs/pepabo-fetcher';
+import { FreeeFetcher } from './corporate-blogs/freee-fetcher';
+import { CookpadFetcher } from './corporate-blogs/cookpad-fetcher';
+import { CyberAgentFetcher } from './corporate-blogs/cyberagent-fetcher';
+import { GMOFetcher } from './corporate-blogs/gmo-fetcher';
+
 export function createFetcher(source: Source): BaseFetcher {
   switch (source.name) {
     case 'はてなブックマーク':
@@ -101,8 +116,36 @@ export function createFetcher(source: Source): BaseFetcher {
       return new NVIDIADeveloperBlogFetcher(source);
     case 'DeepMind Blog':
       return new DeepMindBlogFetcher(source);
-    case 'Hatena Blog Dev':
+    case '企業技術ブログ':
       return new HatenaBlogDevFetcher(source);
+
+    // Japanese Corporate Tech Blogs
+    case 'DeNA Engineering':
+      return new DeNAFetcher(source);
+    case 'SmartHR Tech Blog':
+      return new SmartHRFetcher(source);
+    case 'LY Corporation Tech Blog':
+      return new LYCorpFetcher(source);
+    case 'Mercari Engineering':
+      return new MercariFetcher(source);
+    case 'Sansan Builders Box':
+      return new SansanFetcher(source);
+    case 'ZOZO TECH BLOG':
+      return new ZOZOFetcher(source);
+    case 'Hatena Developer Blog':
+      return new HatenaFetcher(source);
+    case 'Money Forward Developers Blog':
+      return new MoneyForwardFetcher(source);
+    case 'ペパボテックブログ':
+      return new PepaboFetcher(source);
+    case 'freee Developers Hub':
+      return new FreeeFetcher(source);
+    case 'Cookpad Tech Life':
+      return new CookpadFetcher(source);
+    case 'CyberAgent Developers Blog':
+      return new CyberAgentFetcher(source);
+    case 'GMO Developers':
+      return new GMOFetcher(source);
 
     // DevelopersIO (dev.classmethod.jp) tag-based sources
     case 'DevelopersIO AWS':

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -92,7 +92,7 @@ async function main() {
     }),
     prisma.source.create({
       data: {
-        name: 'Hatena Blog Dev',
+        name: '企業技術ブログ',
         type: 'SCRAPING',
         url: 'https://hatena.blog/dev/entries',
         enabled: true,


### PR DESCRIPTION
## Summary
- Add 14 Japanese corporate blog fetcher mappings to createFetcher
- Align source name to `企業技術ブログ` (was `Hatena Blog Dev`)
- Add unit tests to validate createFetcher mappings

## Implementation Details
Commit 32fee65b (2025-12-04) removed the local fetchers map in collect-feeds.ts without adding the 14 Japanese corporate blog mappings to createFetcher, so those sources stopped fetching after that refactor.

### Changes
- `lib/fetchers/index.ts`: Import 13 corporate blog fetchers and add case statements; map `企業技術ブログ`
- `prisma/seed.ts`: Update source name to `企業技術ブログ`
- `__tests__/fetchers/hatena-blog-dev.test.ts`: Update mock source name
- `__tests__/fetchers/create-fetcher.test.ts`: New mapping validation tests

### Affected Sources (14)
DeNA Engineering, SmartHR Tech Blog, LY Corporation Tech Blog, Mercari Engineering, Sansan Builders Box, ZOZO TECH BLOG, Hatena Developer Blog, Money Forward Developers Blog, ペパボテックブログ, freee Developers Hub, Cookpad Tech Life, CyberAgent Developers Blog, GMO Developers, 企業技術ブログ

## Test Results
- `npm run docker:test:file` with `__tests__/fetchers/create-fetcher.test.ts` (16 tests pass)
- `npm run docker:test:file` with `__tests__/fetchers/hatena-blog-dev.test.ts` (16 tests pass)
- Manual verification (2025-12-12 JST): ZOZO TECH BLOG 7 articles, 企業技術ブログ 60, Mercari Engineering 15
- `npm run lint && npm run type-check && npm run docker:build` (pass)

## Checklist
- [x] Tests passing
- [x] Manual verification completed
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 複数の日本の企業技術ブログソースに新たに対応しました（DeNA、SmartHR、LY Corp、Mercari、Sansan、ZOZO、Money Forward、Pepabo、freee、Cookpad、CyberAgent、GMO等）。
  * Hatena Blog Devを「企業技術ブログ」に名称変更しました。

* **テスト**
  * 新しいフェッチャー機能の検証テストを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->