### PR TITLE
refactor: ArticleCardの日時表示を絶対日時・Calendarアイコンに統一

### DIFF
--- a/__tests__/components/ArticleCard.test.tsx
+++ b/__tests__/components/ArticleCard.test.tsx
@@ -331,9 +331,9 @@ describe('ArticleCard', () => {
   it('displays absolute date for publication date', () => {
     renderWithProviders(<ArticleCard article={mockArticle} />);
 
-    expect(screen.getByText('公開:')).toBeInTheDocument();
+    // Calendar icon with sr-only label (matching article detail page)
+    expect(screen.getByText('公開日:')).toBeInTheDocument();
     // formatDateWithTime outputs "YYYY/MM/DD HH:MM" in JST
-    // mockArticle.publishedAt = 2025-01-01T10:00:00Z = 2025/01/01 19:00 JST
     const dateSpans = screen.getAllByText(/\d{4}\/\d{2}\/\d{2}\s\d{2}:\d{2}/);
     expect(dateSpans.length).toBeGreaterThanOrEqual(1);
   });

--- a/app/components/article/card.tsx
+++ b/app/components/article/card.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import { ExternalLink } from 'lucide-react';
+import { Calendar, ExternalLink } from 'lucide-react';
 import { CardV2 } from '@/components/ui-v2/card-v2';
 import { BadgeV2 } from '@/components/ui-v2/badge-v2';
 import { ButtonV2 } from '@/components/ui-v2/button-v2';
@@ -179,7 +179,8 @@ export function ArticleCard({
             </BadgeV2>
           )}
           <span className="text-muted-foreground flex items-center gap-1">
-            <span>公開:</span>
+            <Calendar className="h-3 w-3" aria-hidden="true" />
+            <span className="sr-only">公開日:</span>
             <span>{formatDateWithTime(article.publishedAt)}</span>
           </span>
         </div>


### PR DESCRIPTION
## Summary
- ArticleCardの日時表示を相対日時（「5日前」）から絶対日時（「2026/02/21 14:06」、JST固定 `formatDateWithTime`）に変更し、他コンポーネントとの一貫性を確保
- 取得日（createdAt）表示を削除（ソート選択は別UIで提供されており、カード上での表示は情報重複）
- 「公開:」テキストラベルをCalendarアイコン + sr-onlyラベルに変更し、記事詳細ページとUIを統一しつつアクセシビリティを維持

## Implementation Details
- `app/components/article/card.tsx`: `RelativeTime` -> `formatDateWithTime`（JST固定）に置換、取得日表示ブロック・未使用`sortBy`変数を削除、lucide-react `Calendar`アイコン導入
- `__tests__/components/ArticleCard.test.tsx`: テスト期待値を絶対日時フォーマット・sr-onlyラベルに更新、不要なfakeTimers/waitForを削除
- props・データ契約の変更なし（表示ロジックのみ）

## Test Results
- `npm run docker:test:react:file` (jest.config.dom.js): 33/33 PASS
- `npm run docker:build`: PASS

## Checklist
- [x] Tests passing
- [x] No breaking changes (props/data contract unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)