### PR TITLE
fix: unify thumbnail height and add published time label (#421)

### DIFF
--- a/__tests__/components/ArticleCard.test.tsx
+++ b/__tests__/components/ArticleCard.test.tsx
@@ -341,6 +341,8 @@ describe('ArticleCard', () => {
 
       renderWithProviders(<ArticleCard article={recentArticle} />);
 
+      // 「公開:」ラベルと相対時間は別々のspan要素で描画される
+      expect(screen.getByText('公開:')).toBeInTheDocument();
       // RelativeTimeはuseEffect後に表示されるため、waitForで待つ
       await waitFor(() => {
         expect(screen.getByText('3時間前')).toBeInTheDocument();
@@ -561,19 +563,19 @@ describe('ArticleCard', () => {
       ).toBeInTheDocument();
     });
 
-    it('uses object-contain for presentation sources (Speaker Deck)', () => {
-      const presentationArticle = createMockArticleWithRelations({
+    it('uses object-contain for thumbnail display', () => {
+      const articleWithThumbnail = createMockArticleWithRelations({
         article: {
-          title: 'Presentation Slides',
+          title: 'Article With Slides',
           thumbnail: 'https://example.com/slide.jpg',
         },
         source: createMockSource({ name: 'Speaker Deck' }),
       });
 
-      renderWithProviders(<ArticleCard article={presentationArticle} />);
+      renderWithProviders(<ArticleCard article={articleWithThumbnail} />);
 
       const thumbnail = screen.getByRole('img', {
-        name: 'Presentation Slides',
+        name: 'Article With Slides',
       });
       expect(thumbnail).toHaveClass('object-contain');
     });
@@ -594,19 +596,21 @@ describe('ArticleCard', () => {
       expect(thumbnail).toHaveClass('object-contain');
     });
 
-    it('shows title for presentation sources', () => {
-      const presentationArticle = createMockArticleWithRelations({
+    it('shows title alongside thumbnail', () => {
+      const articleWithThumbnail = createMockArticleWithRelations({
         article: {
-          title: 'Presentation Title',
+          title: 'Article Title With Thumbnail',
           thumbnail: 'https://example.com/slide.jpg',
         },
         source: createMockSource({ name: 'Speaker Deck' }),
       });
 
-      renderWithProviders(<ArticleCard article={presentationArticle} />);
+      renderWithProviders(<ArticleCard article={articleWithThumbnail} />);
 
-      // プレゼン型でもタイトルが表示される
-      expect(screen.getByText('Presentation Title')).toBeInTheDocument();
+      // サムネイル付きでもタイトルが表示される
+      expect(
+        screen.getByText('Article Title With Thumbnail')
+      ).toBeInTheDocument();
     });
   });
 });

--- a/app/components/article/card.tsx
+++ b/app/components/article/card.tsx
@@ -50,27 +50,6 @@ export function ArticleCard({
     setIsRead(initialIsRead);
   }, [initialIsRead]);
 
-  // T1: Presentation type detection (Speaker Deck / Docswell)
-  const isPresentation = (() => {
-    let isSpeakerDeck = article.source?.name === 'Speaker Deck';
-    let isDocswell = article.source?.name === 'Docswell';
-
-    if (!isSpeakerDeck && !isDocswell && article.url) {
-      try {
-        const hostname = new URL(article.url).hostname;
-        isSpeakerDeck =
-          hostname === 'speakerdeck.com' ||
-          hostname.endsWith('.speakerdeck.com');
-        isDocswell =
-          hostname === 'www.docswell.com' || hostname === 'docswell.com';
-      } catch {
-        // Invalid URL, skip URL-based detection
-      }
-    }
-
-    return isSpeakerDeck || isDocswell;
-  })();
-
   // T1: Thumbnail display with validation and error fallback
   const [thumbnailError, setThumbnailError] = useState(false);
   const hasValidThumbnailUrl =
@@ -129,7 +108,7 @@ export function ArticleCard({
         <div
           className={cn(
             'relative isolate w-full overflow-hidden rounded-t-lg bg-gray-100 dark:bg-gray-800',
-            isPresentation ? 'min-h-[160px]' : 'h-[120px]'
+            'min-h-[160px]'
           )}
         >
           <OptimizedImage
@@ -139,7 +118,7 @@ export function ArticleCard({
             priority={false}
             className={cn(
               'transition-transform duration-300 ease-out group-hover:scale-[1.01]',
-              isPresentation ? 'object-contain p-3' : 'object-contain'
+              'object-contain'
             )}
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
             onError={() => setThumbnailError(true)}
@@ -202,7 +181,8 @@ export function ArticleCard({
               {article.companyName ?? article.source.name}
             </BadgeV2>
           )}
-          <span className="text-muted-foreground">
+          <span className="text-muted-foreground flex items-center gap-1">
+            <span>公開:</span>
             <RelativeTime date={article.publishedAt} />
           </span>
           {sortBy === 'createdAt' && (


### PR DESCRIPTION
## Summary
- ArticleCardのサムネイル最小高さを `min-h-[160px]` に統一（ソース依存の高さ分岐を廃止）
- Speaker Deck / Docswell 判定用の `isPresentation` ロジックを削除し、表示ロジックを共通化
- 公開日時の相対時間表示に `公開:` プレフィックスを追加し、時刻の意味を明確化（例: `公開: 3時間前`）

## Changes
- `app/components/article/card.tsx`
  - サムネイルコンテナの高さ分岐を削除し、全カードに `min-h-[160px]` を適用
  - 画像クラスのソース依存分岐（`object-contain p-3`）を削除し、共通クラスへ統一
  - `isPresentation` IIFE（Speaker Deck / Docswell 判定ロジック全体）を削除
  - `publishedAt` の相対時間表示を `公開: X前` 形式へ変更
- `__tests__/components/ArticleCard.test.tsx`
  - ソース依存の見た目差分テストを、共通表示仕様を検証するテストに置き換え
  - 公開日時表示テストを `公開:` ラベル付き仕様に更新

## Test Results
- ArticleCard: 33 tests passed
- TypeScript type-check: passed
- ESLint: 0 errors, 0 warnings
- Production build: passed

## Checklist
- [x] Tests passing
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)