### PR TITLE
fix(ci): update Lighthouse CI test URLs to existing routes

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -15,7 +15,7 @@ module.exports = {
       // Note: Only use routes that exist in the app. Verify with `npm run build` output.
       url: [
         'http://localhost:3000/',           // Top page (contains article list)
-        'http://localhost:3000/auth/login', // Login page (static, no DB dependency)
+        'http://localhost:3000/auth/login', // Login page (client component, no DB dependency)
       ],
       // Number of runs per URL for consistent results
       numberOfRuns: 3,


### PR DESCRIPTION
## Summary
- Fix Lighthouse CI failure caused by non-existent `/articles` route (404 error)
- Replace `/articles` with `/auth/login` as second test URL
- Add comment in `lighthouserc.js` about verifying routes before updates

## Implementation Details
The Lighthouse CI workflow was failing because `lighthouserc.js` specified `http://localhost:3000/articles` as a test URL, but this route does not exist in the application (only `/articles/[id]` exists for individual article pages).

Changed the URL configuration to use `/auth/login` instead, which is:
- A static page (confirmed as static route with mark in `next build` output)
- No database dependency
- Metrics are expected to be stable due to no data dependencies

## Changes
- `lighthouserc.js`: Updated URL array (lines 14-19)

## Checklist
- [x] Build passing
- [x] Lint passing
- [x] Type-check passing
- [x] Security audit clean
- [ ] Lighthouse CI verification (pending after merge due to CI-only environment)

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **チェア（Chores）**
  * テスト設定のテスト対象URLを記事一覧から認証（ログイン）ルートに変更しました。
  * URL一覧上部に、ビルド後に該当ルートが存在することを確認する注記を追記しました。
  * 起動コマンド、タイムアウト、アサーションなどの他設定に変更はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->