### PR TITLE
fix: add Anthropic News to scraping scheduler

### DIFF
--- a/.github/workflows/scheduler-scraping.yml
+++ b/.github/workflows/scheduler-scraping.yml
@@ -53,7 +53,7 @@ jobs:
           SLACK_NOTIFICATION_ENABLED: ${{ secrets.SLACK_NOTIFICATION_ENABLED }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          npx tsx scripts/scheduled/collect-feeds.ts "Speaker Deck" "Docswell" "Claude Blog"
+          npx tsx scripts/scheduled/collect-feeds.ts "Speaker Deck" "Docswell" "Claude Blog" "Anthropic News"
           npx tsx scripts/scheduled/manage-summaries.ts generate
           npx tsx scripts/scheduled/manage-quality-scores.ts calculate
           npx tsx scripts/scheduled/calculate-difficulty-levels.ts


### PR DESCRIPTION
## Summary
- PR #406 added the Anthropic News fetcher code but missed adding "Anthropic News" to the scraping scheduler workflow arguments
- Without this fix, the source would never be collected in production

## Changes
- `.github/workflows/scheduler-scraping.yml`: Add `"Anthropic News"` to `collect-feeds.ts` arguments

## Test plan
- [ ] Verify scheduler-scraping workflow includes "Anthropic News" in collect-feeds arguments
- [ ] Confirm next scheduled run picks up Anthropic News articles

Generated with Claude Code