### PR TITLE
fix: add missing --url flag to prisma db execute in entity extraction workflow

### DIFF
--- a/.github/workflows/scheduler-entity-extraction.yml
+++ b/.github/workflows/scheduler-entity-extraction.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
-          echo "SELECT 1;" | npx prisma db execute --stdin
+          echo "SELECT 1;" | npx prisma db execute --stdin --url "$DATABASE_URL"
       - name: Apply DB migrations
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}


### PR DESCRIPTION
## Summary
- `scheduler-entity-extraction.yml` の `prisma db execute --stdin` に `--url "$DATABASE_URL"` が欠落していたため、Prisma 6.x + `prisma.config.ts` 環境でDB接続ウォームアップが失敗していた
- 他の全schedulerワークフローと同じ形式に統一

## Test plan
- [ ] `extract-entities` ワークフローが正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)