### PR TITLE
fix: send read status via beacon on article page unmount

### DIFF
--- a/__tests__/components/article/read-tracker.test.tsx
+++ b/__tests__/components/article/read-tracker.test.tsx
@@ -1,0 +1,297 @@
+import { render, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReadTracker } from '@/components/article/read-tracker';
+import { useSession } from 'next-auth/react';
+
+// Mock next-auth/react
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}));
+
+// Mock logger
+jest.mock('@/lib/logger.client', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const READ_STATUS_STORAGE_KEY = 'techtrend-read-articles';
+const ARTICLE_ID = 'article-123';
+const API_URL = '/api/articles/read-status';
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function renderReadTracker(
+  queryClient: QueryClient,
+  articleId: string = ARTICLE_ID
+) {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return render(<ReadTracker articleId={articleId} />, { wrapper: Wrapper });
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('ReadTracker', () => {
+  let queryClient: QueryClient;
+  let dispatchEventSpy: jest.SpyInstance;
+  let originalSendBeacon: typeof navigator.sendBeacon;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+
+    queryClient = createQueryClient();
+
+    // Default: authenticated session
+    (useSession as jest.Mock).mockReturnValue({
+      data: { user: { id: 'user-1' } },
+    });
+
+    // Mock fetch
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+
+    // Mock sendBeacon
+    originalSendBeacon = navigator.sendBeacon;
+    navigator.sendBeacon = jest.fn().mockReturnValue(true);
+
+    // Spy on dispatchEvent
+    dispatchEventSpy = jest.spyOn(window, 'dispatchEvent');
+
+    // Mock localStorage
+    const store: Record<string, string> = {};
+    jest
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation((key: string) => store[key] ?? null);
+    jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation((key: string, value: string) => {
+        store[key] = value;
+      });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    navigator.sendBeacon = originalSendBeacon;
+    jest.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Normal flow: 3-second delay marks as read
+  // -------------------------------------------------------------------------
+  it('marks article as read after 3-second delay', async () => {
+    const setQueriesDataSpy = jest.spyOn(queryClient, 'setQueriesData');
+
+    renderReadTracker(queryClient);
+
+    // Advance past the 3-second delay
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    // Wait for the fetch promise to resolve
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Verify fetch was called with correct URL and body
+    expect(global.fetch).toHaveBeenCalledWith(
+      API_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ articleId: ARTICLE_ID }),
+      })
+    );
+
+    // Verify optimistic updates
+    expect(setQueriesDataSpy).toHaveBeenCalled();
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'article-read-status-changed',
+        detail: { articleId: ARTICLE_ID, isRead: true },
+      })
+    );
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      READ_STATUS_STORAGE_KEY,
+      expect.stringContaining(ARTICLE_ID)
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Unmount before 3 seconds: sendBeacon fires
+  // -------------------------------------------------------------------------
+  it('fires sendBeacon on unmount before 3-second delay', () => {
+    const setQueriesDataSpy = jest.spyOn(queryClient, 'setQueriesData');
+
+    const { unmount } = renderReadTracker(queryClient);
+
+    // Unmount immediately (no timer advance)
+    unmount();
+
+    // Verify sendBeacon was called
+    expect(navigator.sendBeacon).toHaveBeenCalledWith(
+      API_URL,
+      expect.any(Blob)
+    );
+
+    // Verify the Blob content
+    const blobArg = (navigator.sendBeacon as jest.Mock).mock
+      .calls[0][1] as Blob;
+    expect(blobArg.type).toBe('application/json');
+
+    // Verify optimistic updates were applied
+    expect(setQueriesDataSpy).toHaveBeenCalled();
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'article-read-status-changed',
+        detail: { articleId: ARTICLE_ID, isRead: true },
+      })
+    );
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      READ_STATUS_STORAGE_KEY,
+      expect.stringContaining(ARTICLE_ID)
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Unmount before 3 seconds: fetch keepalive fallback when sendBeacon
+  //    returns false
+  // -------------------------------------------------------------------------
+  it('falls back to fetch keepalive when sendBeacon returns false', () => {
+    (navigator.sendBeacon as jest.Mock).mockReturnValue(false);
+    const setQueriesDataSpy = jest.spyOn(queryClient, 'setQueriesData');
+
+    const { unmount } = renderReadTracker(queryClient);
+    unmount();
+
+    // sendBeacon was called but returned false
+    expect(navigator.sendBeacon).toHaveBeenCalled();
+
+    // Fallback fetch with keepalive
+    expect(global.fetch).toHaveBeenCalledWith(
+      API_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ articleId: ARTICLE_ID }),
+        keepalive: true,
+      })
+    );
+
+    // Verify optimistic updates were applied
+    expect(setQueriesDataSpy).toHaveBeenCalled();
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'article-read-status-changed',
+      })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Unmount before 3 seconds: fetch keepalive fallback when sendBeacon
+  //    is unavailable
+  // -------------------------------------------------------------------------
+  it('falls back to fetch keepalive when sendBeacon is unavailable', () => {
+    // Remove sendBeacon entirely
+    Object.defineProperty(navigator, 'sendBeacon', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    const { unmount } = renderReadTracker(queryClient);
+    unmount();
+
+    // Fallback fetch with keepalive
+    expect(global.fetch).toHaveBeenCalledWith(
+      API_URL,
+      expect.objectContaining({
+        method: 'POST',
+        keepalive: true,
+      })
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Unmount after successful fetch: sendBeacon NOT called
+  // -------------------------------------------------------------------------
+  it('does not fire sendBeacon after successful fetch', async () => {
+    const { unmount } = renderReadTracker(queryClient);
+
+    // Advance past the 3-second delay
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    // Wait for fetch to resolve and hasSentRequest to become true
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Reset sendBeacon mock to track only post-unmount calls
+    (navigator.sendBeacon as jest.Mock).mockClear();
+
+    unmount();
+
+    // sendBeacon should NOT be called because hasSentRequest is true
+    expect(navigator.sendBeacon).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. No beacon when unauthenticated
+  // -------------------------------------------------------------------------
+  it('does not fire sendBeacon or fetch when unauthenticated', () => {
+    (useSession as jest.Mock).mockReturnValue({ data: null });
+
+    const { unmount } = renderReadTracker(queryClient);
+    unmount();
+
+    expect(navigator.sendBeacon).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Fetch in-progress on unmount: sendBeacon still fires
+  // -------------------------------------------------------------------------
+  it('fires sendBeacon on unmount while fetch is still in-progress', () => {
+    // Make fetch hang (never resolve)
+    global.fetch = jest.fn(() => new Promise<Response>(() => {}));
+
+    const { unmount } = renderReadTracker(queryClient);
+
+    // Advance past the 3-second delay — fetch starts but never resolves
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    // Unmount before fetch resolves
+    unmount();
+
+    // sendBeacon should fire because hasSentRequest is still false
+    expect(navigator.sendBeacon).toHaveBeenCalledWith(
+      API_URL,
+      expect.any(Blob)
+    );
+  });
+});

--- a/components/article/read-tracker.tsx
+++ b/components/article/read-tracker.tsx
@@ -45,6 +45,57 @@ export function ReadTracker({ articleId }: ReadTrackerProps) {
 
     const controller = new AbortController();
 
+    // Helper: optimistic cache/event/localStorage updates
+    // Shared by markAsRead success handler and cleanup beacon
+    const applyOptimisticUpdates = () => {
+      queryClient.setQueriesData(
+        { queryKey: ['infinite-articles'], exact: false },
+        (oldData: any) => {
+          if (!oldData || !Array.isArray(oldData.pages)) return oldData;
+
+          let changed = false;
+          const pages = oldData.pages.map((page: any) => {
+            const items: any[] | undefined = page?.data?.items;
+            if (!Array.isArray(items)) return page;
+
+            let pageChanged = false;
+            const newItems = items.map((item: any) => {
+              if (item?.id === articleId && item?.isRead !== true) {
+                pageChanged = true;
+                changed = true;
+                return { ...item, isRead: true };
+              }
+              return item;
+            });
+
+            return pageChanged
+              ? { ...page, data: { ...page.data, items: newItems } }
+              : page;
+          });
+
+          return changed ? { ...oldData, pages } : oldData;
+        }
+      );
+
+      window.dispatchEvent(
+        new CustomEvent('article-read-status-changed', {
+          detail: { articleId, isRead: true },
+        })
+      );
+
+      try {
+        const stored = localStorage.getItem(READ_STATUS_STORAGE_KEY);
+        const parsed = stored ? JSON.parse(stored) : [];
+        const ids = Array.isArray(parsed) ? parsed : [];
+        if (!ids.includes(articleId)) {
+          ids.push(articleId);
+          localStorage.setItem(READ_STATUS_STORAGE_KEY, JSON.stringify(ids));
+        }
+      } catch {
+        // Ignore cache update errors
+      }
+    };
+
     // Mark article as read
     const markAsRead = async () => {
       // Prevent duplicate requests or post-unmount execution
@@ -82,59 +133,7 @@ export function ReadTracker({ articleId }: ReadTrackerProps) {
             return;
           }
           hasSentRequest.current = true;
-
-          // Update react-query caches even if the list page is unmounted (e.g., browser back)
-          queryClient.setQueriesData(
-            { queryKey: ['infinite-articles'], exact: false },
-            (oldData: any) => {
-              if (!oldData || !Array.isArray(oldData.pages)) return oldData;
-
-              let changed = false;
-              const pages = oldData.pages.map((page: any) => {
-                const items: any[] | undefined = page?.data?.items;
-                if (!Array.isArray(items)) return page;
-
-                let pageChanged = false;
-                const newItems = items.map((item: any) => {
-                  if (item?.id === articleId && item?.isRead !== true) {
-                    pageChanged = true;
-                    changed = true;
-                    return { ...item, isRead: true };
-                  }
-                  return item;
-                });
-
-                return pageChanged
-                  ? { ...page, data: { ...page.data, items: newItems } }
-                  : page;
-              });
-
-              return changed ? { ...oldData, pages } : oldData;
-            }
-          );
-
-          // Dispatch custom event to update UI
-          window.dispatchEvent(
-            new CustomEvent('article-read-status-changed', {
-              detail: { articleId, isRead: true },
-            })
-          );
-
-          // Also update localStorage cache used by useReadStatus()
-          try {
-            const stored = localStorage.getItem(READ_STATUS_STORAGE_KEY);
-            const parsed = stored ? JSON.parse(stored) : [];
-            const ids = Array.isArray(parsed) ? parsed : [];
-            if (!ids.includes(articleId)) {
-              ids.push(articleId);
-              localStorage.setItem(
-                READ_STATUS_STORAGE_KEY,
-                JSON.stringify(ids)
-              );
-            }
-          } catch {
-            // Ignore cache update errors
-          }
+          applyOptimisticUpdates();
         }
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') return;
@@ -170,12 +169,42 @@ export function ReadTracker({ articleId }: ReadTrackerProps) {
 
     return () => {
       isMountedRef.current = false;
-      controller.abort();
       clearTimeout(delayId);
       if (retryTimeoutId.current) {
         clearTimeout(retryTimeoutId.current);
         retryTimeoutId.current = null;
       }
+
+      // Send beacon on unmount if read status was never sent
+      if (!hasSentRequest.current && session?.user?.id) {
+        const payload = JSON.stringify({ articleId });
+        let beaconSent = false;
+
+        if (
+          typeof navigator !== 'undefined' &&
+          typeof navigator.sendBeacon === 'function'
+        ) {
+          beaconSent = navigator.sendBeacon(
+            '/api/articles/read-status',
+            new Blob([payload], { type: 'application/json' })
+          );
+        }
+
+        if (!beaconSent) {
+          // Fire-and-forget fallback — no await, no signal
+          void fetch('/api/articles/read-status', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: payload,
+            keepalive: true,
+          }).catch(() => {});
+        }
+
+        applyOptimisticUpdates();
+      }
+
+      controller.abort();
     };
   }, [articleId, session?.user?.id, queryClient]);
 


### PR DESCRIPTION
## Summary
- ReadTrackerコンポーネントのアンマウント時に`navigator.sendBeacon()`で既読ステータスを送信するよう修正
- 記事詳細ページから3秒以内に一覧へ戻った際の既読ステータス送信漏れを解消
- sendBeacon失敗時は`fetch({ keepalive: true })`でフォールバック

## Background
ReadTrackerは初回レンダリングを優先するため、既読APIコールを3秒遅延していた。

`t=0 記事表示 → t<3s 一覧へ戻る → useEffect cleanup で clearTimeout → APIコール未発行 → 未読のまま`

## Implementation Details
- cleanup関数内で`hasSentRequest.current === false`の場合に`navigator.sendBeacon()`を発行
- sendBeaconが`false`を返した場合は`fetch({ keepalive: true, credentials: 'include' })`でfire-and-forgetフォールバック
- 楽観的キャッシュ更新ロジック（React Query `setQueriesData`、カスタムイベント、localStorage）を`applyOptimisticUpdates()`ヘルパーに抽出し、通常フロー（3秒後fetch成功時）とcleanupパスで共有

### Safety
- **冪等性**: サーバー側のPOST `/api/articles/read-status` はupsert（既存レコードをupdate）するため、sendBeaconとfetchが重複送信されても副作用なし
- **CSRF**: 本プロジェクトはOrigin/Refererヘッダベースの検証方式。sendBeaconは同一オリジンからの送信でこの検証を通過する（カスタムCSRFトークン方式は未使用）
- **best-effort**: sendBeacon/fetch keepaliveともにブラウザのbest-effort送信。両方失敗した場合、クライアントは楽観的に既読表示するが、次回API取得時にサーバー状態と同期される

### Scope
- API仕様変更なし（エンドポイント/ペイロード/レスポンス不変）
- DB変更なし
- UI変更なし

## Test Results
7テスト全PASS:
1. 3秒遅延後の正常な既読マーク
2. アンマウント時のsendBeacon発火 + 楽観的更新
3. sendBeacon false時のfetch keepaliveフォールバック
4. sendBeacon未定義時のfetch keepaliveフォールバック
5. fetch成功後のアンマウントではsendBeacon不発火
6. 未認証時はsendBeacon/fetch不発火
7. fetch進行中のアンマウントでもsendBeacon発火（サーバー側upsertにより冪等）

## Checklist
- [x] Tests passing (7/7)
- [x] Lint, type-check, build all passing
- [x] No breaking changes
- [x] CodeRabbit review: no issues found
- [x] Codex cross-review: warnings addressed

Generated with [Claude Code](https://claude.com/claude-code)