### PR TITLE
fix: add thumbnail URL validation and error fallback

### DIFF
--- a/app/components/article/card.tsx
+++ b/app/components/article/card.tsx
@@ -73,8 +73,11 @@ export function ArticleCard({
     return isSpeakerDeck || isDocswell;
   })();
 
-  // T1: Simplified thumbnail display - show whenever thumbnail exists
-  const showThumbnail = !!article.thumbnail;
+  // T1: Thumbnail display with validation and error fallback
+  const [thumbnailError, setThumbnailError] = useState(false);
+  const hasValidThumbnailUrl =
+    !!article.thumbnail && /^https?:\/\//.test(article.thumbnail);
+  const showThumbnail = hasValidThumbnailUrl && !thumbnailError;
   const trimmedSummary = article.summary?.trim() || '';
 
   const searchParams = useSearchParams();
@@ -120,8 +123,8 @@ export function ArticleCard({
           : sourceColor?.borderLeft
       )}
     >
-      {/* Header: Title (Pattern 2/3 only) */}
-      {!isPresentation && (
+      {/* Header: Title (Pattern 2/3, or presentation fallback when thumbnail fails) */}
+      {(!isPresentation || !showThumbnail) && (
         <h3
           className={cn(
             'font-heading text-foreground line-clamp-2 text-base leading-snug font-semibold sm:text-lg',
@@ -195,6 +198,7 @@ export function ArticleCard({
             priority={false}
             className="object-contain p-3 transition-transform duration-300 ease-out group-hover:scale-[1.01]"
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            onError={() => setThumbnailError(true)}
           />
         </div>
       ) : showThumbnail ? (
@@ -208,6 +212,7 @@ export function ArticleCard({
               priority={false}
               className="object-contain transition-transform duration-300 ease-out group-hover:scale-[1.01]"
               sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              onError={() => setThumbnailError(true)}
             />
           </div>
           {trimmedSummary && (


### PR DESCRIPTION
## Summary
- サムネイルURLのバリデーション追加（相対パス・不正データ3,054件を事前除外）
- 画像読み込みエラー（404等）時にテキスト要約表示へ自動フォールバック
- プレゼンカード（Speaker Deck/Docswell）のサムネイル失敗時にタイトル表示を追加

## Background
サムネイル表示追加後、一部記事で「Image」プレースホルダーが表示される問題が発生。
原因はDB内の無効なサムネイルデータ（相対パス2,224件、テキスト混入830件）と、
元サイトのOGP画像削除（HTTP 404）。

## Implementation Details
`app/components/article/card.tsx` のみ変更（+9行）:
- Layer 1: `/^https?:\/\//` 正規表現で有効URLのみサムネイル表示
- Layer 2: `thumbnailError` stateとonErrorハンドラで画像エラー時のフォールバック
- タイトル表示条件を `(!isPresentation || !showThumbnail)` に拡張

## Test plan
- [x] TypeScript type-check passed
- [x] ESLint passed (0 errors, 0 warnings)
- [x] Security audit passed (0 vulnerabilities)
- [x] Docker build passed
- [x] Codex review completed (1 issue found and fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)