### PR TITLE
fix(ci): update LighthouseCI NEXTAUTH_SECRET to meet 32-char minimum

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -40,7 +40,7 @@ jobs:
           SKIP_DB_CHECK: 'true'
           # Use placeholder for required env vars
           DATABASE_URL: 'postgresql://localhost:5432/db'
-          NEXTAUTH_SECRET: 'test-secret-for-build'
+          NEXTAUTH_SECRET: 'build-secret-key-for-testing-purposes-only-32chars'
           NEXTAUTH_URL: 'http://localhost:3000'
 
       - name: Run Lighthouse CI


### PR DESCRIPTION
## Summary
- Fixed LighthouseCI workflow build failure caused by NEXTAUTH_SECRET validation error
- Updated NEXTAUTH_SECRET from 22 characters to 50 characters to meet the minimum 32-character requirement
- Aligned with the same pattern used in ci.yml Build job for consistency

## Root Cause
The `lib/config/env.ts` validates NEXTAUTH_SECRET with `z.string().min(32)`. The LighthouseCI workflow was using a 22-character placeholder, causing the build to fail during environment validation.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/lighthouse-ci.yml` | Updated NEXTAUTH_SECRET placeholder to 50-character string (matching ci.yml Build job pattern) |

## Test Plan
All checks were executed locally before PR creation:
- [x] Lint check passed (10s)
- [x] Type check passed (9s)
- [x] Security audit passed - 0 vulnerabilities (1s)
- [x] Docker build passed - 72/72 static pages generated (71s)

## Verification
LighthouseCI workflow success will be verified after merge by triggering the workflow manually or via schedule.

---
Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CD ワークフロー内のテスト設定値を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->