### PR TITLE
fix(deps): update undici to ^7.24.1 to resolve 6 Dependabot security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,7 +136,7 @@
         "tsx": "^4.20.5",
         "tw-animate-css": "^1.3.8",
         "typescript": "^5.8.3",
-        "undici": "^7.18.2",
+        "undici": "^7.24.1",
         "web-streams-polyfill": "^4.2.0",
         "whatwg-fetch": "^3.6.20"
       }
@@ -21986,9 +21986,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.1.tgz",
-      "integrity": "sha512-Gpq0iNm5M6cQWlyHQv9MV+uOj1jWk7LpkoE5vSp/7zjb4zMdAcUD+VL5y0nH4p9EbUklq00eVIIX/XcDHzu5xg==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
+      "integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -254,7 +254,7 @@
     "tsx": "^4.20.5",
     "tw-animate-css": "^1.3.8",
     "typescript": "^5.8.3",
-    "undici": "^7.18.2",
+    "undici": "^7.24.1",
     "web-streams-polyfill": "^4.2.0",
     "whatwg-fetch": "^3.6.20"
   },


### PR DESCRIPTION
## 概要
- undiciパッケージを7.19.1から7.24.1に更新し、Dependabotセキュリティアラート6件を解消

## 実装内容
- `package.json`: undiciバージョン指定を `^7.18.2` -> `^7.24.1` に更新
- `package-lock.json`: undici 7.19.1 -> 7.24.1 に更新

## 対象アラート
| # | 深刻度 | 概要 |
|---|--------|------|
| #48 | high | WebSocket permessage-deflate メモリ無制限消費 |
| #47 | high | WebSocket Client 不正バリデーションで例外 |
| #46 | medium | CRLF Injection via upgrade option |
| #45 | medium | DeduplicationHandler メモリ消費 DoS |
| #44 | medium | HTTP Request/Response Smuggling |
| #43 | high | WebSocket 64bit length overflow |

## テスト結果
- 型チェック: PASS
- Lint: PASS (0 errors, 0 warnings)
- Security Audit: PASS (0 vulnerabilities)
- Build: PASS
- 全テスト: 46 suites, 591 tests passed

## チェックリスト
- [x] テスト通過
- [x] 破壊的変更なし

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **保守作業**
  * 開発用依存パッケージをアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->