### PR TITLE
fix(ai): ensure Japanese output in summary generation prompts

### DIFF
--- a/lib/ai/adapter/__tests__/prompt-builder.test.ts
+++ b/lib/ai/adapter/__tests__/prompt-builder.test.ts
@@ -46,8 +46,8 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('Tone: formal');
-      expect(prompt).toContain('professional language');
+      expect(prompt).toContain('トーン: フォーマル');
+      expect(prompt).toContain('専門的で正確な用語');
     });
 
     it('should include article type guidance when specified', () => {
@@ -64,8 +64,8 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('Article type: technical');
-      expect(prompt).toContain('implementation details');
+      expect(prompt).toContain('記事タイプ: 技術記事');
+      expect(prompt).toContain('実装の詳細');
     });
   });
 
@@ -84,9 +84,9 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('12000 characters (very long)');
-      expect(prompt).toContain('detailedSummaryItems: 7-9 items');
-      expect(prompt).toContain('120-180 characters with specific details');
+      expect(prompt).toContain('12000文字（非常に長い）');
+      expect(prompt).toContain('detailedSummaryItems: 7-9項目');
+      expect(prompt).toContain('120-180文字');
       expect(prompt).toContain(
         'IMPORTANT: The above metadata is for your reference only'
       );
@@ -106,9 +106,9 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('7000 characters (long)');
-      expect(prompt).toContain('detailedSummaryItems: 5-7 items');
-      expect(prompt).toContain('120-200 characters with concrete details');
+      expect(prompt).toContain('7000文字（長い）');
+      expect(prompt).toContain('detailedSummaryItems: 5-7項目');
+      expect(prompt).toContain('120-200文字');
     });
 
     it('should generate instructions for medium content (3000-4999 chars)', () => {
@@ -125,9 +125,9 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('4000 characters');
-      expect(prompt).toContain('detailedSummaryItems: 4-5 items');
-      expect(prompt).toContain('150-200 characters');
+      expect(prompt).toContain('4000文字');
+      expect(prompt).toContain('detailedSummaryItems: 4-5項目');
+      expect(prompt).toContain('150-200文字');
     });
 
     it('should generate instructions for short content (1000-2999 chars)', () => {
@@ -144,9 +144,9 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('1500 characters');
-      expect(prompt).toContain('detailedSummaryItems: 3-4 items');
-      expect(prompt).toContain('130-175 characters');
+      expect(prompt).toContain('1500文字');
+      expect(prompt).toContain('detailedSummaryItems: 3-4項目');
+      expect(prompt).toContain('130-175文字');
     });
 
     it('should generate instructions for short-medium content (400-999 chars)', () => {
@@ -163,9 +163,9 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('500 characters (short)');
-      expect(prompt).toContain('detailedSummaryItems: 2-3 items');
-      expect(prompt).toContain('80-200 characters');
+      expect(prompt).toContain('500文字（短い）');
+      expect(prompt).toContain('detailedSummaryItems: 2-3項目');
+      expect(prompt).toContain('80-200文字');
     });
 
     it('should generate instructions for very short content (<400 chars)', () => {
@@ -182,9 +182,9 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('200 characters (very short)');
-      expect(prompt).toContain('empty array []');
-      expect(prompt).toContain('Focus only on writing a good summary field');
+      expect(prompt).toContain('200文字（非常に短い）');
+      expect(prompt).toContain('空配列[]');
+      expect(prompt).toContain('summaryフィールドの作成のみに集中');
     });
   });
 
@@ -203,7 +203,7 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('detailedSummaryItems: 6-8 items');
+      expect(prompt).toContain('detailedSummaryItems: 6-8項目');
     });
 
     it('should adjust item count for short policy', () => {
@@ -221,7 +221,7 @@ describe('PromptBuilder', () => {
       const prompt = builder.buildPrompt(input);
 
       // short policy: min=max(5, floor(5*0.8))=5, max=max(5, floor(7*0.8))=5
-      expect(prompt).toContain('detailedSummaryItems: 5-5 items');
+      expect(prompt).toContain('detailedSummaryItems: 5-5項目');
     });
 
     it('should use default multiplier for medium policy', () => {
@@ -238,7 +238,7 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('detailedSummaryItems: 5-7 items');
+      expect(prompt).toContain('detailedSummaryItems: 5-7項目');
     });
   });
 
@@ -257,8 +257,8 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('Tone: formal');
-      expect(prompt).toContain('professional language and precise terminology');
+      expect(prompt).toContain('トーン: フォーマル');
+      expect(prompt).toContain('専門的で正確な用語を使用');
     });
 
     it('should add casual tone guidance', () => {
@@ -275,8 +275,8 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('Tone: casual');
-      expect(prompt).toContain('approachable and friendly language');
+      expect(prompt).toContain('トーン: カジュアル');
+      expect(prompt).toContain('親しみやすく分かりやすい表現');
     });
 
     it('should not add tone guidance when not specified', () => {
@@ -292,7 +292,7 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).not.toContain('Tone:');
+      expect(prompt).not.toContain('トーン:');
     });
   });
 
@@ -311,8 +311,8 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('Article type: technical');
-      expect(prompt).toContain('implementation details, specifications');
+      expect(prompt).toContain('記事タイプ: 技術記事');
+      expect(prompt).toContain('実装の詳細、仕様');
     });
 
     it('should add news article guidance', () => {
@@ -329,8 +329,8 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('Article type: news');
-      expect(prompt).toContain('announcements, new features');
+      expect(prompt).toContain('記事タイプ: ニュース');
+      expect(prompt).toContain('発表内容、新機能');
     });
 
     it('should add tutorial article guidance', () => {
@@ -347,8 +347,8 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('Article type: tutorial');
-      expect(prompt).toContain('steps, implementation methods');
+      expect(prompt).toContain('記事タイプ: チュートリアル');
+      expect(prompt).toContain('手順、実装方法');
     });
 
     it('should add opinion article guidance', () => {
@@ -365,8 +365,8 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).toContain('Article type: opinion');
-      expect(prompt).toContain("author's perspective");
+      expect(prompt).toContain('記事タイプ: オピニオン');
+      expect(prompt).toContain('著者の見解');
     });
 
     it('should not add article type guidance when not specified', () => {
@@ -382,7 +382,7 @@ describe('PromptBuilder', () => {
 
       const prompt = builder.buildPrompt(input);
 
-      expect(prompt).not.toContain('Article type:');
+      expect(prompt).not.toContain('記事タイプ:');
     });
   });
 
@@ -441,11 +441,11 @@ describe('PromptBuilder', () => {
       const prompt = builder.buildPrompt(input);
 
       expect(prompt).toContain('タイトル: Complex Article');
-      expect(prompt).toContain('Tone: formal');
-      expect(prompt).toContain('Article type: technical');
-      expect(prompt).toContain('5000 characters (long)');
+      expect(prompt).toContain('トーン: フォーマル');
+      expect(prompt).toContain('記事タイプ: 技術記事');
+      expect(prompt).toContain('5000文字（長い）');
       // long policy on 5000-9999: min=max(5,floor(5*1.2))=6, max=max(6,floor(7*1.2))=8
-      expect(prompt).toContain('detailedSummaryItems: 6-8 items');
+      expect(prompt).toContain('detailedSummaryItems: 6-8項目');
     });
   });
 });

--- a/lib/ai/adapter/gemini-summary-adapter.ts
+++ b/lib/ai/adapter/gemini-summary-adapter.ts
@@ -25,23 +25,23 @@ const SUMMARY_JSON_SCHEMA = {
   properties: {
     summary: {
       type: 'STRING',
-      description: '150-250 characters, one-line article summary',
+      description: '記事の一行要約。150-250文字で必ず日本語で記述すること',
     },
     detailedSummaryItems: {
       type: 'ARRAY',
-      description: 'Detailed summary items with specific titles and content',
+      description: '詳細要約の項目リスト。必ず日本語で記述すること',
       items: {
         type: 'OBJECT',
         properties: {
           title: {
             type: 'STRING',
             description:
-              'Specific title for this item (generic names like "overview" are prohibited)',
+              'この項目の具体的なタイトル（「概要」「背景」等の汎用名は禁止）。必ず日本語で記述',
           },
           content: {
             type: 'STRING',
             description:
-              'Detailed content with 2-3 sentences of concrete information (120-200 characters per item)',
+              '具体的な情報を含む詳細内容（120-200文字）。必ず日本語で記述',
           },
         },
         required: ['title', 'content'],
@@ -49,7 +49,7 @@ const SUMMARY_JSON_SCHEMA = {
     },
     category: {
       type: 'STRING',
-      description: 'Article category',
+      description: '記事のカテゴリ',
       enum: [
         'Programming Language',
         'Framework/Library',
@@ -65,7 +65,7 @@ const SUMMARY_JSON_SCHEMA = {
     },
     tags: {
       type: 'ARRAY',
-      description: '3-5 technical tags',
+      description: '3-5個の技術タグ（技術用語は英語の正式名称を使用）',
       items: { type: 'STRING' },
     },
   },

--- a/lib/ai/adapter/prompt-builder.ts
+++ b/lib/ai/adapter/prompt-builder.ts
@@ -3,6 +3,11 @@ import { SummaryProviderInput } from './summary-provider.interface';
 const SYSTEM_INSTRUCTIONS = `
 あなたは技術記事の要約を生成する専門AIです。以下のルールを厳守してください：
 
+【言語ルール（最重要）】
+- summary、detailedSummaryItemsの全フィールド（title, content）は必ず日本語で記述してください
+- 英語の記事であっても、要約は必ず日本語で生成してください
+- tagsは技術用語の正式名称（英語可）を使用してください
+
 【一覧要約ルール（summaryフィールド）】
 - 150-250文字で記事の核心を端的に表現する
 - 技術的価値を明確に示す
@@ -89,9 +94,9 @@ export class PromptBuilder {
     if (contentLength < 400) {
       return `
 
-Article is ${contentLength} characters (very short).
-Set detailedSummaryItems to an empty array [].
-Focus only on writing a good summary field.
+記事は${contentLength}文字（非常に短い）です。
+detailedSummaryItemsは空配列[]にしてください。
+summaryフィールドの作成のみに集中してください。
 ${METADATA_WARNING}`;
     }
 
@@ -103,40 +108,40 @@ ${METADATA_WARNING}`;
       const maxItems = Math.max(minItems, Math.floor(9 * policyMultiplier));
       return `
 
-Article is ${contentLength} characters (very long).
-detailedSummaryItems: ${minItems}-${maxItems} items.
-Each item's content: 120-180 characters with specific details (versions, metrics, dates, commands).
-TOTAL detailedSummaryItems length MUST NOT exceed 1500 characters. Prioritize item count over item length.
+記事は${contentLength}文字（非常に長い）です。
+detailedSummaryItems: ${minItems}-${maxItems}項目。
+各項目のcontent: 具体的な詳細（バージョン、数値、日付、コマンド等）を含め120-180文字。
+detailedSummaryItems全体の合計は1500文字以内。項目数を優先し、1項目あたりの長さは抑えてください。
 ${METADATA_WARNING}`;
     } else if (contentLength >= 5000) {
       const minItems = Math.max(5, Math.floor(5 * policyMultiplier));
       const maxItems = Math.max(minItems, Math.floor(7 * policyMultiplier));
       return `
 
-Article is ${contentLength} characters (long).
-detailedSummaryItems: ${minItems}-${maxItems} items.
-Each item's content: 120-200 characters with concrete details.
-TOTAL detailedSummaryItems length MUST NOT exceed 1200 characters. Prioritize total limit over per-item length.
+記事は${contentLength}文字（長い）です。
+detailedSummaryItems: ${minItems}-${maxItems}項目。
+各項目のcontent: 具体的な詳細を含め120-200文字。
+detailedSummaryItems全体の合計は1200文字以内。合計文字数を優先してください。
 ${METADATA_WARNING}`;
     } else if (contentLength >= 3000) {
       const minItems = Math.max(4, Math.floor(4 * policyMultiplier));
       const maxItems = Math.max(minItems, Math.floor(5 * policyMultiplier));
       return `
 
-Article is ${contentLength} characters.
-detailedSummaryItems: ${minItems}-${maxItems} items.
-Each item's content: 150-200 characters.
-TOTAL detailedSummaryItems length MUST NOT exceed 1000 characters. Prioritize total limit over per-item length.
+記事は${contentLength}文字です。
+detailedSummaryItems: ${minItems}-${maxItems}項目。
+各項目のcontent: 150-200文字。
+detailedSummaryItems全体の合計は1000文字以内。合計文字数を優先してください。
 ${METADATA_WARNING}`;
     } else if (contentLength >= 1000) {
       const minItems = Math.max(3, Math.floor(3 * policyMultiplier));
       const maxItems = Math.max(minItems, Math.floor(4 * policyMultiplier));
       return `
 
-Article is ${contentLength} characters.
-detailedSummaryItems: ${minItems}-${maxItems} items.
-Each item's content: 130-175 characters.
-TOTAL detailedSummaryItems length MUST NOT exceed 700 characters. Prioritize total limit over per-item length.
+記事は${contentLength}文字です。
+detailedSummaryItems: ${minItems}-${maxItems}項目。
+各項目のcontent: 130-175文字。
+detailedSummaryItems全体の合計は700文字以内。合計文字数を優先してください。
 ${METADATA_WARNING}`;
     } else {
       // 400-999 characters
@@ -144,10 +149,10 @@ ${METADATA_WARNING}`;
       const maxItems = Math.max(minItems, Math.floor(3 * policyMultiplier));
       return `
 
-Article is ${contentLength} characters (short).
-detailedSummaryItems: ${minItems}-${maxItems} items.
-Each item's content: 80-200 characters.
-TOTAL detailedSummaryItems length MUST NOT exceed 600 characters. Prioritize total limit over per-item length.
+記事は${contentLength}文字（短い）です。
+detailedSummaryItems: ${minItems}-${maxItems}項目。
+各項目のcontent: 80-200文字。
+detailedSummaryItems全体の合計は600文字以内。合計文字数を優先してください。
 ${METADATA_WARNING}`;
     }
   }
@@ -158,9 +163,9 @@ ${METADATA_WARNING}`;
     }
 
     if (tone === 'formal') {
-      return '\n\nTone: formal. Use professional language and precise terminology.';
+      return '\n\nトーン: フォーマル。専門的で正確な用語を使用してください。';
     } else {
-      return '\n\nTone: casual. Use approachable and friendly language.';
+      return '\n\nトーン: カジュアル。親しみやすく分かりやすい表現を使用してください。';
     }
   }
 
@@ -173,12 +178,12 @@ ${METADATA_WARNING}`;
 
     const typeGuidance: Record<string, string> = {
       technical:
-        '\n\nArticle type: technical. Focus on implementation details, specifications, and performance characteristics.',
-      news: '\n\nArticle type: news. Focus on announcements, new features, impact, and future outlook.',
+        '\n\n記事タイプ: 技術記事。実装の詳細、仕様、パフォーマンス特性に焦点を当ててください。',
+      news: '\n\n記事タイプ: ニュース。発表内容、新機能、影響、今後の展望に焦点を当ててください。',
       tutorial:
-        '\n\nArticle type: tutorial. Focus on steps, implementation methods, code examples, and caveats.',
+        '\n\n記事タイプ: チュートリアル。手順、実装方法、コード例、注意点に焦点を当ててください。',
       opinion:
-        "\n\nArticle type: opinion. Focus on the author's perspective, pros/cons, and recommendations.",
+        '\n\n記事タイプ: オピニオン。著者の見解、メリット・デメリット、推奨事項に焦点を当ててください。',
     };
 
     return typeGuidance[articleType] || '';


### PR DESCRIPTION
## Summary

- **Why**: PR #403でGemini Structured Output (JSON Schema)移行時、JSON Schemaのdescriptionと動的プロンプト指示が英語のまま残っていた。英語ソース記事の要約がそのまま英語で生成されるケースが本番DBで3件確認された
- **What**: JSON Schema descriptionの日本語化、言語ルール明示追加、動的プロンプト指示の日本語化
- **Impact**: JSONフィールド契約（category/tags含む）は不変。出力言語の挙動を日本語優先に変更（意図的な仕様修正）

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `gemini-summary-adapter.ts` | `SUMMARY_JSON_SCHEMA`のdescriptionを日本語化（summary, detailedSummaryItems, title, content, tags） |
| `prompt-builder.ts` | `SYSTEM_INSTRUCTIONS`に【言語ルール（最重要）】セクション追加。`buildItemCountInstruction()`/`buildToneGuidance()`/`buildArticleTypeGuidance()`の英語指示を日本語化 |
| `prompt-builder.test.ts` | 日本語化されたプロンプト文字列に合わせてアサーション更新 |

## Before / After

英語記事入力時の要約出力:
- **Before**: `"summary": "This article discusses the new features of React 19..."`
- **After**: `"summary": "React 19の新機能について解説する記事です。..."`

## Test Results

- `prompt-builder.test.ts`: 23 passed
- `gemini-summary-adapter.test.ts`: 27 passed（adapter側はJSON Schema descriptionを直接アサートしていないため変更不要。Structured Output経由の統合テストで担保）
- lint: 0 errors, 0 warnings
- type-check: passed
- build: passed

## Post-Deploy

本番DBの英語要約3件はデプロイ後に `regenerateSummaries()` で手動再生成予定

## Checklist
- [x] Tests passing
- [x] lint / type-check / build all passed
- [x] JSON field contract unchanged (category/tags)
- [x] Output language behavior intentionally changed to Japanese-first

Generated with [Claude Code](https://claude.com/claude-code)