### PR TITLE
feat: redesign article card with 3-pattern layout

### DIFF
--- a/app/components/article/card.tsx
+++ b/app/components/article/card.tsx
@@ -16,8 +16,6 @@ import {
   useIsNewArticle,
 } from '@/app/components/common/relative-time';
 
-const CARD_SUMMARY_MAX_LENGTH = 300;
-
 export function ArticleCard({
   article,
   onArticleClick,


### PR DESCRIPTION
## Background
Pattern 2（サムネイル付き記事）はタイトル行数によってサムネイルの縦位置がずれ、グリッド内で視線移動が不安定になっていた。

## What changed
- Pattern 2のサムネイルをカード最上部に固定し、グリッド内のサムネイル位置を統一（YouTube風配置）
- Pattern 2/3の要約テキストサイズを`text-xs`に統一
- Pattern 3の余分な装飾（`border-muted/40 border shadow-sm`）を削除
- 文字数制限（`CARD_SUMMARY_MAX_LENGTH`）をCSS `line-clamp`に置換し、定数を削除

## Implementation
- Pattern 2判定を`isPattern2Thumbnail`（`!isPresentation && showThumbnail`）に集約し、Pattern 1汚染を防止
- サムネイルをカード最上部に移動（`h-[120px]`, `rounded-t-lg`, `object-contain`で画像全体を表示）
- CardV2のパディングを条件分岐（Pattern 2: サムネ全幅のため`gap-0 pb-4` / 他: 従来通り`gap-1.5 px-4 pt-3 pb-4`）
- Pattern 3の要約テキストに`line-clamp-5`を追加し、手動300文字切り詰めを廃止
- 変更対象: `app/components/article/card.tsx`（1ファイルのみ）

## Out of scope
- Pattern 1（プレゼンテーション）のレイアウト・スタイル変更はなし

## Test plan
- [ ] Pattern 2: タイトル行数が異なってもサムネイル上端が揃う
- [ ] Pattern 3: `text-xs`反映、不要ボーダー/影なし
- [ ] Pattern 1: レイアウト変更なし（回帰確認）
- [ ] モバイル/タブレット/デスクトップでレイアウト崩れなし
- [ ] ライト/ダークモードで視認性問題なし


🤖 Generated with [Claude Code](https://claude.com/claude-code)