### PR TITLE
fix: improve trend report v2 summary generation retry logic

### DIFF
--- a/lib/services/trend-report-generator.ts
+++ b/lib/services/trend-report-generator.ts
@@ -832,16 +832,26 @@ ${JSON.stringify(input)}`;
       return result.response.text().trim();
     };
 
-    const rawText1 = await generateOnce(prompt, 0.2);
-    const json1 = extractFirstJsonObject(rawText1);
-    if (json1 && typeof json1 === 'object') {
-      TrendReportGenerator.resolveRefKeysToIds(
-        json1 as Record<string, unknown>,
-        refMap,
-        fallbackId
-      );
-    }
-    const errors1 = validateV2Content(json1);
+    const runAttempt = async (promptText: string, temperature: number) => {
+      const rawText = await generateOnce(promptText, temperature);
+      const json = extractFirstJsonObject(rawText);
+      if (json && typeof json === 'object') {
+        TrendReportGenerator.resolveRefKeysToIds(
+          json as Record<string, unknown>,
+          refMap,
+          fallbackId
+        );
+      }
+      const errors = validateV2Content(json);
+      return { rawText, json, errors };
+    };
+
+    // Attempt 1: 初回生成 (temperature=0.2)
+    const {
+      rawText: rawText1,
+      json: json1,
+      errors: errors1,
+    } = await runAttempt(prompt, 0.2);
     if (errors1.length === 0) {
       return JSON.stringify(json1);
     }
@@ -879,58 +889,37 @@ evidenceArticleIds / articleIds には参照キー（A1〜A10）を使うこと�
 モデル出力:
 ${rawText}`;
 
-    const repairPrompt = buildRepairPrompt(errors1, rawText1);
-
-    const rawText2 = await generateOnce(repairPrompt, 0.0);
-    const json2 = extractFirstJsonObject(rawText2);
-    if (json2 && typeof json2 === 'object') {
-      TrendReportGenerator.resolveRefKeysToIds(
-        json2 as Record<string, unknown>,
-        refMap,
-        fallbackId
-      );
-    }
-    const errors2 = validateV2Content(json2);
+    // Attempt 2: repair (temperature=0.0)
+    const { json: json2, errors: errors2 } = await runAttempt(
+      buildRepairPrompt(errors1, rawText1),
+      0.0
+    );
     if (errors2.length === 0) {
       return JSON.stringify(json2);
     }
 
-    // repair失敗: v2を再生成（temperature=0.0でリトライ）
+    // Attempt 3: repair失敗 → v2再生成 (temperature=0.0)
     logger.warn(
       `Repair failed (${errors2.join(' / ')}), retrying v2 generation with temperature=0.0`
     );
-
-    const rawText3 = await generateOnce(prompt, 0.0);
-    const json3 = extractFirstJsonObject(rawText3);
-    if (json3 && typeof json3 === 'object') {
-      TrendReportGenerator.resolveRefKeysToIds(
-        json3 as Record<string, unknown>,
-        refMap,
-        fallbackId
-      );
-    }
-    const errors3 = validateV2Content(json3);
+    const {
+      rawText: rawText3,
+      json: json3,
+      errors: errors3,
+    } = await runAttempt(prompt, 0.0);
     if (errors3.length === 0) {
       logger.info('Structured AI summary succeeded on retry (attempt 3)');
       return JSON.stringify(json3);
     }
 
-    // リトライ生成もバリデーション失敗: もう一度repair
+    // Attempt 4: リトライ生成も失敗 → 最終repair
     logger.warn(
       `Retry generation failed (${errors3.join(' / ')}), attempting final repair`
     );
-    const repairPrompt2 = buildRepairPrompt(errors3, rawText3);
-
-    const rawText4 = await generateOnce(repairPrompt2, 0.0);
-    const json4 = extractFirstJsonObject(rawText4);
-    if (json4 && typeof json4 === 'object') {
-      TrendReportGenerator.resolveRefKeysToIds(
-        json4 as Record<string, unknown>,
-        refMap,
-        fallbackId
-      );
-    }
-    const errors4 = validateV2Content(json4);
+    const { json: json4, errors: errors4 } = await runAttempt(
+      buildRepairPrompt(errors3, rawText3),
+      0.0
+    );
     if (errors4.length > 0) {
       throw new Error(
         `Structured AI summary validation failed after 4 attempts: ${errors4.join(' / ')}`


### PR DESCRIPTION
## Summary
- v2構造化サマリーのバリデーション失敗時、レガシーフォールバック前にv2再生成リトライを追加
- repairプロンプトの禁止語リストをcoreとkeyTopicsで統一し、8語を明示
- レガシーフォールバック出力の最低長チェック（100文字未満で例外）を追加

## Background
2026-03-03 (JST)のDaily Trendレポートで、v2構造化サマリーのバリデーション失敗後にレガシーフォールバックが55文字の途中切れ出力を返し、ページ表示が崩れた。

根本原因:
1. repairプロンプトのkeyTopics向け指示が不十分（具体的な禁止語リストの欠如）
2. レガシーフォールバック出力の長さ検証がなく、55文字でもDBに保存された

## Implementation Details

### repairプロンプト修正
- core/keyTopicsで共通の禁止語リスト8語（増加/減少/急増/急減/増えた/減った/拡大/縮小）を明示
- 従来はcoreのみに具体的リスト、keyTopicsには抽象的な指示のみだった

### v2リトライロジック追加
変更後フロー（`generateAISummaryStructured`内）:
```
v2生成(temp=0.2) -> validate -> repair(temp=0.0) -> validate
  [失敗時] -> retry v2生成(temp=0.0) -> validate -> retry repair(temp=0.0) -> validate
  [それでも失敗時] -> throw -> catchブロックでlegacy fallbackへ遷移
```
- v2系の最大API呼び出し回数: 4回（legacy呼び出しは別途1回で計最大5回）
- repairプロンプトを`buildRepairPrompt()`テンプレート関数化（`String.replace`の`$&`展開問題を回避）
- リトライ各段階でのログ出力追加（成功時info、失敗時warn）

### レガシー最低長チェック
- `LEGACY_SUMMARY_MIN_LENGTH`定数（100文字）未満の場合にthrow
- aiSummary=nullで保存され、フロントは「AI分析は準備中です」を表示

## Test Results
- TypeScript: 0 errors
- Jest: 46 suites, 591 tests passed (Docker環境)
- Lint: 0 errors, 0 warnings
- Build: success
- Security audit: 0 vulnerabilities

## Review Results
外部レビュー実施（Full tier）、重大指摘なし。CodeRabbit nitpick 2件を対応済み。

## Post-deploy Task
2026-03-03 (JST)レポートの再生成が必要:
1. 本番DBで該当レコードを削除: `DELETE FROM "TrendReport" WHERE "periodType" = 'DAILY' AND "periodStart" = '2026-03-02T15:00:00Z'`
2. GitHub Actions `workflow_dispatch`で再生成: `confirm=YES`, `type=daily`, `date=2026-03-03`
3. ロールバック: 単一ファイル修正のためgit revertで即座に復旧可能

## Checklist
- [x] Tests passing
- [x] No breaking changes
- [x] Cross-review completed (Full tier)
- [x] CodeRabbit review completed

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * AIサマリー生成の信頼性がさらに向上しました。複数段階の再試行と修復プロンプトにより生成成功率が高くなります。
  * バリデーションが強化され、出力品質と一貫性が改善されます。
  * 旧形式のプレーンテキスト要約に最小長さのチェックが追加され、短すぎる要約はエラーになります。
  * エラーメッセージが明確化され、問題対応がしやすくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->