### PR TITLE
feat(sources): add Phase 2 foreign tech engineering blogs (9 sources)

### DIFF
--- a/lib/constants/source-categories.ts
+++ b/lib/constants/source-categories.ts
@@ -75,6 +75,18 @@ export const SOURCE_CATEGORIES: Record<SourceCategoryId, SourceCategory> = {
       'netflix_techblog', // Netflix TechBlog
       'spotify_engineering', // Spotify Engineering
       'pinterest_engineering', // Pinterest Engineering
+      // Phase 2: 大手テック企業
+      'stripe_engineering', // Stripe Engineering
+      'discord_engineering', // Discord Engineering
+      'slack_engineering', // Slack Engineering
+      // Phase 2: クラウドネイティブ・Web
+      'the_new_stack', // The New Stack
+      'cncf_blog', // CNCF Blog
+      'kubernetes_blog', // Kubernetes Blog
+      'chrome_developers', // Chrome Developers
+      // Phase 2: 言語公式ブログ
+      'go_blog', // Go Blog
+      'rust_blog', // Rust Blog
     ],
   },
   domestic: {

--- a/lib/fetchers/generic-foreign-rss.ts
+++ b/lib/fetchers/generic-foreign-rss.ts
@@ -294,6 +294,7 @@ export class GenericForeignRssFetcher extends BaseFetcher {
  * 大手テック企業のエンジニアリングブログ
  */
 export const FOREIGN_SOURCE_CONFIGS: Record<string, ForeignSourceConfig> = {
+  // Phase 1: 大手テック企業エンジニアリングブログ
   'Meta Engineering': {
     feedUrl: 'https://engineering.fb.com/feed/',
     tagPrefix: 'Meta',
@@ -309,6 +310,45 @@ export const FOREIGN_SOURCE_CONFIGS: Record<string, ForeignSourceConfig> = {
   'Pinterest Engineering': {
     feedUrl: 'https://medium.com/feed/pinterest-engineering',
     tagPrefix: 'Pinterest',
+  },
+  // Phase 2: 大手テック企業
+  'Stripe Engineering': {
+    feedUrl: 'https://stripe.com/blog/feed.rss',
+    tagPrefix: 'Stripe',
+  },
+  'Discord Engineering': {
+    feedUrl: 'https://discord.com/blog/rss.xml',
+    tagPrefix: 'Discord',
+  },
+  'Slack Engineering': {
+    feedUrl: 'https://slack.engineering/feed/',
+    tagPrefix: 'Slack',
+  },
+  // Phase 2: クラウドネイティブ・Web
+  'The New Stack': {
+    feedUrl: 'https://thenewstack.io/feed/',
+    tagPrefix: 'CloudNative',
+  },
+  'CNCF Blog': {
+    feedUrl: 'https://www.cncf.io/feed/',
+    tagPrefix: 'CNCF',
+  },
+  'Kubernetes Blog': {
+    feedUrl: 'https://kubernetes.io/feed.xml',
+    tagPrefix: 'Kubernetes',
+  },
+  'Chrome Developers': {
+    feedUrl: 'https://developer.chrome.com/blog/feed.xml',
+    tagPrefix: 'Chrome',
+  },
+  // Phase 2: 言語公式ブログ
+  'Go Blog': {
+    feedUrl: 'https://go.dev/blog/feed.atom',
+    tagPrefix: 'Go',
+  },
+  'Rust Blog': {
+    feedUrl: 'https://blog.rust-lang.org/feed.xml',
+    tagPrefix: 'Rust',
   },
 };
 

--- a/lib/fetchers/index.ts
+++ b/lib/fetchers/index.ts
@@ -173,7 +173,17 @@ export function createFetcher(source: Source): BaseFetcher {
     case 'Meta Engineering':
     case 'Netflix TechBlog':
     case 'Spotify Engineering':
-    case 'Pinterest Engineering': {
+    case 'Pinterest Engineering':
+    // Foreign Tech Company Engineering Blogs (Phase 2)
+    case 'Stripe Engineering':
+    case 'Discord Engineering':
+    case 'Slack Engineering':
+    case 'The New Stack':
+    case 'CNCF Blog':
+    case 'Chrome Developers':
+    case 'Kubernetes Blog':
+    case 'Go Blog':
+    case 'Rust Blog': {
       const foreignConfig = getForeignSourceConfig(source.name);
       if (!foreignConfig) {
         throw new Error(`Invalid foreign source name: ${source.name}`);

--- a/scripts/maintenance/add-foreign-sources-phase2.ts
+++ b/scripts/maintenance/add-foreign-sources-phase2.ts
@@ -1,0 +1,130 @@
+/**
+ * Phase 2: 海外技術ブログソースをDBに登録するスクリプト
+ *
+ * 対象ソース:
+ * - Stripe Engineering
+ * - Discord Engineering
+ * - Slack Engineering
+ * - The New Stack
+ * - CNCF Blog
+ * - Chrome Developers
+ * - Kubernetes Blog
+ * - Go Blog
+ * - Rust Blog
+ *
+ * 使用方法:
+ *   npx tsx scripts/maintenance/add-foreign-sources-phase2.ts
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const PHASE2_SOURCES = [
+  // 大手テック企業
+  {
+    id: 'stripe_engineering',
+    name: 'Stripe Engineering',
+    url: 'https://stripe.com/blog/feed.rss',
+    type: 'RSS',
+    enabled: true,
+  },
+  {
+    id: 'discord_engineering',
+    name: 'Discord Engineering',
+    url: 'https://discord.com/blog/rss.xml',
+    type: 'RSS',
+    enabled: true,
+  },
+  {
+    id: 'slack_engineering',
+    name: 'Slack Engineering',
+    url: 'https://slack.engineering/feed/',
+    type: 'RSS',
+    enabled: true,
+  },
+  // クラウドネイティブ・Web
+  {
+    id: 'the_new_stack',
+    name: 'The New Stack',
+    url: 'https://thenewstack.io/feed/',
+    type: 'RSS',
+    enabled: true,
+  },
+  {
+    id: 'cncf_blog',
+    name: 'CNCF Blog',
+    url: 'https://www.cncf.io/feed/',
+    type: 'RSS',
+    enabled: true,
+  },
+  {
+    id: 'chrome_developers',
+    name: 'Chrome Developers',
+    url: 'https://developer.chrome.com/blog/feed.xml',
+    type: 'RSS',
+    enabled: true,
+  },
+  // 言語公式ブログ
+  {
+    id: 'kubernetes_blog',
+    name: 'Kubernetes Blog',
+    url: 'https://kubernetes.io/feed.xml',
+    type: 'RSS',
+    enabled: true,
+  },
+  {
+    id: 'go_blog',
+    name: 'Go Blog',
+    url: 'https://go.dev/blog/feed.atom',
+    type: 'RSS',
+    enabled: true,
+  },
+  {
+    id: 'rust_blog',
+    name: 'Rust Blog',
+    url: 'https://blog.rust-lang.org/feed.xml',
+    type: 'RSS',
+    enabled: true,
+  },
+];
+
+async function main() {
+  console.log('=== Phase 2: 海外技術ブログソース登録 ===\n');
+
+  let addedCount = 0;
+  let skippedCount = 0;
+
+  for (const source of PHASE2_SOURCES) {
+    // IDとnameの両方でチェック（nameはユニーク制約があるため）
+    const existingById = await prisma.source.findUnique({
+      where: { id: source.id },
+    });
+    const existingByName = await prisma.source.findUnique({
+      where: { name: source.name },
+    });
+
+    if (existingById || existingByName) {
+      const reason = existingById ? 'ID' : 'name';
+      console.log(`[SKIP] ${source.name} - 既に登録済み (${reason})`);
+      skippedCount++;
+      continue;
+    }
+
+    await prisma.source.create({ data: source });
+    console.log(`[ADDED] ${source.name}`);
+    addedCount++;
+  }
+
+  console.log('\n=== 完了 ===');
+  console.log(`追加: ${addedCount}件`);
+  console.log(`スキップ: ${skippedCount}件`);
+  console.log(`合計: ${PHASE2_SOURCES.length}件`);
+}
+
+main()
+  .catch((error) => {
+    console.error('エラーが発生しました:', error);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/scheduled/scheduler.ts
+++ b/scripts/scheduled/scheduler.ts
@@ -237,6 +237,16 @@ const RSS_SOURCES = [
   'Netflix TechBlog',
   'Spotify Engineering',
   'Pinterest Engineering',
+  // 海外テック企業エンジニアリングブログ（Phase 2）
+  'Stripe Engineering',
+  'Discord Engineering',
+  'Slack Engineering',
+  'The New Stack',
+  'CNCF Blog',
+  'Chrome Developers',
+  'Kubernetes Blog',
+  'Go Blog',
+  'Rust Blog',
 ];
 
 // スクレイピング系ソース（12時間ごとに更新）


### PR DESCRIPTION
## Summary
- Add 9 international engineering blog sources (Phase 2)
  - **Tech Companies**: Stripe Engineering, Discord Engineering, Slack Engineering
  - **Cloud Native/Web**: The New Stack, CNCF Blog, Kubernetes Blog, Chrome Developers
  - **Language Blogs**: Go Blog, Rust Blog
- Reuse GenericForeignRssFetcher for all sources (following Phase 1 pattern)
- Add DB registration script for new sources

## Changes
- `lib/fetchers/generic-foreign-rss.ts`: Add 9 source configurations
- `lib/fetchers/index.ts`: Add 9 case statements to createFetcher
- `lib/constants/source-categories.ts`: Add 9 source IDs to foreign category
- `scripts/scheduled/scheduler.ts`: Add 9 sources to RSS_SOURCES
- `scripts/maintenance/add-foreign-sources-phase2.ts`: New DB registration script

## Test Results
All 9 sources tested successfully (136 total articles):
- Stripe: 10, Discord: 26, Slack: 8
- The New Stack: 26, CNCF: 10, Kubernetes: 30, Chrome: 10
- Go: 8, Rust: 8

## Test plan
- [x] npm run lint - passed
- [x] npm run type-check - passed  
- [x] npm audit - passed
- [x] npm run build - passed
- [x] Local DB registration - completed
- [x] Production DB registration - completed
- [x] Codex review - passed
- [x] CodeRabbit review - passed (Kubernetes Blog categorization fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)