### PR TITLE
fix(personalization): exclude arXiv papers from personalized top page results

### DIFF
--- a/__tests__/lib/personalization/category-filter-service.test.ts
+++ b/__tests__/lib/personalization/category-filter-service.test.ts
@@ -25,7 +25,9 @@ const mockPrisma = {
     count: jest.fn(),
   },
   $queryRaw: jest.fn(),
-  $transaction: jest.fn((fn: (tx: typeof mockPrisma) => Promise<any>) => fn(mockPrisma)),
+  $transaction: jest.fn((fn: (tx: typeof mockPrisma) => Promise<any>) =>
+    fn(mockPrisma)
+  ),
 };
 
 jest.mock('@/lib/prisma', () => ({
@@ -56,7 +58,7 @@ describe('CategoryFilterService', () => {
   // ===========================================================================
 
   describe('calculateRecencyDecay', () => {
-    it('should return 1.0 for today\'s article', () => {
+    it("should return 1.0 for today's article", () => {
       const today = new Date();
       const decay = calculateRecencyDecay(today);
       expect(decay).toBeCloseTo(1.0, 2);
@@ -93,7 +95,11 @@ describe('CategoryFilterService', () => {
       const hasTagMatch = true;
       const recencyDecay = 0.9;
 
-      const score = calculateFinalScore(embeddingSimilarity, hasTagMatch, recencyDecay);
+      const score = calculateFinalScore(
+        embeddingSimilarity,
+        hasTagMatch,
+        recencyDecay
+      );
 
       // Expected: 0.8 + 0.03 * 1 + 0.1 * 0.9 = 0.8 + 0.03 + 0.09 = 0.92
       expect(score).toBeCloseTo(0.92, 2);
@@ -104,7 +110,11 @@ describe('CategoryFilterService', () => {
       const hasTagMatch = false;
       const recencyDecay = 0.9;
 
-      const score = calculateFinalScore(embeddingSimilarity, hasTagMatch, recencyDecay);
+      const score = calculateFinalScore(
+        embeddingSimilarity,
+        hasTagMatch,
+        recencyDecay
+      );
 
       // Expected: 0.8 + 0.03 * 0 + 0.1 * 0.9 = 0.8 + 0 + 0.09 = 0.89
       expect(score).toBeCloseTo(0.89, 2);
@@ -120,7 +130,12 @@ describe('CategoryFilterService', () => {
         recencyBeta: 0.2,
       };
 
-      const score = calculateFinalScore(embeddingSimilarity, hasTagMatch, recencyDecay, customParams);
+      const score = calculateFinalScore(
+        embeddingSimilarity,
+        hasTagMatch,
+        recencyDecay,
+        customParams
+      );
 
       // Expected: 0.8 + 0.1 * 1 + 0.2 * 0.9 = 0.8 + 0.1 + 0.18 = 1.08
       expect(score).toBeCloseTo(1.08, 2);
@@ -142,7 +157,10 @@ describe('CategoryFilterService', () => {
       const result = computeWeightedCentroid(centroids);
 
       // Average: [0.5, 0.5, 0], normalized: [0.707, 0.707, 0]
-      const parsed = result.replace(/^\[|\]$/g, '').split(',').map(Number);
+      const parsed = result
+        .replace(/^\[|\]$/g, '')
+        .split(',')
+        .map(Number);
       expect(parsed[0]).toBeCloseTo(0.707, 2);
       expect(parsed[1]).toBeCloseTo(0.707, 2);
       expect(parsed[2]).toBeCloseTo(0, 2);
@@ -153,7 +171,10 @@ describe('CategoryFilterService', () => {
       const weights = [3, 1]; // 3:1 ratio, favor first
 
       const result = computeWeightedCentroid(centroids, weights);
-      const parsed = result.replace(/^\[|\]$/g, '').split(',').map(Number);
+      const parsed = result
+        .replace(/^\[|\]$/g, '')
+        .split(',')
+        .map(Number);
 
       // Weighted average: [0.75, 0.25, 0], normalized
       // Norm = sqrt(0.75^2 + 0.25^2) = sqrt(0.5625 + 0.0625) = sqrt(0.625) ~ 0.79
@@ -162,12 +183,16 @@ describe('CategoryFilterService', () => {
     });
 
     it('should throw error for empty centroids array', () => {
-      expect(() => computeWeightedCentroid([])).toThrow('No centroids provided');
+      expect(() => computeWeightedCentroid([])).toThrow(
+        'No centroids provided'
+      );
     });
 
     it('should throw error for mismatched dimensions', () => {
       const centroids = ['[1,0,0]', '[0,1]'];
-      expect(() => computeWeightedCentroid(centroids)).toThrow('Centroid dimensions do not match');
+      expect(() => computeWeightedCentroid(centroids)).toThrow(
+        'Centroid dimensions do not match'
+      );
     });
   });
 
@@ -529,6 +554,247 @@ describe('CategoryFilterService', () => {
       expect(result.meta.appliedCategories).toEqual([]);
       expect(result.articles).toHaveLength(1);
       expect(result.articles[0].articleId).toBe('fallback-1');
+    });
+
+    it('should pass excludeSourceIds to multi-category search', async () => {
+      const excludeSourceIds = ['arxiv-source-id'];
+      mockPrisma.$queryRaw
+        .mockResolvedValueOnce(mockMultiCentroids)
+        .mockResolvedValueOnce(mockCandidatesFrontend)
+        .mockResolvedValueOnce(mockCandidatesBackend)
+        .mockResolvedValueOnce([]);
+
+      await service.filterArticles({
+        categoryIds: ['cat-1', 'cat-2'],
+        periodMonths: 12,
+        limit: 10,
+        excludeSourceIds,
+      });
+
+      // getEmbeddingCandidates is called via $queryRaw (2nd and 3rd calls)
+      // $queryRaw receives tagged template args: [stringsArray, ...values]
+      // Prisma.sql fragments are passed as objects with {strings, values} structure
+      const secondCallValues = mockPrisma.$queryRaw.mock.calls[1].slice(1);
+      const thirdCallValues = mockPrisma.$queryRaw.mock.calls[2].slice(1);
+
+      // The sourceExcludeFilter is a Prisma.sql fragment containing the excludeSourceIds
+      const findExcludeFragment = (values: unknown[]) =>
+        values.find(
+          (v): v is { strings: string[]; values: unknown[] } =>
+            typeof v === 'object' &&
+            v !== null &&
+            'strings' in v &&
+            'values' in v &&
+            (v as { strings: string[] }).strings.some((s: string) =>
+              s.includes('"sourceId"')
+            )
+        );
+
+      const secondFragment = findExcludeFragment(secondCallValues);
+      const thirdFragment = findExcludeFragment(thirdCallValues);
+
+      expect(secondFragment).toBeDefined();
+      expect(secondFragment!.values).toEqual(
+        expect.arrayContaining([excludeSourceIds])
+      );
+      expect(thirdFragment).toBeDefined();
+      expect(thirdFragment!.values).toEqual(
+        expect.arrayContaining([excludeSourceIds])
+      );
+    });
+
+    it('should pass excludeSourceIds to single-category SQL query', async () => {
+      const mockSingleCentroids = [
+        { id: 'cat-1', slug: 'frontend', centroid_embedding: '[0.5,0.5,0]' },
+      ];
+      const excludeSourceIds = ['arxiv-source-id'];
+
+      mockPrisma.$queryRaw
+        .mockResolvedValueOnce(mockSingleCentroids) // getCategoryCentroids
+        .mockResolvedValueOnce(mockCandidatesFrontend) // getEmbeddingCandidates
+        .mockResolvedValueOnce([]); // checkTagMatches
+
+      await service.filterArticles({
+        categoryIds: ['cat-1'],
+        periodMonths: 12,
+        limit: 10,
+        excludeSourceIds,
+      });
+
+      // getEmbeddingCandidates is the 2nd $queryRaw call
+      const secondCallValues = mockPrisma.$queryRaw.mock.calls[1].slice(1);
+
+      // Find the Prisma.sql fragment containing sourceId exclude filter
+      const excludeFragment = secondCallValues.find(
+        (v: unknown): v is { strings: string[]; values: unknown[] } =>
+          typeof v === 'object' &&
+          v !== null &&
+          'strings' in v &&
+          'values' in v &&
+          (v as { strings: string[] }).strings.some((s: string) =>
+            s.includes('"sourceId"')
+          )
+      );
+
+      expect(excludeFragment).toBeDefined();
+      expect(excludeFragment!.values).toEqual(
+        expect.arrayContaining([excludeSourceIds])
+      );
+    });
+
+    it('should apply excludeSourceIds to fallback results when no centroids found', async () => {
+      const excludeSourceIds = ['arxiv-source-id'];
+
+      mockPrisma.$queryRaw.mockResolvedValueOnce([]); // No centroids
+      mockPrisma.article.count.mockResolvedValue(1);
+      mockPrisma.article.findMany.mockResolvedValue([
+        { id: 'fallback-1', publishedAt: new Date() },
+      ]);
+
+      await service.filterArticles({
+        categoryIds: ['non-existent'],
+        periodMonths: 12,
+        limit: 10,
+        excludeSourceIds,
+      });
+
+      // Verify fallback findMany where clause includes sourceId notIn
+      const findManyCall = mockPrisma.article.findMany.mock.calls[0][0];
+      expect(findManyCall.where).toEqual(
+        expect.objectContaining({
+          sourceId: { notIn: excludeSourceIds },
+        })
+      );
+    });
+
+    it('should not add sourceId filter when excludeSourceIds is not specified (backward compatibility)', async () => {
+      const mockSingleCentroids = [
+        { id: 'cat-1', slug: 'frontend', centroid_embedding: '[0.5,0.5,0]' },
+      ];
+
+      // Test embedding path: no excludeSourceIds in SQL
+      mockPrisma.$queryRaw
+        .mockResolvedValueOnce(mockSingleCentroids) // getCategoryCentroids
+        .mockResolvedValueOnce(mockCandidatesFrontend) // getEmbeddingCandidates
+        .mockResolvedValueOnce([]); // checkTagMatches
+
+      await service.filterArticles({
+        categoryIds: ['cat-1'],
+        periodMonths: 12,
+        limit: 10,
+        // excludeSourceIds is not specified
+      });
+
+      // getEmbeddingCandidates is the 2nd $queryRaw call
+      const secondCallValues = mockPrisma.$queryRaw.mock.calls[1].slice(1);
+
+      // When excludeSourceIds is undefined, Prisma.empty is used (no sourceId exclude fragment)
+      const excludeFragment = secondCallValues.find(
+        (v: unknown): v is { strings: string[]; values: unknown[] } =>
+          typeof v === 'object' &&
+          v !== null &&
+          'strings' in v &&
+          'values' in v &&
+          (v as { strings: string[] }).strings.some((s: string) =>
+            s.includes('!= ALL')
+          )
+      );
+      expect(excludeFragment).toBeUndefined();
+
+      // Test fallback path: no sourceId filter in where clause
+      jest.clearAllMocks();
+      mockPrisma.$queryRaw.mockResolvedValueOnce([]); // No centroids
+      mockPrisma.article.count.mockResolvedValue(1);
+      mockPrisma.article.findMany.mockResolvedValue([
+        { id: 'fallback-1', publishedAt: new Date() },
+      ]);
+
+      await service.filterArticles({
+        categoryIds: ['non-existent'],
+        periodMonths: 12,
+        limit: 10,
+        // excludeSourceIds is not specified
+      });
+
+      const findManyCall = mockPrisma.article.findMany.mock.calls[0][0];
+      expect(findManyCall.where).not.toHaveProperty('sourceId');
+    });
+
+    it('should apply excludeSourceIds to fallback when database error occurs', async () => {
+      const excludeSourceIds = ['arxiv-source-id'];
+
+      mockPrisma.$queryRaw.mockRejectedValueOnce(new Error('Database error'));
+      mockPrisma.article.count.mockResolvedValue(1);
+      mockPrisma.article.findMany.mockResolvedValue([
+        { id: 'fallback-1', publishedAt: new Date() },
+      ]);
+
+      await service.filterArticles({
+        categoryIds: ['cat-1'],
+        periodMonths: 12,
+        limit: 10,
+        excludeSourceIds,
+      });
+
+      // Verify fallback findMany where clause includes sourceId notIn
+      const findManyCall = mockPrisma.article.findMany.mock.calls[0][0];
+      expect(findManyCall.where).toEqual(
+        expect.objectContaining({
+          sourceId: { notIn: excludeSourceIds },
+        })
+      );
+    });
+
+    it('should not add sourceId filter when excludeSourceIds is empty array', async () => {
+      const mockSingleCentroids = [
+        { id: 'cat-1', slug: 'frontend', centroid_embedding: '[0.5,0.5,0]' },
+      ];
+
+      mockPrisma.$queryRaw
+        .mockResolvedValueOnce(mockSingleCentroids) // getCategoryCentroids
+        .mockResolvedValueOnce(mockCandidatesFrontend) // getEmbeddingCandidates
+        .mockResolvedValueOnce([]); // checkTagMatches
+
+      await service.filterArticles({
+        categoryIds: ['cat-1'],
+        periodMonths: 12,
+        limit: 10,
+        excludeSourceIds: [], // empty array
+      });
+
+      // getEmbeddingCandidates is the 2nd $queryRaw call
+      const secondCallValues = mockPrisma.$queryRaw.mock.calls[1].slice(1);
+
+      // Empty array should not add exclude filter (Prisma.empty is used)
+      const excludeFragment = secondCallValues.find(
+        (v: unknown): v is { strings: string[]; values: unknown[] } =>
+          typeof v === 'object' &&
+          v !== null &&
+          'strings' in v &&
+          'values' in v &&
+          (v as { strings: string[] }).strings.some((s: string) =>
+            s.includes('!= ALL')
+          )
+      );
+      expect(excludeFragment).toBeUndefined();
+
+      // Test fallback path with empty array
+      jest.clearAllMocks();
+      mockPrisma.$queryRaw.mockResolvedValueOnce([]); // No centroids
+      mockPrisma.article.count.mockResolvedValue(1);
+      mockPrisma.article.findMany.mockResolvedValue([
+        { id: 'fallback-1', publishedAt: new Date() },
+      ]);
+
+      await service.filterArticles({
+        categoryIds: ['non-existent'],
+        periodMonths: 12,
+        limit: 10,
+        excludeSourceIds: [], // empty array
+      });
+
+      const findManyCall = mockPrisma.article.findMany.mock.calls[0][0];
+      expect(findManyCall.where).not.toHaveProperty('sourceId');
     });
 
     it('should apply tag boost from any matching category (OR)', async () => {

--- a/app/api/articles/handlers/get.ts
+++ b/app/api/articles/handlers/get.ts
@@ -288,7 +288,7 @@ async function executePersonalizedQuery(
   params: ParsedQueryParams,
   metrics: MetricsCollector
 ): Promise<ArticleQueryResult | null> {
-  const { pagination, display, personalization } = params;
+  const { pagination, display, personalization, filters } = params;
   const { page, limit, sortBy, sortOrder } = pagination;
   const { categoryIds, periodMonths } = personalization;
 
@@ -300,6 +300,9 @@ async function executePersonalizedQuery(
       offset: (page - 1) * limit,
       sortBy: sortBy as PersonalizedSortBy,
       sortOrder,
+      excludeSourceIds: filters.excludeSources
+        ? filters.excludeSources.split(',').map((s) => s.trim()).filter(Boolean)
+        : undefined,
     };
 
     const { articles: scoredArticles, meta: personalizationMeta } =

--- a/lib/personalization/category-filter-service.ts
+++ b/lib/personalization/category-filter-service.ts
@@ -234,7 +234,7 @@ export class CategoryFilterService {
 
       if (centroids.length === 0) {
         logger.warn({ categoryIds }, 'No centroids found for categories');
-        return this.getFallbackResults(periodMonths, limit, offset, startTime);
+        return this.getFallbackResults(periodMonths, limit, offset, startTime, options.excludeSourceIds);
       }
 
       // Branch: single category vs multiple categories
@@ -247,7 +247,7 @@ export class CategoryFilterService {
         const result = await this.filterArticlesSingleCategory(options, centroids[0]);
         if (result.candidates.length === 0) {
           logger.warn('No embedding candidates found');
-          return this.getFallbackResults(periodMonths, limit, offset, startTime);
+          return this.getFallbackResults(periodMonths, limit, offset, startTime, options.excludeSourceIds);
         }
         qualifiedArticles = result.articles;
         candidateCount = result.candidates.length;
@@ -255,7 +255,7 @@ export class CategoryFilterService {
         // Multiple categories: use OR-based search
         const result = await this.filterArticlesMultiCategory(options, centroids);
         if (result.mergedCount === 0) {
-          return this.getFallbackResults(periodMonths, limit, offset, startTime);
+          return this.getFallbackResults(periodMonths, limit, offset, startTime, options.excludeSourceIds);
         }
         qualifiedArticles = result.articles;
         candidateCount = result.mergedCount;
@@ -305,7 +305,7 @@ export class CategoryFilterService {
         { error: sanitizeError(error), categoryIds },
         'Failed to filter articles'
       );
-      return this.getFallbackResults(periodMonths, limit, offset, startTime);
+      return this.getFallbackResults(periodMonths, limit, offset, startTime, options.excludeSourceIds);
     }
   }
 
@@ -374,7 +374,8 @@ export class CategoryFilterService {
   private async getEmbeddingCandidates(
     centroid: string,
     periodMonths: number,
-    topK: number
+    topK: number,
+    excludeSourceIds?: string[]
   ): Promise<EmbeddingCandidate[]> {
     // Build period filter using calculated date parameter (safer than Prisma.raw)
     const cutoffDate =
@@ -384,6 +385,12 @@ export class CategoryFilterService {
     const periodFilter = cutoffDate
       ? Prisma.sql`AND a."publishedAt" >= ${cutoffDate}`
       : Prisma.empty;
+
+    // Build source exclusion filter
+    const sourceExcludeFilter =
+      excludeSourceIds && excludeSourceIds.length > 0
+        ? Prisma.sql`AND a."sourceId" != ALL(${excludeSourceIds}::text[])`
+        : Prisma.empty;
 
     // Use threshold-based filtering with topK limit
     // similarity = 1 - distance, so distance < (1 - threshold)
@@ -412,6 +419,7 @@ export class CategoryFilterService {
         AND a."summaryComputedAt" IS NOT NULL
         AND (ae.embedding <=> ${centroid}::vector) < ${maxDistance}
         ${periodFilter}
+        ${sourceExcludeFilter}
       ORDER BY ae.embedding <=> ${centroid}::vector
       LIMIT ${effectiveLimit}
     `;
@@ -559,7 +567,8 @@ export class CategoryFilterService {
     const candidates = await this.getEmbeddingCandidates(
       centroid.centroid_embedding!,
       periodMonths,
-      DEFAULT_TOP_K_CANDIDATES
+      DEFAULT_TOP_K_CANDIDATES,
+      options.excludeSourceIds
     );
 
     if (candidates.length === 0) {
@@ -604,7 +613,7 @@ export class CategoryFilterService {
 
     // Parallel search per category using Promise.allSettled for graceful partial failure handling
     const searchPromises = centroids.map((c) =>
-      this.getEmbeddingCandidates(c.centroid_embedding!, periodMonths, kPerCategory)
+      this.getEmbeddingCandidates(c.centroid_embedding!, periodMonths, kPerCategory, options.excludeSourceIds)
     );
     const settledResults = await Promise.allSettled(searchPromises);
 
@@ -682,7 +691,8 @@ export class CategoryFilterService {
     periodMonths: number,
     limit: number,
     offset: number,
-    startTime: number
+    startTime: number,
+    excludeSourceIds?: string[]
   ): Promise<{ articles: ScoredArticle[]; meta: PersonalizedFilterMeta }> {
     logger.info('Using fallback: recent articles by published date');
 
@@ -690,6 +700,9 @@ export class CategoryFilterService {
       summaryComputedAt: { not: null },
       ...(periodMonths > 0
         ? { publishedAt: { gte: new Date(Date.now() - periodMonths * 30 * 24 * 60 * 60 * 1000) } }
+        : {}),
+      ...(excludeSourceIds && excludeSourceIds.length > 0
+        ? { sourceId: { notIn: excludeSourceIds } }
         : {}),
     };
 

--- a/lib/personalization/types.ts
+++ b/lib/personalization/types.ts
@@ -87,6 +87,7 @@ export interface PersonalizedFilterOptions {
   offset?: number;
   sortBy?: PersonalizedSortBy;
   sortOrder?: 'asc' | 'desc';
+  excludeSourceIds?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- パーソナライズ機能有効時にarXiv論文がトップページに表示されるバグを修正
- `CategoryFilterService`が共有クエリビルダの`excludeSources`フィルタをバイパスしていた根本原因に対応
- embedding検索（pgvector）とフォールバック（Prisma ORM）の両経路でソース除外を実装

## Implementation Details

### Root Cause
`HomeClientInfinite`から渡される`excludeSources`パラメータが、パーソナライズ経路（`CategoryFilterService`）に伝播していなかった。通常経路は`buildWhereClause`で処理されるが、パーソナライズ経路は独自のSQL/Prismaクエリを使用するため、除外ロジックが欠落していた。

### Changes

| File | Change |
|------|--------|
| `lib/personalization/types.ts` | `PersonalizedFilterOptions`に`excludeSourceIds?: string[]`追加 |
| `lib/personalization/category-filter-service.ts` | `getEmbeddingCandidates`にSQL除外フィルタ追加、`getFallbackResults`にPrisma notIn条件追加、全4箇所のフォールバック呼び出しにパラメータ伝播 |
| `app/api/articles/handlers/get.ts` | `executePersonalizedQuery`で`filters.excludeSources`を解析して`excludeSourceIds`に変換 |
| `__tests__/lib/personalization/category-filter-service.test.ts` | 6テストケース追加 |

### Technical Notes
- embedding検索: `Prisma.sql`タグ付きテンプレートで`AND a."sourceId" != ALL(${excludeSourceIds}::text[])`
- フォールバック: Prisma ORM `sourceId: { notIn: excludeSourceIds }`
- オプショナルフィールドのため後方互換性あり（未指定時は既存動作と同一）

## Test Results

全32テストパス（6件追加、既存26件影響なし）

| Test Case | Coverage |
|-----------|----------|
| Multi-category excludeSourceIds propagation | embedding検索（複数カテゴリ） |
| Single-category SQL query inclusion | embedding検索（単一カテゴリ） |
| Fallback with no centroids | フォールバック経路 |
| Backward compatibility (undefined) | 後方互換性 |
| Fallback on database error | エラー時フォールバック |
| Empty array edge case | エッジケース |

## Checklist
- [x] Tests passing (32/32)
- [x] Type check passing
- [x] Lint passing
- [x] Docker build passing
- [x] No breaking changes (optional field addition)

Generated with [Claude Code](https://claude.com/claude-code)