### PR TITLE
fix(cache): improve cache invalidation after bulk import and summary generation

### DIFF
--- a/__tests__/lib/cache/cache-invalidator.test.ts
+++ b/__tests__/lib/cache/cache-invalidator.test.ts
@@ -1,0 +1,211 @@
+// モック設定（インポート前に宣言）
+jest.mock('@/lib/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// RedisCacheのモック
+jest.mock('@/lib/cache/index', () => ({
+  RedisCache: jest.fn().mockImplementation(() => ({
+    invalidatePattern: jest.fn().mockResolvedValue(undefined),
+    getOrSet: jest.fn(),
+    get: jest.fn(),
+    set: jest.fn(),
+    delete: jest.fn(),
+  })),
+}));
+
+// tagCache, sourceCache, popularCacheのモック
+jest.mock('@/lib/cache/tag-cache', () => ({
+  tagCache: {
+    invalidate: jest.fn().mockResolvedValue(undefined),
+    invalidateTag: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// 注意: Jest config の moduleNameMapper で `@/lib/cache/source-cache` は manual mock に差し替えられるため、
+// CacheInvalidator 側（相対import）と同じ実体を指すパスでモックする
+jest.mock('../../../lib/cache/source-cache', () => ({
+  sourceCache: {
+    invalidate: jest.fn().mockResolvedValue(undefined),
+    invalidateSource: jest.fn().mockResolvedValue(undefined),
+  },
+  SourceCache: jest.fn(),
+}));
+
+jest.mock('@/lib/cache/popular-cache', () => ({
+  popularCache: {
+    invalidateAll: jest.fn().mockResolvedValue(undefined),
+    invalidatePeriod: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// getRedisServiceをモックして実際のRedis接続を避ける
+jest.mock('@/lib/redis/factory', () => ({
+  getRedisService: jest.fn(() => ({
+    clearPattern: jest.fn().mockResolvedValue(undefined),
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+  })),
+}));
+
+// インポート（モック設定後）
+import { CacheInvalidator } from '@/lib/cache/cache-invalidator';
+import { CACHE_NAMESPACES, createCachePattern } from '@/lib/cache/constants';
+import { RedisCache } from '@/lib/cache/index';
+import { popularCache } from '@/lib/cache/popular-cache';
+import { sourceCache } from '../../../lib/cache/source-cache';
+import { tagCache } from '@/lib/cache/tag-cache';
+import type { IRedisService } from '@/lib/redis/interfaces';
+
+describe('CacheInvalidator', () => {
+  let cacheInvalidator: CacheInvalidator;
+  let mockRedisService: jest.Mocked<IRedisService>;
+  let mockTagCacheInvalidate: jest.Mock;
+  let mockSourceCacheInvalidate: jest.Mock;
+  let mockPopularCacheInvalidateAll: jest.Mock;
+
+  const getRedisCacheInvalidatePatternMocks = (): jest.Mock[] => {
+    const redisCacheConstructor = RedisCache as unknown as jest.Mock;
+    return redisCacheConstructor.mock.results.map((result: { value: unknown }) => {
+      const instance = result.value as { invalidatePattern?: unknown };
+      return instance.invalidatePattern as jest.Mock;
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockTagCacheInvalidate = tagCache.invalidate as unknown as jest.Mock;
+    mockSourceCacheInvalidate = sourceCache.invalidate as unknown as jest.Mock;
+    mockPopularCacheInvalidateAll = popularCache.invalidateAll as unknown as jest.Mock;
+
+    // モックRedisServiceを作成し、コンストラクタに注入
+    mockRedisService = {
+      clearPattern: jest.fn().mockResolvedValue(undefined),
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(0),
+      exists: jest.fn().mockResolvedValue(false),
+      incr: jest.fn().mockResolvedValue(1),
+      expire: jest.fn().mockResolvedValue(true),
+      ttl: jest.fn().mockResolvedValue(-1),
+      scan: jest.fn().mockResolvedValue({ cursor: '0', keys: [] }),
+      keys: jest.fn().mockResolvedValue([]),
+      pipeline: jest.fn().mockReturnValue({
+        set: jest.fn().mockReturnThis(),
+        del: jest.fn().mockReturnThis(),
+        expire: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([]),
+      }),
+      multi: jest.fn().mockReturnValue({
+        set: jest.fn().mockReturnThis(),
+        del: jest.fn().mockReturnThis(),
+        expire: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([]),
+      }),
+      getClient: jest.fn().mockReturnValue(null),
+      isConnected: jest.fn().mockReturnValue(true),
+    } as unknown as jest.Mocked<IRedisService>;
+
+    // モックRedisServiceを注入してインスタンス化
+    cacheInvalidator = new CacheInvalidator(mockRedisService);
+  });
+
+  describe('onBulkImport', () => {
+    it('should invalidate LayeredCache L1 PUBLIC namespace', async () => {
+      await cacheInvalidator.onBulkImport();
+
+      expect(mockRedisService.clearPattern).toHaveBeenCalledWith(
+        createCachePattern(CACHE_NAMESPACES.L1_PUBLIC)
+      );
+    });
+
+    it('should invalidate LayeredCache L3 SEARCH namespace', async () => {
+      await cacheInvalidator.onBulkImport();
+
+      expect(mockRedisService.clearPattern).toHaveBeenCalledWith(
+        createCachePattern(CACHE_NAMESPACES.L3_SEARCH)
+      );
+    });
+
+    it('should invalidate ARTICLES_LIGHTWEIGHT namespace', async () => {
+      await cacheInvalidator.onBulkImport();
+
+      expect(mockRedisService.clearPattern).toHaveBeenCalledWith(
+        createCachePattern(CACHE_NAMESPACES.ARTICLES_LIGHTWEIGHT)
+      );
+    });
+
+    it('should invalidate ARTICLES_API namespace', async () => {
+      await cacheInvalidator.onBulkImport();
+
+      expect(mockRedisService.clearPattern).toHaveBeenCalledWith(
+        createCachePattern(CACHE_NAMESPACES.ARTICLES_API)
+      );
+    });
+
+    it('should invalidate all existing caches', async () => {
+      await cacheInvalidator.onBulkImport();
+
+      // RedisCacheのinvalidatePatternが呼ばれることを確認
+      // 3つのRedisCache（articleCache, relatedCache, tagCloudCache）で呼ばれる
+      const invalidatePatternMocks = getRedisCacheInvalidatePatternMocks();
+      expect(invalidatePatternMocks).toHaveLength(3);
+      for (const mock of invalidatePatternMocks) {
+        expect(mock).toHaveBeenCalledWith('*');
+      }
+
+      // 既存のキャッシュ無効化
+      expect(mockTagCacheInvalidate).toHaveBeenCalled();
+      expect(mockSourceCacheInvalidate).toHaveBeenCalled();
+      expect(mockPopularCacheInvalidateAll).toHaveBeenCalled();
+    });
+
+    it('should call clearPattern with correct namespace patterns', async () => {
+      await cacheInvalidator.onBulkImport();
+
+      // 4つのnamespaceパターンでclearPatternが呼ばれることを確認
+      expect(mockRedisService.clearPattern).toHaveBeenCalledTimes(4);
+
+      // パターンの内容を確認
+      const calls = (mockRedisService.clearPattern as jest.Mock).mock.calls.map(
+        (call: unknown[]) => call[0]
+      );
+      expect(calls).toContain(createCachePattern(CACHE_NAMESPACES.L1_PUBLIC));
+      expect(calls).toContain(createCachePattern(CACHE_NAMESPACES.L3_SEARCH));
+      expect(calls).toContain(createCachePattern(CACHE_NAMESPACES.ARTICLES_LIGHTWEIGHT));
+      expect(calls).toContain(createCachePattern(CACHE_NAMESPACES.ARTICLES_API));
+    });
+
+    it('should execute all invalidations in parallel', async () => {
+      // Promise.allで並列実行されることを確認するため、
+      // 各モックの呼び出し順序は保証されないが、全て呼ばれることを確認
+      const promise = cacheInvalidator.onBulkImport();
+
+      // Promiseが返されることを確認
+      expect(promise).toBeInstanceOf(Promise);
+
+      await promise;
+
+      // 全ての無効化が呼ばれたことを確認
+      expect(mockRedisService.clearPattern).toHaveBeenCalledTimes(4);
+      // invalidatePatternは3つのRedisCache（articleCache, relatedCache, tagCloudCache）で呼ばれる
+      const invalidatePatternMocks = getRedisCacheInvalidatePatternMocks();
+      const invalidatePatternCallCount = invalidatePatternMocks.reduce(
+        (total, mock) => total + mock.mock.calls.length,
+        0
+      );
+      expect(invalidatePatternCallCount).toBe(3);
+      expect(mockTagCacheInvalidate).toHaveBeenCalledTimes(1);
+      expect(mockSourceCacheInvalidate).toHaveBeenCalledTimes(1);
+      expect(mockPopularCacheInvalidateAll).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/__tests__/lib/cache/layered-cache-key.test.ts
+++ b/__tests__/lib/cache/layered-cache-key.test.ts
@@ -1,0 +1,64 @@
+import { LayeredCache } from '@/lib/cache/layered-cache';
+
+describe('LayeredCache cache key generation', () => {
+  const cache = Object.create(LayeredCache.prototype) as any;
+
+  it('should include sortOrder in basic cache keys', () => {
+    const ascKey = cache.generateBasicKey({ sortBy: 'publishedAt', sortOrder: 'asc' });
+    const descKey = cache.generateBasicKey({ sortBy: 'publishedAt', sortOrder: 'desc' });
+    const defaultKey = cache.generateBasicKey({ sortBy: 'publishedAt' });
+
+    expect(ascKey).not.toBe(descKey);
+    expect(ascKey).toContain('sortOrder:asc');
+    expect(descKey).toContain('sortOrder:desc');
+    expect(defaultKey).toBe(descKey);
+  });
+
+  it('should include sortOrder in user cache keys', () => {
+    const ascKey = cache.generateUserKey({
+      userId: 'user-1',
+      readFilter: 'read',
+      sortBy: 'publishedAt',
+      sortOrder: 'asc',
+    });
+    const descKey = cache.generateUserKey({
+      userId: 'user-1',
+      readFilter: 'read',
+      sortBy: 'publishedAt',
+      sortOrder: 'desc',
+    });
+    const defaultKey = cache.generateUserKey({
+      userId: 'user-1',
+      readFilter: 'read',
+      sortBy: 'publishedAt',
+    });
+
+    expect(ascKey).not.toBe(descKey);
+    expect(ascKey).toContain('sortOrder:asc');
+    expect(descKey).toContain('sortOrder:desc');
+    expect(defaultKey).toBe(descKey);
+  });
+
+  it('should include sortOrder in search cache keys', () => {
+    const ascKey = cache.generateSearchKey({
+      search: 'foo bar',
+      sortBy: 'publishedAt',
+      sortOrder: 'asc',
+    });
+    const descKey = cache.generateSearchKey({
+      search: 'foo bar',
+      sortBy: 'publishedAt',
+      sortOrder: 'desc',
+    });
+    const defaultKey = cache.generateSearchKey({
+      search: 'foo bar',
+      sortBy: 'publishedAt',
+    });
+
+    expect(ascKey).not.toBe(descKey);
+    expect(ascKey).toContain('sortOrder:asc');
+    expect(descKey).toContain('sortOrder:desc');
+    expect(defaultKey).toBe(descKey);
+  });
+});
+

--- a/__tests__/lib/cache/layered-cache.test.ts
+++ b/__tests__/lib/cache/layered-cache.test.ts
@@ -248,6 +248,43 @@ describe('LayeredCache', () => {
       expect(fetcher2).toHaveBeenCalledTimes(1);
     });
 
+    test('異なるsortOrderは異なるキャッシュキーを生成', async () => {
+      const paramsAsc: ArticleQueryParams = {
+        sortBy: 'publishedAt',
+        sortOrder: 'asc',
+        page: 1,
+        limit: 20,
+      };
+
+      const paramsDesc: ArticleQueryParams = {
+        sortBy: 'publishedAt',
+        sortOrder: 'desc',
+        page: 1,
+        limit: 20,
+      };
+
+      const mockDataAsc = { items: [{ id: 'oldest' }], total: 100 };
+      const mockDataDesc = { items: [{ id: 'newest' }], total: 100 };
+
+      const fetcherAsc = jest.fn().mockResolvedValue(mockDataAsc);
+      const fetcherDesc = jest.fn().mockResolvedValue(mockDataDesc);
+
+      // asc順で取得
+      const resultAsc = await cache.getArticles(paramsAsc, fetcherAsc);
+      expect(resultAsc.items[0].id).toBe('oldest');
+      expect(fetcherAsc).toHaveBeenCalledTimes(1);
+
+      // desc順で取得（別キャッシュ）
+      const resultDesc = await cache.getArticles(paramsDesc, fetcherDesc);
+      expect(resultDesc.items[0].id).toBe('newest');
+      expect(fetcherDesc).toHaveBeenCalledTimes(1);
+
+      // 再度asc順で取得（キャッシュから）
+      const cachedAsc = await cache.getArticles(paramsAsc, fetcherAsc);
+      expect(cachedAsc.items[0].id).toBe('oldest');
+      expect(fetcherAsc).toHaveBeenCalledTimes(1); // キャッシュヒット
+    });
+
     test('sources=noneは正しく処理される', async () => {
       const params: ArticleQueryParams = {
         sources: 'none',

--- a/app/api/articles/lib/response.ts
+++ b/app/api/articles/lib/response.ts
@@ -97,7 +97,9 @@ export function createGetResponse(
     response.headers.set('X-Cache-Bypass', 'user-context');
   } else {
     // Public responses can be cached
-    response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300');
+    // s-maxageとCDN max-ageを整合させる（300秒）
+    // stale-while-revalidateはバックグラウンド再検証用に60秒
+    response.headers.set('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=60');
     response.headers.set('CDN-Cache-Control', 'max-age=300');
   }
 

--- a/lib/cache/cache-invalidator.ts
+++ b/lib/cache/cache-invalidator.ts
@@ -191,7 +191,14 @@ export class CacheInvalidator {
    */
   async onBulkImport(): Promise<void> {
     await Promise.all([
-      // すべてのキャッシュを無効化
+      // LayeredCacheの全層を無効化
+      this.redisService.clearPattern(createCachePattern(CACHE_NAMESPACES.L1_PUBLIC)),
+      this.redisService.clearPattern(createCachePattern(CACHE_NAMESPACES.L3_SEARCH)),
+      // Lightweightキャッシュも無効化
+      this.redisService.clearPattern(createCachePattern(CACHE_NAMESPACES.ARTICLES_LIGHTWEIGHT)),
+      // APIキャッシュを無効化
+      this.redisService.clearPattern(createCachePattern(CACHE_NAMESPACES.ARTICLES_API)),
+      // 既存のキャッシュ無効化
       this.articleCache.invalidatePattern('*'),
       this.relatedCache.invalidatePattern('*'),
       this.tagCloudCache.invalidatePattern('*'),

--- a/lib/cache/layered-cache.ts
+++ b/lib/cache/layered-cache.ts
@@ -199,6 +199,7 @@ export class LayeredCache {
       page: params.page || 1,
       limit: params.limit || 20,
       sortBy: params.sortBy || 'publishedAt',
+      sortOrder: params.sortOrder || 'desc',
       category: params.category || 'all',
       sources: params.sources || 'all',  // sourcesパラメータを追加
       sourceId: params.sourceId || 'none',  // sourceIdパラメータを追加（後方互換性）
@@ -282,6 +283,7 @@ export class LayeredCache {
       page: params.page || 1,
       limit: params.limit || 20,
       sortBy: params.sortBy || 'publishedAt',
+      sortOrder: params.sortOrder || 'desc',
       sources: params.sources || 'all',  // sourcesパラメータを追加
       sourceId: params.sourceId || 'none',  // sourceIdパラメータを追加（後方互換性）
       category: params.category || 'all',  // categoryも追加
@@ -317,6 +319,7 @@ export class LayeredCache {
       page: params.page || 1,
       limit: params.limit || 20,
       sortBy: params.sortBy || 'publishedAt',
+      sortOrder: params.sortOrder || 'desc',
       category: params.category || 'all',
       sources: params.sources || 'all',  // sourcesパラメータを追加
       sourceId: params.sourceId || 'none',  // sourceIdパラメータを追加（後方互換性）

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -535,6 +535,13 @@ async function collectFeeds(sourceTypes?: string[]): Promise<CollectResult> {
         const { generateSummaries } = await import('../maintenance/generate-summaries');
         const result = await generateSummaries({ articleIds: newArticleIds });
         console.error(`[INFO] 要約生成完了: ${result.generated}件の要約を生成`);
+
+        // 要約生成後に再度キャッシュを無効化
+        // excludeUnprocessed=trueクエリで要約生成済み記事が即座に表示されるようにする
+        if (result.generated > 0) {
+          console.error('[INFO] 要約生成後のキャッシュ無効化中...');
+          await cacheInvalidator.onBulkImport();
+        }
       } catch (error) {
         console.error(
           '[WARN] 要約生成でエラーが発生しましたが、記事収集は成功しています:',


### PR DESCRIPTION
## Summary
- Add LayeredCache (L1, L3) invalidation to `onBulkImport()` to resolve stale article issue
  - L2 (user-specific cache) is excluded as it's per-user and doesn't need bulk invalidation
- Add `sortOrder` to cache key generation to prevent asc/desc cache collision (defaults to 'desc')
- Add post-summary generation cache invalidation for immediate reflection
- Align CDN cache headers: `public, s-maxage=300, stale-while-revalidate=60`

## Implementation Details

**`lib/cache/cache-invalidator.ts`:**
- Added invalidation for:
  - `L1_PUBLIC`: Public article list cache (TTL: 1hr) - main cause of stale articles
  - `L3_SEARCH`: Search results cache (TTL: 10min)
  - `ARTICLES_LIGHTWEIGHT`: /api/articles/list lightweight cache (TTL: 30min)
  - `ARTICLES_API`: API response cache (TTL: varies)

**`lib/cache/layered-cache.ts`:**
- Added `sortOrder` (default: 'desc') to `generateBasicKey`, `generateUserKey`, `generateSearchKey`
- Prevents asc/desc results from being served from same cache key

**`scripts/scheduled/collect-feeds.ts`:**
- Added `cacheInvalidator.onBulkImport()` call after summary generation completes
- Invalidates all list caches so `excludeUnprocessed=true` queries return fresh results

**`app/api/articles/lib/response.ts`:**
- Changed: `s-maxage=60` -> `s-maxage=300` (align with CDN-Cache-Control)
- Changed: `stale-while-revalidate=300` -> `stale-while-revalidate=60` (faster background revalidation)

## Impact
- **Before:** New articles delayed up to 1 hour (L1_PUBLIC TTL was 1hr, not invalidated by onBulkImport)
- **After:** New articles appear immediately after collection
- **Deployment note:** Cache keys change, expect temporary cache miss spike (~5-10 min cold cache period)

## Test Results
```bash
npm run docker:test:file  # Run individual test files
```
- `cache-invalidator.test.ts`: 7 tests passing (validates L1/L3/Lightweight/API invalidation)
- `layered-cache.test.ts`: 21 tests passing (includes sortOrder cache separation test)
- `layered-cache-key.test.ts`: 3 tests passing (validates sortOrder in all key types)

## Checklist
- [x] Tests passing (31 tests)
- [x] Lint/Type-check passing
- [x] Build verification passing
- [x] No breaking changes
- [x] Rollback plan: Revert commit, redeploy (cache will rebuild naturally)

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * キャッシュシステムの最適化により、コンテンツの読み込み速度を向上させました
  * キャッシュレイヤーの管理を改善し、より確実で効率的なデータ配信を実現しました
  * サマリー生成後のキャッシュ更新処理を強化しました

* **テスト**
  * キャッシュ無効化機能の包括的なテストスイートを追加しました
  * キャッシュキー生成ロジックの検証テストを追加しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->