### PR TITLE
feat(article-detail): show list summary as overview above detailed summary

### DIFF
--- a/app/articles/[id]/page.tsx
+++ b/app/articles/[id]/page.tsx
@@ -285,19 +285,31 @@ export default async function ArticlePage({ params, searchParams }: PageProps) {
                 </div>
               ) : article.detailedSummary &&
                 article.detailedSummary !== '__SKIP_DETAILED_SUMMARY__' ? (
-                <DetailedSummaryDisplay
-                  detailedSummary={article.detailedSummary}
-                  articleType={
-                    article.articleType as
-                      | 'release'
-                      | 'problem-solving'
-                      | 'tutorial'
-                      | 'tech-intro'
-                      | 'implementation'
-                      | undefined
-                  }
-                  summaryVersion={article.summaryVersion}
-                />
+                <>
+                  {article.summary && (
+                    <div className="rounded-lg border-l-4 border-[var(--tt-color-primary)] bg-[var(--tt-color-primary)]/5 p-4">
+                      <p className="mb-1 text-sm font-semibold tracking-tight">
+                        概要
+                      </p>
+                      <p className="text-foreground/80 text-sm leading-relaxed">
+                        {article.summary}
+                      </p>
+                    </div>
+                  )}
+                  <DetailedSummaryDisplay
+                    detailedSummary={article.detailedSummary}
+                    articleType={
+                      article.articleType as
+                        | 'release'
+                        | 'problem-solving'
+                        | 'tutorial'
+                        | 'tech-intro'
+                        | 'implementation'
+                        | undefined
+                    }
+                    summaryVersion={article.summaryVersion}
+                  />
+                </>
               ) : article.summary ? (
                 <div className="bg-muted rounded-lg p-4">
                   <p className="mb-1 text-sm font-medium">要約</p>


### PR DESCRIPTION
## Summary
- 記事詳細画面で、詳細要約（detailedSummary）の上に一覧要約（summary）を「概要」ブロックとして表示
- 左ボーダー + プライマリカラー背景で詳細要約セクションと視覚的に区別
- ユーザーが記事全体像を素早く把握してから詳細を読める（段階的開示）

## Implementation Details
- 変更ファイル: `app/articles/[id]/page.tsx`（1ファイルのみ）
- `detailedSummary`表示分岐内にFragmentを追加し、`article.summary`存在時に概要ブロックを表示
- スタイル: `border-l-4 border-[var(--tt-color-primary)] bg-[var(--tt-color-primary)]/5`
- 既存の表示条件（スライド/短記事/summaryのみ）への影響なし

## Checklist
- [x] Type check passing
- [x] Lint passing
- [x] Security audit passing (0 vulnerabilities)
- [x] Docker build passing
- [x] No breaking changes

Generated with [Claude Code](https://claude.com/claude-code)