### PR TITLE
perf(batch): N+1クエリ解消 — generate-tags/collect-feeds

### DIFF
--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -467,7 +467,41 @@ async function processSource({
           metaTarget.includes('url');
 
         if (isPrismaDuplicateUrlError) {
-          duplicateCount++;
+          // Re-fetch latest article for self-healing on concurrent URL collision
+          const latestExisting = await prisma.article.findUnique({
+            where: { url: article.url },
+            select: { id: true, sourceId: true, contentLength: true, thumbnail: true, url: true }
+          });
+
+          if (latestExisting) {
+            const updates: Prisma.ArticleUpdateInput = {};
+
+            if (latestExisting.sourceId === HATENA_SOURCE_ID && source.id !== HATENA_SOURCE_ID) {
+              updates.sourceId = source.id;
+              console.error(`   [INFO] sourceId更新: ${source.name} <- Hatena`);
+            }
+
+            if ((!latestExisting.contentLength || latestExisting.contentLength === 0) &&
+                article.content && article.content.length > 0) {
+              Object.assign(updates, {
+                content: article.content,
+                thumbnail: article.thumbnail ?? latestExisting.thumbnail,
+                contentUpdatedAt: new Date(),
+              });
+            }
+
+            if (Object.keys(updates).length > 0) {
+              await prisma.article.update({
+                where: { id: latestExisting.id },
+                data: updates,
+              });
+              updatedCount++;
+            } else {
+              duplicateCount++;
+            }
+          } else {
+            duplicateCount++;
+          }
         } else {
           console.error(`   記事保存エラー: ${article.title}`, error instanceof Error ? error.message : String(error));
         }

--- a/scripts/scheduled/generate-tags.ts
+++ b/scripts/scheduled/generate-tags.ts
@@ -137,17 +137,28 @@ async function generateTagsForArticles(): Promise<GenerateResult> {
         if (tags.length > 0) {
           // AI生成タグのみ正規化（既存タグはDB上の名前を維持 — 'article'等の特殊タグ保護）
           const newTagRecords = await getOrCreateTags(tags, { normalize: true, maxTags: 30 });
-          const existingTagIds = article.tags.map(t => ({ id: t.id }));
-          const newTagIds = newTagRecords.map(t => ({ id: t.id }));
-          const allTagIds = [...new Map([...existingTagIds, ...newTagIds].map(t => [t.id, t])).values()];
 
-          // 記事にタグを関連付け
-          await prisma.article.update({
-            where: { id: article.id },
-            data: {
-              tags: {
-                set: allTagIds
-              }
+          // 更新直前に現在のタグを読み、追加分のみconnect（staleスナップショット書き戻し防止）
+          await prisma.$transaction(async (tx) => {
+            const current = await tx.article.findUniqueOrThrow({
+              where: { id: article.id },
+              select: { tags: { select: { id: true } } }
+            });
+
+            const currentTagIdSet = new Set(current.tags.map(t => t.id));
+            const tagsToConnect = newTagRecords
+              .filter(t => !currentTagIdSet.has(t.id))
+              .map(t => ({ id: t.id }));
+
+            if (tagsToConnect.length > 0) {
+              await tx.article.update({
+                where: { id: article.id },
+                data: {
+                  tags: {
+                    connect: tagsToConnect
+                  }
+                }
+              });
             }
           });
           


### PR DESCRIPTION
## 概要
- generate-tags.ts: タグごとの `findUnique` / `create` ループを `getOrCreateTags` に置換
- collect-feeds.ts: 記事ごとのURL重複チェックをバルク `findMany` + `Map` に置換

## 実装内容

### generate-tags.ts
- `Promise.all` + `findUnique` / `create` ループを `getOrCreateTags`（$transaction内upsert）に置換
- AI生成タグのみ `normalize: true` で正規化し、`maxTags: 30` を適用
- 既存タグはIDベースで保持し、`article` 等の特殊タグ名を維持

### collect-feeds.ts
- forループ前に URL 一覧でバルク `findMany` を実行して既存記事をプリフェッチ
- `Map<url, article>` で既存記事の参照を O(1) 化
- `content` の代わりに `contentLength` を `select` し、自己修復判定を維持しつつDB転送量を削減
- `sourceId` 更新、content補完、thumbnailフォールバックの既存ロジックは維持

## テスト結果
- 全単体テスト通過（Node: 273 suites / 4154 tests, DOM: 46 suites / 591 tests）
- tag-service統合テスト 11 tests 通過
- Lint: 0 errors, 0 warnings / Type-check: 通過 / Build: 通過

## レビュー品質
- /simplify: content→contentLength最適化、冗長コード除去
- cross-review (Light Tier, Codex): articleタグ正規化問題を検出・修正済み

## チェックリスト
- [x] テスト通過
- [x] 破壊的変更なし
- [x] 既存の自己修復ロジック保持

Closes部分的に #520

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * フィード収集処理を一括読み取りにより高速化し、処理回数を削減しました。
  * タグ生成で冗長なルックアップを避け、既存タグの再接続を最小化しました。

* **バグ修正**
  * 既存記事のコンテンツ／サムネイル更新判定を修正しました。
  * 重複URL発生時に最新データを反映する処理を追加し、更新計上の精度を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->