### PR TITLE
refactor(api): buildWhereClause共通predicate抽出 — where-clause-predicates.ts

### DIFF
--- a/app/api/articles/lib/query-builder.ts
+++ b/app/api/articles/lib/query-builder.ts
@@ -138,10 +138,7 @@ export class ArticleWhereClauseBuilder {
    * Exclude articles without processed summaries
    */
   withProcessedFilter(excludeUnprocessed: boolean): this {
-    pushProcessedFilter(
-      this.where.AND as ArticleWhereInput[],
-      excludeUnprocessed
-    );
+    pushProcessedFilter(this.where, excludeUnprocessed);
     return this;
   }
 

--- a/app/api/articles/lib/where-clause-predicates.ts
+++ b/app/api/articles/lib/where-clause-predicates.ts
@@ -67,16 +67,16 @@ export function pushLowQualityFilter(
 // ---------------------------------------------------------------------------
 
 /**
- * Push a summaryComputedAt not-null condition into AND conditions when
+ * Set summaryComputedAt not-null condition directly onto the WHERE object when
  * `excludeUnprocessed` is true. Excludes articles without processed summaries.
  */
 export function pushProcessedFilter(
-  andConditions: ArticleWhereInput[],
+  where: ArticleWhereInput,
   excludeUnprocessed: boolean
 ): void {
   if (!excludeUnprocessed) return;
 
-  andConditions.push({ summaryComputedAt: { not: null } });
+  where.summaryComputedAt = { not: null };
 }
 
 // ---------------------------------------------------------------------------
@@ -168,13 +168,23 @@ export function pushTagFilter(
     andConditions.push(...tagConditions);
   } else {
     // OR search: articles with any of the specified tags
-    where.tags = {
-      some: {
-        OR: tagList.map((tagName) => ({
-          name: { equals: tagName, mode: 'insensitive' as const },
-        })),
-      },
-    };
+    if (tagList.length === 1) {
+      // Single tag: direct match (backward-compatible structure)
+      where.tags = {
+        some: {
+          name: { equals: tagList[0], mode: 'insensitive' as const },
+        },
+      };
+    } else {
+      // Multiple tags: OR condition
+      where.tags = {
+        some: {
+          OR: tagList.map((tagName) => ({
+            name: { equals: tagName, mode: 'insensitive' as const },
+          })),
+        },
+      };
+    }
   }
 }
 

--- a/app/api/articles/list/query-helpers.ts
+++ b/app/api/articles/list/query-helpers.ts
@@ -112,10 +112,7 @@ export function buildWhereClause(params: WhereClauseParams): ArticleWhereInput {
   });
 
   // Exclude articles without processed summaries
-  pushProcessedFilter(
-    where.AND as ArticleWhereInput[],
-    params.excludeUnprocessed
-  );
+  pushProcessedFilter(where, params.excludeUnprocessed);
 
   // Exclude low quality articles
   pushLowQualityFilter(


### PR DESCRIPTION
## 概要
- query-builder.tsとquery-helpers.tsに重複していたフィルタロジックのうち、processed / lowQuality / read / tag / searchの5件をwhere-clause-predicates.tsに共通化
- /api/articlesと/api/articles/listで共通化可能なフィルタロジックを統一し、重複コードを削減
- contentフィルタ、sourceフィルタ、categoryフィルタ、dateRangeフィルタは意図的に非共通化

## 実装内容

### 新規作成
- `app/api/articles/lib/where-clause-predicates.ts`
  - pushLowQualityFilter: skipReason + qualityScore>=30 除外
  - pushProcessedFilter: summaryComputedAt not null
  - pushReadFilter: read/unread フィルタ
  - pushTagFilter: tag/tags OR/ANDモード
  - pushSearchFilter: 複数キーワードAND検索
  - pushDateRangeFilter: プリセット/カスタム日付範囲（現状はquery-builder.ts側で利用）

### 変更
- `query-builder.ts`: 6つのインラインフィルタを共通関数呼び出しに置換、未使用Prisma import削除
- `query-helpers.ts`: processed / lowQualityのインライン処理とread / tag / searchのローカル関数を共通関数呼び出しに置換

### 意図的に非共通化
- contentフィルタ: query-builder(`not: ''`) vs query-helpers(`notIn: whitespace配列`) -- 厳密度の意図的差異
- sourceフィルタ: async(キャッシュ解決) vs sync
- categoryフィルタ: enum検証 vs normalizeArticleCategory()
- dateRangeフィルタ: query-helpers側はlogger.warnを含むローカルラッパーを維持

## テスト結果
- TypeScript型チェック: PASS
- ESLint: 0 errors, 0 warnings（変更ファイル）
- articles APIテスト: 13 suites, 104 passed, 1 skipped
- ビルド: PASS

## チェックリスト
- [x] テスト通過
- [x] 破壊的変更なし
- [x] tag/tags同時指定時の後方互換性維持（cross-review Full Tier指摘対応済み）

Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * 記事一覧のフィルタ処理を共通化された判定ロジックに統合（検索、タグ、既読/未読、日付範囲、処理済み、低品質除外）。フィルタの安定性と保守性が向上しました。  
  * 公開APIの署名に変更はなく、既存挙動は維持されています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->