### PR TITLE
fix(security): resolve Dependabot vulnerabilities for qs and nodemailer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -303,21 +303,21 @@
       }
     },
     "node_modules/@auth/prisma-adapter": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.10.0.tgz",
-      "integrity": "sha512-EliOQoTjGK87jWWqnJvlQjbR4PjQZQqtwRwPAe108WwT9ubuuJJIrL68aNnQr4hFESz6P7SEX2bZy+y2yL37Gw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.1.tgz",
+      "integrity": "sha512-Ke7DXP0Fy0Mlmjz/ZJLXwQash2UkA4621xCM0rMtEczr1kppLc/njCbUkHkIQ/PnmILjqSPEKeTjDPsYruvkug==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.40.0"
+        "@auth/core": "0.41.1"
       },
       "peerDependencies": {
         "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5 || >=6"
       }
     },
     "node_modules/@auth/prisma-adapter/node_modules/@auth/core": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.40.0.tgz",
-      "integrity": "sha512-n53uJE0RH5SqZ7N1xZoMKekbHfQgjd0sAEyUbE+IYJnmuQkbvuZnXItCU7d+i7Fj8VGOgqvNO7Mw4YfBTlZeQw==",
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.1.tgz",
+      "integrity": "sha512-t9cJ2zNYAdWMacGRMT6+r4xr1uybIdmYa49calBPeTqwgAFPV/88ac9TEvCR85pvATiSPt8VaNf+Gt24JIT/uw==",
       "license": "ISC",
       "dependencies": {
         "@panva/hkdf": "^1.2.1",
@@ -329,7 +329,7 @@
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
         "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^6.8.0"
+        "nodemailer": "^7.0.7"
       },
       "peerDependenciesMeta": {
         "@simplewebauthn/browser": {
@@ -341,17 +341,6 @@
         "nodemailer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@auth/prisma-adapter/node_modules/nodemailer": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
-      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
-      "license": "MIT-0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@axe-core/playwright": {
@@ -18472,9 +18461,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Update qs from 6.14.0 to 6.14.1 (CVE-2025-15284 - HIGH)
- Update @auth/prisma-adapter from 2.10.0 to 2.11.1 and @auth/core from 0.40.0 to 0.41.1
- Resolve nodemailer vulnerabilities (CVE-2025-14874, CVE-2025-13033, GHSA-mm7p-fcc7-pg87)

## Vulnerabilities Resolved

| Package | CVE | Severity | Status |
|---------|-----|----------|--------|
| qs | CVE-2025-15284 | HIGH | Fixed |
| nodemailer | CVE-2025-14874 | MEDIUM | Fixed |
| nodemailer | GHSA-mm7p-fcc7-pg87 | LOW | Fixed |
| nodemailer | CVE-2025-13033 | MEDIUM | Fixed |

## Remaining (No Action Required)

- `tmp` (LOW) - devDependency only, requires breaking change to @lhci/cli

## Test Plan

- [ ] npm audit shows only LOW severity vulnerabilities (tmp)
- [ ] CI/CD pipeline passes
- [ ] Email authentication still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)