### PR TITLE
refactor(docker): optimize Docker Compose configuration

### DIFF
--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -33,7 +33,7 @@ RUN npx playwright install chromium firefox webkit
 COPY --chown=pwuser:pwuser . .
 
 # Build Next.js application for E2E tests
-RUN npm run build || true
+RUN npm run build
 
 # Create necessary directories
 RUN mkdir -p test-results playwright-report tmp .cache

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ npm run monitoring:down
 
 #### Grafana UIアクセス
 
-1. **URL**: http://localhost:3001
+1. **URL**: http://localhost:3002
 2. **ログイン**:
    - Username: `admin`
    - Password: `admin`（初回ログイン時に変更必須）

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build:
@@ -23,7 +21,7 @@ services:
       - /app/tmp
       - /app/.cache
     ports:
-      - "3001:3000"
+      - "127.0.0.1:3001:3000"
     env_file:
       - .env
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     build:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,11 +1,9 @@
-version: "3.9"
-
 services:
   loki:
     image: grafana/loki:3.0.0
     command: ["-config.file=/etc/loki/local-config.yaml"]
     ports:
-      - "3100:3100"
+      - "127.0.0.1:3100:3100"
     volumes:
       - ./loki-config.yaml:/etc/loki/local-config.yaml:ro
       - loki_data:/loki
@@ -18,7 +16,7 @@ services:
     image: grafana/tempo:2.4.1
     command: ["-config.file=/etc/tempo/config.yaml"]
     ports:
-      - "3200:3200"
+      - "127.0.0.1:3200:3200"
     volumes:
       - ./tempo-config.yaml:/etc/tempo/config.yaml:ro
       - tempo_data:/var/tempo
@@ -30,10 +28,10 @@ services:
   grafana:
     image: grafana/grafana:11.2.0
     ports:
-      - "3001:3000"
+      - "127.0.0.1:3002:3000"
     environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro

--- a/docker-compose.otel.yml
+++ b/docker-compose.otel.yml
@@ -1,12 +1,10 @@
-version: "3.9"
-
 services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.101.0
     command: ["--config=/etc/otel-collector-config.yaml"]
     ports:
-      - "4317:4317"  # OTLP gRPC
-      - "4318:4318"  # OTLP HTTP
+      - "127.0.0.1:4317:4317"  # OTLP gRPC
+      - "127.0.0.1:4318:4318"  # OTLP HTTP
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
     healthcheck:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,3 +1,15 @@
+x-common-test-env: &common-test-env
+  DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres_test_password}@postgres-test:5432/techtrend_test
+  TEST_DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres_test_password}@postgres-test:5432/techtrend_test
+  REDIS_URL: redis://:${REDIS_PASSWORD:-redis_test_password}@redis-test:6379
+  NODE_ENV: test
+  CI: "true"
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres_test_password}
+  GEMINI_API_KEY: ${GEMINI_API_KEY}
+  AUTH_SECRET: ${AUTH_SECRET:-test-secret-key-for-testing-only-32-chars}
+  NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-test-secret-key-for-testing-only-32-chars}
+  PRISMA_MIGRATION_ENGINE_SKIP_TRANSACTIONS: "1"
+
 services:
   postgres-test:
     build:
@@ -48,20 +60,11 @@ services:
     container_name: techtrend-node-ci
     working_dir: /app
     environment:
-      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres_test_password}@postgres-test:5432/techtrend_test
-      TEST_DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres_test_password}@postgres-test:5432/techtrend_test
-      REDIS_URL: redis://:${REDIS_PASSWORD:-redis_test_password}@redis-test:6379
-      NODE_ENV: test
-      CI: true
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres_test_password}
-      GEMINI_API_KEY: ${GEMINI_API_KEY}
-      AUTH_SECRET: ${AUTH_SECRET:-test-secret-key-for-testing-only-32-chars}
-      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-test-secret-key-for-testing-only-32-chars}
+      <<: *common-test-env
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-test-github-client-id}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-test-github-client-secret}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-test-google-client-id}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-test-google-client-secret}
-      PRISMA_MIGRATION_ENGINE_SKIP_TRANSACTIONS: "1"
     init: true
     depends_on:
       postgres-test:
@@ -78,17 +81,8 @@ services:
     container_name: techtrend-playwright-e2e
     working_dir: /app
     environment:
-      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres_test_password}@postgres-test:5432/techtrend_test
-      TEST_DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres_test_password}@postgres-test:5432/techtrend_test
-      REDIS_URL: redis://:${REDIS_PASSWORD:-redis_test_password}@redis-test:6379
+      <<: *common-test-env
       BASE_URL: http://localhost:3000
-      NODE_ENV: test
-      CI: true
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres_test_password}
-      GEMINI_API_KEY: ${GEMINI_API_KEY}
-      AUTH_SECRET: ${AUTH_SECRET:-test-secret-key-for-testing-only-32-chars}
-      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-test-secret-key-for-testing-only-32-chars}
-      PRISMA_MIGRATION_ENGINE_SKIP_TRANSACTIONS: "1"
       NEXT_PUBLIC_ENABLE_AI_SEARCH: "true"
     volumes:
       - ./__tests__:/app/__tests__:ro


### PR DESCRIPTION
## Summary

- Remove obsolete `version` key from 4 compose files (Docker Compose V2 migration)
- Bind all exposed ports to `127.0.0.1` for security (app, otel, monitoring)
- Resolve port conflict: Grafana 3001 → 3002 (was conflicting with app service)
- Parameterize Grafana admin credentials via environment variables
- Extract common test environment variables into YAML anchor (`x-common-test-env`) to eliminate 14-line duplication
- Remove `|| true` from `Dockerfile.playwright` build step (was silently ignoring build failures)

## Changed Files

| File | Change |
|------|--------|
| `docker-compose.dev.yml` | Remove `version` key |
| `docker-compose.app.yml` | Remove `version` key, bind port to 127.0.0.1 |
| `docker-compose.otel.yml` | Remove `version` key, bind ports to 127.0.0.1 |
| `docker-compose.monitoring.yml` | Remove `version` key, bind ports to 127.0.0.1, Grafana port 3001→3002, parameterize credentials |
| `docker-compose.test.yml` | YAML anchor for shared env vars (DRY) |
| `Dockerfile.playwright` | Remove `\|\| true` from build command |
| `README.md` | Update Grafana URL to port 3002 |

## Verification

- [x] `docker compose config` passed for all 5 compose files
- [x] Lint passed
- [x] Type-check passed
- [x] Security audit passed (0 vulnerabilities)
- [x] Code review: no critical issues, port reference consistency verified
- [x] Codex review: YAML anchor expansion verified with `docker compose config`

## Test plan

- [ ] `docker compose -f docker-compose.dev.yml up -d` starts postgres/redis correctly
- [ ] `npm run docker:test` passes (test environment with YAML anchor)
- [ ] `docker compose -f docker-compose.monitoring.yml up -d` starts Grafana on port 3002
- [ ] `docker compose -f docker-compose.otel.yml up -d` starts collector with 127.0.0.1 binding
- [ ] `npm run docker:build:e2e` succeeds (Dockerfile.playwright without `|| true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)