### PR TITLE
fix: add Cloudinary OGP thumbnail fallback for Zenn articles

### DIFF
--- a/lib/fetchers/ai/zenn-ai.ts
+++ b/lib/fetchers/ai/zenn-ai.ts
@@ -6,7 +6,7 @@ import { CreateArticleInput } from '@/types';
 import { parseRSSDate } from '@/lib/utils/date';
 import logger from '@/lib/logger';
 import { ZennAIEnricher } from '@/lib/enrichers/zenn-ai';
-import { sanitizeHtml } from '@/lib/utils/html-sanitizer';
+import { generateZennThumbnail } from '@/lib/utils/zenn-thumbnail';
 
 interface ZennTopic {
   name: string;
@@ -21,28 +21,28 @@ export class ZennAIFetcher extends BaseFetcher {
     {
       name: 'LLM',
       url: 'https://zenn.dev/topics/llm/feed',
-      maxArticles: 5
+      maxArticles: 5,
     },
     {
       name: 'NLP',
       url: 'https://zenn.dev/topics/nlp/feed',
-      maxArticles: 5
+      maxArticles: 5,
     },
     {
       name: 'ChatGPT',
       url: 'https://zenn.dev/topics/chatgpt/feed',
-      maxArticles: 5
+      maxArticles: 5,
     },
     {
       name: 'LangChain',
       url: 'https://zenn.dev/topics/langchain/feed',
-      maxArticles: 5
+      maxArticles: 5,
     },
     {
       name: '機械学習',
       url: 'https://zenn.dev/topics/%E6%A9%9F%E6%A2%B0%E5%AD%A6%E7%BF%92/feed',
-      maxArticles: 5
-    }
+      maxArticles: 5,
+    },
   ];
 
   constructor(source: Source) {
@@ -64,9 +64,7 @@ export class ZennAIFetcher extends BaseFetcher {
       try {
         logger.info(`Zenn ${topic.name}トピック記事取得開始`);
 
-        const feed = await this.retry(() =>
-          this.parser.parseURL(topic.url)
-        );
+        const feed = await this.retry(() => this.parser.parseURL(topic.url));
 
         if (!feed.items || feed.items.length === 0) {
           logger.warn(`Zenn ${topic.name}: 記事が見つかりませんでした`);
@@ -88,8 +86,9 @@ export class ZennAIFetcher extends BaseFetcher {
             continue;
           }
 
-          const publishedAt = item.pubDate ?
-            parseRSSDate(item.pubDate) : new Date();
+          const publishedAt = item.pubDate
+            ? parseRSSDate(item.pubDate)
+            : new Date();
 
           // 30日以内の記事のみ
           if (publishedAt < thirtyDaysAgo) {
@@ -102,7 +101,8 @@ export class ZennAIFetcher extends BaseFetcher {
 
           // Webページから本文を取得
           let fullContent: string | null = null;
-          let thumbnail: string | undefined = this.extractThumbnailFromItem(item);
+          let thumbnail: string | undefined =
+            this.extractThumbnailFromItem(item);
 
           try {
             const enrichedData = await this.enricher.enrich(item.link);
@@ -113,21 +113,30 @@ export class ZennAIFetcher extends BaseFetcher {
               }
             }
           } catch (_error) {
-            logger.warn(`Zenn ${topic.name}: エンリッチメント失敗 ${item.link}`);
+            logger.warn(
+              `Zenn ${topic.name}: エンリッチメント失敗 ${item.link}`
+            );
           }
 
           // フルコンテンツが取得できなかった場合はRSSコンテンツを使用
-          const content = fullContent || this.generateEnrichedContent(item, topic.name, author, tags);
+          const content =
+            fullContent ||
+            this.generateEnrichedContent(item, topic.name, author, tags);
 
           // エンリッチメント処理
-          const enrichedArticle = this.enrichArticle({
-            title: item.title,
-            url: item.link,
-            content, // Webから取得したフルコンテンツ
-            publishedAt,
-            sourceId: this.source.id,
-            thumbnail,
-          }, topic.name, author, tags);
+          const enrichedArticle = this.enrichArticle(
+            {
+              title: item.title,
+              url: item.link,
+              content, // Webから取得したフルコンテンツ
+              publishedAt,
+              sourceId: this.source.id,
+              thumbnail,
+            },
+            topic.name,
+            author,
+            tags
+          );
 
           articles.push(enrichedArticle);
           processedUrls.add(urlKey);
@@ -135,7 +144,6 @@ export class ZennAIFetcher extends BaseFetcher {
         }
 
         logger.info(`Zenn ${topic.name}: ${topicArticleCount}件の記事を取得`);
-
       } catch (error) {
         const errorMessage = `Zenn ${topic.name}取得エラー: ${error instanceof Error ? error.message : String(error)}`;
         logger.error(errorMessage);
@@ -204,19 +212,10 @@ export class ZennAIFetcher extends BaseFetcher {
       }
     }
 
-    // Zennのデフォルトサムネイル構造から抽出
+    // Cloudinary OGP画像URLを共通ユーティリティで生成
     if (itemAny.link) {
-      // Zenn記事URLから著者名と記事IDを抽出してOGP画像URLを構築
-      const match = itemAny.link.match(/zenn\.dev\/([^\/]+)\/articles\/([^\/\?]+)/);
-      if (match) {
-        // 著者スラッグのエンコード
-        const authorSlug = encodeURIComponent(match[1]);
-        // セキュアなHTML sanitizerを使用してタイトルをサニタイゼーション
-        const sanitizedTitle = sanitizeHtml(itemAny.title || 'Article');
-        // タイトルの長さ制限（過長なURLを防ぐ）
-        const safeTitle = sanitizedTitle.slice(0, 120);
-        return `https://res.cloudinary.com/zenn/image/upload/s--og-default--/co_rgb:222%2Cg_south_west%2Cl_text:notosansjp-medium.otf_37_bold:${authorSlug}%2Cx_203%2Cy_98/c_fit%2Cco_rgb:222%2Cg_north_west%2Cl_text:notosansjp-medium.otf_70_bold:${encodeURIComponent(safeTitle)}%2Cw_1010%2Cx_90%2Cy_100/bo_3px_solid_rgb:d6d6d6%2Cg_center%2Ch_630%2Cw_1200/v1627283836/default/og-bg-zenn.png`;
-      }
+      const thumbnail = generateZennThumbnail(itemAny.link, itemAny.title);
+      if (thumbnail) return thumbnail;
     }
 
     return undefined;
@@ -233,11 +232,11 @@ export class ZennAIFetcher extends BaseFetcher {
 
     // トピック別のタグ付け
     const topicTags: Record<string, string[]> = {
-      'LLM': ['LLM', '大規模言語モデル', 'AI実装'],
-      'NLP': ['自然言語処理', 'NLP', 'テキスト処理'],
-      'ChatGPT': ['ChatGPT', 'OpenAI', 'AIアプリ'],
-      'LangChain': ['LangChain', 'AI開発', 'LLMフレームワーク'],
-      '機械学習': ['機械学習', 'ML', 'データサイエンス']
+      LLM: ['LLM', '大規模言語モデル', 'AI実装'],
+      NLP: ['自然言語処理', 'NLP', 'テキスト処理'],
+      ChatGPT: ['ChatGPT', 'OpenAI', 'AIアプリ'],
+      LangChain: ['LangChain', 'AI開発', 'LLMフレームワーク'],
+      機械学習: ['機械学習', 'ML', 'データサイエンス'],
     };
 
     // メタデータとして記事情報を追加
@@ -252,9 +251,11 @@ export class ZennAIFetcher extends BaseFetcher {
         language: 'ja',
         keywords: aiKeywords,
         // タグの重複を排除
-        tags: Array.from(new Set([...(topicTags[topicName] || []), ...(tags || [])])),
+        tags: Array.from(
+          new Set([...(topicTags[topicName] || []), ...(tags || [])])
+        ),
         fetchedAt: new Date().toISOString(),
-      }
+      },
     };
 
     return enrichedArticle;
@@ -264,22 +265,22 @@ export class ZennAIFetcher extends BaseFetcher {
     const text = `${title} ${(tags || []).join(' ')}`.toLowerCase();
 
     const keywordPatterns = {
-      'GPT': ['gpt', 'chatgpt', 'openai'],
-      'Claude': ['claude', 'anthropic'],
-      'Gemini': ['gemini', 'bard', 'google ai'],
-      'LLM': ['llm', '大規模言語モデル', 'large language model'],
-      'RAG': ['rag', 'retrieval', '検索拡張'],
+      GPT: ['gpt', 'chatgpt', 'openai'],
+      Claude: ['claude', 'anthropic'],
+      Gemini: ['gemini', 'bard', 'google ai'],
+      LLM: ['llm', '大規模言語モデル', 'large language model'],
+      RAG: ['rag', 'retrieval', '検索拡張'],
       'Fine-tuning': ['fine-tun', 'ファインチューニング', '微調整'],
       'Prompt Engineering': ['prompt', 'プロンプト'],
-      'LangChain': ['langchain', 'ラングチェーン'],
+      LangChain: ['langchain', 'ラングチェーン'],
       'Vector DB': ['vector', 'ベクトル', 'embedding', '埋め込み'],
-      'Transformer': ['transformer', 'attention', 'bert'],
-      'Diffusion': ['diffusion', 'stable diffusion', '画像生成'],
+      Transformer: ['transformer', 'attention', 'bert'],
+      Diffusion: ['diffusion', 'stable diffusion', '画像生成'],
       'AI Agent': ['agent', 'エージェント', 'autonomous'],
       'Function Calling': ['function call', 'tool use', 'ツール使用'],
-      'Streaming': ['stream', 'ストリーミング', 'リアルタイム'],
-      'Token': ['token', 'トークン', 'context'],
-      'Hallucination': ['hallucination', 'ハルシネーション', '幻覚']
+      Streaming: ['stream', 'ストリーミング', 'リアルタイム'],
+      Token: ['token', 'トークン', 'context'],
+      Hallucination: ['hallucination', 'ハルシネーション', '幻覚'],
     };
 
     const detectedKeywords = new Set<string>();
@@ -288,7 +289,10 @@ export class ZennAIFetcher extends BaseFetcher {
       for (const pattern of patterns) {
         // ASCII文字のパターンは単語境界でチェック（誤検知低減）
         if (/^[a-z0-9\s-]+$/i.test(pattern)) {
-          const regex = new RegExp(`\\b${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'i');
+          const regex = new RegExp(
+            `\\b${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
+            'i'
+          );
           if (regex.test(text)) {
             detectedKeywords.add(keyword);
             break;
@@ -306,7 +310,12 @@ export class ZennAIFetcher extends BaseFetcher {
     return Array.from(detectedKeywords);
   }
 
-  private generateEnrichedContent(item: unknown, topicName: string, author?: string, tags?: string[]): string {
+  private generateEnrichedContent(
+    item: unknown,
+    topicName: string,
+    author?: string,
+    tags?: string[]
+  ): string {
     if (typeof item !== 'object' || item === null) return '';
 
     const itemAny = item as any;
@@ -332,7 +341,11 @@ export class ZennAIFetcher extends BaseFetcher {
     }
 
     // カテゴリ情報
-    if (itemAny.categories && Array.isArray(itemAny.categories) && itemAny.categories.length > 0) {
+    if (
+      itemAny.categories &&
+      Array.isArray(itemAny.categories) &&
+      itemAny.categories.length > 0
+    ) {
       enrichedParts.push(`カテゴリ: ${itemAny.categories.join(', ')}`);
     }
 
@@ -350,9 +363,9 @@ export class ZennAIFetcher extends BaseFetcher {
   protected normalizeUrl(url: string): string {
     try {
       const u = new URL(url);
-      u.search = '';  // クエリパラメータを除去
-      u.hash = '';    // ハッシュを除去
-      u.pathname = u.pathname.replace(/\/+$/, '');  // 末尾スラッシュを除去
+      u.search = ''; // クエリパラメータを除去
+      u.hash = ''; // ハッシュを除去
+      u.pathname = u.pathname.replace(/\/+$/, ''); // 末尾スラッシュを除去
       return u.toString();
     } catch {
       // URL構築に失敗した場合のフォールバック

--- a/lib/fetchers/zenn-extended.ts
+++ b/lib/fetchers/zenn-extended.ts
@@ -5,6 +5,7 @@ import { FetchResult } from '@/types/fetchers';
 import { CreateArticleInput } from '@/types';
 import { parseRSSDate } from '@/lib/utils/date';
 import { isUrlFromDomain } from '@/lib/utils/url-validator';
+import { generateZennThumbnail } from '@/lib/utils/zenn-thumbnail';
 import type { ContentEnricherFactory } from '../enrichers';
 
 interface ZennRSSItem {
@@ -42,7 +43,7 @@ export class ZennExtendedFetcher extends BaseFetcher {
     // 複数のトピックから取得
     const topics = [
       'javascript',
-      'typescript', 
+      'typescript',
       'react',
       'nextjs',
       'python',
@@ -50,43 +51,56 @@ export class ZennExtendedFetcher extends BaseFetcher {
       'rust',
       'aws',
       'docker',
-      'kubernetes'
+      'kubernetes',
     ];
 
     // まずメインフィードから取得
     try {
-      const mainFeed = await this.retry(() => this.parser.parseURL(this.source.url));
+      const mainFeed = await this.retry(() =>
+        this.parser.parseURL(this.source.url)
+      );
       for (const item of mainFeed.items || []) {
         if (item.title && item.link && !seenUrls.has(item.link)) {
           seenUrls.add(item.link);
-          const article = await this.createArticleWithEnrichment(item, enricherFactory);
+          const article = await this.createArticleWithEnrichment(
+            item,
+            enricherFactory
+          );
           articles.push(article);
         }
       }
     } catch (_error) {
-      errors.push(new Error(`メインフィード取得エラー: ${_error instanceof Error ? _error.message : String(_error)}`));
+      errors.push(
+        new Error(
+          `メインフィード取得エラー: ${_error instanceof Error ? _error.message : String(_error)}`
+        )
+      );
     }
 
     // 各トピックから追加取得
     for (const topic of topics) {
       if (articles.length >= 30) break; // 30件に達したら終了
-      
+
       try {
         const topicUrl = `https://zenn.dev/topics/${topic}/feed?order=daily`;
         const feed = await this.retry(() => this.parser.parseURL(topicUrl));
-        
-        for (const item of (feed.items || []).slice(0, 5)) { // 各トピックから最大5件
+
+        for (const item of (feed.items || []).slice(0, 5)) {
+          // 各トピックから最大5件
           if (item.title && item.link && !seenUrls.has(item.link)) {
             seenUrls.add(item.link);
-            const article = await this.createArticleWithEnrichment(item, enricherFactory);
+            const article = await this.createArticleWithEnrichment(
+              item,
+              enricherFactory
+            );
             articles.push(article);
-            
+
             if (articles.length >= 30) break;
           }
         }
-        
+
         // レート制限対策
-        await new Promise(resolve => setTimeout(resolve, 300));
+        await new Promise((resolve) => setTimeout(resolve, 300));
       } catch (_error) {
         // 個別トピックのエラーは警告レベル
       }
@@ -96,12 +110,12 @@ export class ZennExtendedFetcher extends BaseFetcher {
   }
 
   private async createArticleWithEnrichment(
-    item: ZennRSSItem, 
+    item: ZennRSSItem,
     enricherFactory: ContentEnricherFactory
   ): Promise<CreateArticleInput> {
     // 基本的な記事データを作成
     const article = this.createArticle(item);
-    
+
     // エンリッチメント処理
     if (item.link && enricherFactory) {
       const enricher = enricherFactory.getEnricher(item.link);
@@ -109,12 +123,12 @@ export class ZennExtendedFetcher extends BaseFetcher {
         try {
           const currentContent = article.content || '';
           const enrichedData = await enricher.enrich(item.link);
-          
+
           if (enrichedData && enrichedData.content) {
             // より長いコンテンツが取得できた場合に更新
             if (enrichedData.content.length > currentContent.length) {
               article.content = enrichedData.content;
-              
+
               // サムネイルも取得できていれば更新
               if (enrichedData.thumbnail) {
                 article.thumbnail = enrichedData.thumbnail;
@@ -126,7 +140,7 @@ export class ZennExtendedFetcher extends BaseFetcher {
         }
       }
     }
-    
+
     return article;
   }
 
@@ -136,7 +150,11 @@ export class ZennExtendedFetcher extends BaseFetcher {
       url: this.normalizeUrl(item.link || ''),
       summary: undefined, // 要約は後で日本語で生成
       content: item.content || item.contentSnippet || undefined,
-      publishedAt: item.isoDate ? new Date(item.isoDate) : (item.pubDate ? parseRSSDate(item.pubDate) : new Date()),
+      publishedAt: item.isoDate
+        ? new Date(item.isoDate)
+        : item.pubDate
+          ? parseRSSDate(item.pubDate)
+          : new Date(),
       sourceId: this.source.id,
       tagNames: this.extractTagsFromUrl(item.link),
     };
@@ -144,6 +162,11 @@ export class ZennExtendedFetcher extends BaseFetcher {
     // Use enclosure URL as thumbnail if available
     if (item.enclosure?.url && item.enclosure.type?.startsWith('image/')) {
       article.thumbnail = item.enclosure.url;
+    }
+
+    // Fallback: generate Cloudinary OGP thumbnail from Zenn article URL
+    if (!article.thumbnail && item.link) {
+      article.thumbnail = generateZennThumbnail(item.link, item.title);
     }
 
     return article;
@@ -170,10 +193,24 @@ export class ZennExtendedFetcher extends BaseFetcher {
     if (match && match[1]) {
       // Extract potential topics from slug
       const slug = match[1];
-      
+
       // Common tech keywords
-      const techKeywords = ['react', 'vue', 'next', 'node', 'typescript', 'javascript', 'python', 'go', 'rust', 'docker', 'aws', 'gcp', 'azure'];
-      
+      const techKeywords = [
+        'react',
+        'vue',
+        'next',
+        'node',
+        'typescript',
+        'javascript',
+        'python',
+        'go',
+        'rust',
+        'docker',
+        'aws',
+        'gcp',
+        'azure',
+      ];
+
       for (const keyword of techKeywords) {
         if (slug.includes(keyword)) {
           tags.push(keyword);

--- a/lib/utils/zenn-thumbnail.ts
+++ b/lib/utils/zenn-thumbnail.ts
@@ -1,0 +1,53 @@
+import { sanitizeHtml } from './html-sanitizer';
+import { isUrlFromDomain } from './url-validator';
+
+const CLOUDINARY_BASE = 'https://res.cloudinary.com/zenn/image/upload';
+const OG_BACKGROUND = 'v1627283836/default/og-bg-zenn.png';
+const AUTHOR_TEXT_STYLE =
+  'co_rgb:222%2Cg_south_west%2Cl_text:notosansjp-medium.otf_37_bold';
+const TITLE_TEXT_STYLE =
+  'c_fit%2Cco_rgb:222%2Cg_north_west%2Cl_text:notosansjp-medium.otf_70_bold';
+const IMAGE_SIZE = 'bo_3px_solid_rgb:d6d6d6%2Cg_center%2Ch_630%2Cw_1200';
+const TITLE_MAX_LENGTH = 120;
+
+/**
+ * Zenn article URL pattern to extract author slug and article ID
+ */
+const ZENN_ARTICLE_PATTERN = /zenn\.dev\/([^\/]+)\/articles\/([^\/\?]+)/;
+
+/**
+ * Safely slice a string without breaking surrogate pairs.
+ * Uses Array.from to handle multi-byte characters correctly.
+ */
+function safeSlice(str: string, maxLength: number): string {
+  const chars = Array.from(str);
+  if (chars.length <= maxLength) return str;
+  return chars.slice(0, maxLength).join('');
+}
+
+/**
+ * Generate a Cloudinary OGP thumbnail URL from a Zenn article URL.
+ * Returns undefined if the URL is not a valid Zenn article URL or if generation fails.
+ */
+export function generateZennThumbnail(
+  link: string,
+  title?: string
+): string | undefined {
+  try {
+    const parsed = new URL(link);
+    if (parsed.protocol !== 'https:') return undefined;
+    if (!isUrlFromDomain(link, 'zenn.dev')) return undefined;
+
+    const match = link.match(ZENN_ARTICLE_PATTERN);
+    if (!match) return undefined;
+
+    const authorSlug = encodeURIComponent(match[1]);
+    const sanitizedTitle = sanitizeHtml(title || 'Article') || 'Article';
+    const safeTitle = safeSlice(sanitizedTitle, TITLE_MAX_LENGTH);
+    const encodedTitle = encodeURIComponent(safeTitle);
+
+    return `${CLOUDINARY_BASE}/s--og-default--/${AUTHOR_TEXT_STYLE}:${authorSlug}%2Cx_203%2Cy_98/${TITLE_TEXT_STYLE}:${encodedTitle}%2Cw_1010%2Cx_90%2Cy_100/${IMAGE_SIZE}/${OG_BACKGROUND}`;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## Summary
Zennソース記事の約29%（1,008/3,479件）にサムネイルが欠落していた問題を修正。
Cloudinary OGP画像URL生成ロジックを共通ユーティリティに切り出し、両Fetcherから使用するように変更。

## Background
- Zenn AIソース: サムネイル率99.9%（1,315/1,316件）
- Zennソース: サムネイル率71.0%（2,471/3,479件）
- 両者とも同じzenn.devからの記事取得だが、サムネイル率に大きな差があった
- 数値はDBの直接クエリで取得（2026-02-15時点）

## Root Cause
ZennAIFetcher（`lib/fetchers/ai/zenn-ai.ts`）は、RSSのenclosureやenricherからサムネイルが取得できない場合に、記事URLパターン（`zenn.dev/[author]/articles/[slug]`）からCloudinary OGP画像URLを動的生成するフォールバックを持っていた。
ZennExtendedFetcher（`lib/fetchers/zenn-extended.ts`）にはこのフォールバックがなく、RSSのenclosureにサムネイルがない＋enricherのHTML取得に失敗した場合、サムネイルなしになっていた。

## Changes
- `lib/utils/zenn-thumbnail.ts`（新規）: 共通ユーティリティとして切り出し
  - `generateZennThumbnail(link, title)`: Zenn記事URLからCloudinary OGP画像URLを生成
  - `safeSlice()`: サロゲートペア安全な文字列切り詰め（Array.fromベース）
  - `isUrlFromDomain` + httpsスキーム検証（zenn.devのみ許可）
  - `sanitizeHtml`後の空文字フォールバック
  - try-catchによるグレースフルデグラデーション（生成失敗時はundefined返却）
  - URL構成要素を6定数に分割（可読性・保守性向上）
- `lib/fetchers/zenn-extended.ts`: 共通ユーティリティを使用してフォールバック追加
- `lib/fetchers/ai/zenn-ai.ts`: インライン実装を共通ユーティリティに置き換え

## Compatibility
- 後方互換性あり: 既存のサムネイル取得ロジック（enclosure、enricher）は維持
- フォールバックは追加のみで、既存動作に影響なし
- 既存のサムネイルなし記事は次回フィード取得時に補完される

## Verification
- [x] Lint: 0 errors, 0 warnings
- [x] Type-check: passed
- [x] Security audit: 0 vulnerabilities
- [x] Docker build: passed (84 pages)
- [x] Cross-review: Codex + Gemini + Claude の3レビュアーで2ラウンド実施、全指摘対応済み

Generated with [Claude Code](https://claude.com/claude-code)