### PR TITLE
fix: formalize orphaned ArticleView partial index via migration (#459)

### DIFF
--- a/prisma/migrations/20260301221518_formalize_articleview_partial_index/migration.sql
+++ b/prisma/migrations/20260301221518_formalize_articleview_partial_index/migration.sql
@@ -1,0 +1,8 @@
+-- ArticleView: NOT EXISTS subquery optimization for digest queries
+-- Covers: getPersonalizedArticles, getMustReadArticles, getMissedArticles (digest-service.ts)
+-- Also benefits: read-status API (app/api/articles/read-status/route.ts)
+-- Original: PR #67 (706163be), lost during baseline consolidation in PR #70 (ab66f085)
+-- This migration formalizes the orphaned index under Prisma management.
+CREATE INDEX IF NOT EXISTS "idx_article_view_user_article_read"
+ON "ArticleView" ("userId", "articleId", "isRead")
+WHERE ("isRead" = true);


### PR DESCRIPTION
## Summary
- PR #67 で追加され PR #70 のbaseline統合時に取りこぼされた孤児インデックス `idx_article_view_user_article_read` を、Prismaマイグレーションとして正式管理する
- `CREATE INDEX IF NOT EXISTS` により、既にインデックスが存在する環境ではno-op（スキップ）。未作成環境でのみインデックスが作成される（短時間のテーブルロックあり、ArticleViewは小規模のため影響軽微）
- アプリケーションコードの変更なし

## Background

Issue #459 は2つの対応を要求していた:
1. `ArticleView.articleId` インデックス追加 → **既に存在** (`ArticleView_articleId_idx`, schema.prisma L240)
2. `getMissedArticles` JOIN順序最適化 → PostgreSQLプランナーがWHERE句の `publishedAt`/`qualityScore` フィルタを先に適用するため、手動でのJOIN順序変更は不要

調査の結果、Issue の前提は一部不正確だったが、関連する問題として部分インデックス `idx_article_view_user_article_read` がDBに存在するもののPrismaマイグレーション管理外であることが判明。本PRでこれを正式管理する。

### 孤児インデックスの経緯
- **PR #67** (706163be): `20250919_add_db_optimization_indexes` マイグレーションでインデックス追加
- **PR #70** (ab66f085): baseline統合時にマイグレーションディレクトリを削除、baselineに含め忘れ
- 結果: dev/prod DBにはインデックスが残存、Prisma管理外

### IF NOT EXISTS の制約
PostgreSQLの `IF NOT EXISTS` は同名インデックスが存在すればスキップするが、定義の一致は検証しない。dev/prod両環境で `pg_get_indexdef()` により期待定義 `(userId, articleId, isRead) WHERE (isRead = true)` との一致を確認済み。

## Implementation Details
- 新規マイグレーション `20260301221518_formalize_articleview_partial_index` を作成
- SQL: `CREATE INDEX IF NOT EXISTS` で冪等に適用
- 対象インデックス: `(userId, articleId, isRead) WHERE (isRead = true)`
- このインデックスはDigest Service の NOT EXISTS サブクエリ（3メソッド共通パターン）および read-status API に恩恵がある

## Test Results
- Build: SUCCESS
- Tests: 4,350 passed / 0 failed / 78 skipped

## Checklist
- [x] Tests passing
- [x] No breaking changes
- [x] Migration uses IF NOT EXISTS for idempotent application
- [x] Index definition verified on dev/prod DBs

Closes #459

Generated with [Claude Code](https://claude.com/claude-code)