### PR TITLE
fix(security): Dependabotアラート3件対応（defu, lodash-es）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10540,9 +10540,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
+      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -17801,16 +17801,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {

--- a/package.json
+++ b/package.json
@@ -264,8 +264,8 @@
     "test-exclude": {
       "glob": "7.2.3"
     },
-    "lodash": "4.17.23",
-    "lodash-es": "4.17.23",
+    "lodash": "4.18.1",
+    "lodash-es": "4.18.1",
     "tar": "7.5.4",
     "minimatch@3": "3.1.3",
     "minimatch@9": "9.0.7",
@@ -273,6 +273,7 @@
     "@prisma/config": {
       "effect": "3.20.0"
     },
-    "nodemailer": "^8.0.4"
+    "nodemailer": "^8.0.4",
+    "defu": "6.1.6"
   }
 }


### PR DESCRIPTION
## 概要

- Dependabotセキュリティアラート3件（#68, #69, #70）を解消
- defu (CVE-2026-35209), lodash-es (CVE-2026-2950, CVE-2026-4800) の脆弱性対応
- lodash（non-es）も同系脆弱性の予防的対応として同時更新

## 実装内容

npm overridesで間接依存パッケージを修正版に更新:

| パッケージ | 変更前 | 変更後 | 対応CVE |
|-----------|--------|--------|---------|
| defu | (なし) | 6.1.6 (override追加) | CVE-2026-35209 (HIGH) |
| lodash-es | 4.17.23 | 4.18.1 | CVE-2026-2950 (MEDIUM), CVE-2026-4800 (HIGH) |
| lodash | 4.17.23 | 4.18.1 | 予防的対応 |

### 依存経路
- defu: prisma -> @prisma/config -> c12 -> defu
- lodash-es: @lhci/cli -> lighthouse, react-force-graph-2d -> force-graph
- lodash: @lhci/cli -> inquirer, @mswjs/data

## テスト結果

- ESLint: 0 errors, 0 warnings
- TypeScript型チェック: PASSED
- npm audit (production): 0 vulnerabilities
- Docker本番ビルド: PASSED
- テスト: 対象テストファイルなし（dependency override変更のみ）

## チェックリスト
- [x] テスト通過
- [x] 破壊的変更なし
- [x] アプリケーションコード変更なし（依存overridesのみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 内部の依存パッケージのバージョンを複数更新しました。これらの更新により、プロジェクトの安定性と互換性が強化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->