### PR TITLE
fix: improve Zenn article thumbnail retrieval rate from 71% to 99.7%

### DIFF
--- a/lib/fetchers/zenn-extended.ts
+++ b/lib/fetchers/zenn-extended.ts
@@ -164,7 +164,7 @@ export class ZennExtendedFetcher extends BaseFetcher {
     };
 
     // Use enclosure URL as thumbnail if available
-    if (item.enclosure?.url && item.enclosure.type?.startsWith('image/')) {
+    if (item.enclosure?.url) {
       article.thumbnail = item.enclosure.url;
     }
 


### PR DESCRIPTION
## Summary
- Zenn記事のサムネイル取得率を71.0%から99.7%に改善
- RSSフィードのenclosure typeチェック（`type?.startsWith('image/')`）を削除
- 既存997件のthumbnail欠損記事をCloudinary OGPでバックフィル済み

## Root Cause
ZennのRSSフィードはenclosureのtypeに`"false"`（文字列）を返す。
`lib/fetchers/zenn-extended.ts`の`startsWith('image/')`チェックが常に条件不成立となり、enclosure URLが無視されていた。

ZennAI fetcher（`lib/fetchers/ai/zenn-ai.ts:203`）はtypeチェックなしで99.9%の取得率を達成しており、同様のアプローチに統一。

## Changes

### Code Change
- `lib/fetchers/zenn-extended.ts` L167: enclosure typeチェック削除（1行変更）

### Data Backfill（コード外作業）
- 対象: Zenn source, thumbnail IS NULL, url LIKE '%/articles/%' (997件)
- 方法: `generateZennThumbnail(url, title)` でCloudinary OGP URLを生成しDB更新
- 結果: 997件全件更新成功

## Verification
| Check | Result |
|-------|--------|
| DB thumbnail rate | 2471/3479 (71.0%) -> 3468/3479 (99.7%) |
| Remaining NULL | 11件 (全て /books/ URL - generateZennThumbnailの対象外パターン) |
| Lint | PASSED |
| Type-check | PASSED |
| Security audit | PASSED |
| Build | PASSED |

## Test plan
- [ ] Verify Zenn article thumbnails display correctly on the article list page
- [ ] Confirm ZennAI article thumbnails are unaffected
- [ ] Monitor next feed collection for proper thumbnail extraction

Generated with [Claude Code](https://claude.com/claude-code)