### PR TITLE
refactor(rag,ai): DIMENSIONS未使用config削除 + タグパース重複解消 (#545)

### DIFF
--- a/lib/ai/local-llm.ts
+++ b/lib/ai/local-llm.ts
@@ -260,11 +260,7 @@ export class LocalLLMClient {
         summary = this.cleanSummary(line.replace(/^要約[:：]\s*/, ''));
       } else if (line.startsWith('タグ:') || line.startsWith('タグ：')) {
         const tagLine = line.replace(/^タグ[:：]\s*/, '');
-        tags = tagLine
-          .split(/[,、，]/)
-          .map((tag) => tag.trim())
-          .filter((tag) => tag.length > 0 && tag.length <= 30)
-          .map((tag) => this.normalizeTag(tag));
+        tags = this.parseTagLine(tagLine);
       }
     }
 
@@ -321,11 +317,7 @@ export class LocalLLMClient {
       } else if (line.startsWith('タグ:') || line.startsWith('タグ：')) {
         isDetailedSummary = false;
         const tagLine = line.replace(/^タグ[:：]\s*/, '');
-        tags = tagLine
-          .split(/[,、，]/)
-          .map((tag) => tag.trim())
-          .filter((tag) => tag.length > 0 && tag.length <= 30)
-          .map((tag) => this.normalizeTag(tag));
+        tags = this.parseTagLine(tagLine);
       } else if (isDetailedSummary && line.trim().startsWith('・')) {
         detailedSummaryLines.push(line.trim());
       } else if (
@@ -387,6 +379,14 @@ export class LocalLLMClient {
     }
 
     return { summary, detailedSummary, tags };
+  }
+
+  private parseTagLine(tagLine: string): string[] {
+    return tagLine
+      .split(/[,、，]/)
+      .map((tag) => tag.trim())
+      .filter((tag) => tag.length > 0 && tag.length <= 30)
+      .map((tag) => this.normalizeTag(tag));
   }
 
   private normalizeTag(tag: string): string {

--- a/lib/config/env.ts
+++ b/lib/config/env.ts
@@ -447,7 +447,6 @@ export const config = {
   },
   embedding: {
     model: () => env.EMBEDDING_MODEL,
-    dimensions: () => env.EMBEDDING_DIMENSIONS,
     batchSize: () => env.EMBEDDING_BATCH_SIZE,
     concurrency: () => env.EMBEDDING_CONCURRENCY,
   },

--- a/lib/rag/embedding-service.ts
+++ b/lib/rag/embedding-service.ts
@@ -18,7 +18,6 @@ import { env } from '@/lib/config/env';
 
 export interface EmbeddingConfig {
   model: string;
-  dimensions: number;
   batchSize: number;
   concurrency: number;
   maxRetries: number;
@@ -36,7 +35,6 @@ export class EmbeddingService {
 
     this.config = {
       model: env.EMBEDDING_MODEL || 'text-embedding-3-small',
-      dimensions: env.EMBEDDING_DIMENSIONS,
       batchSize: env.EMBEDDING_BATCH_SIZE,
       concurrency: env.EMBEDDING_CONCURRENCY,
       maxRetries: 5,


### PR DESCRIPTION
## 概要
- embedding-service: 未使用の `EMBEDDING_DIMENSIONS` 関連参照を削除
- local-llm: タグパース重複ロジックを `parseTagLine()` メソッドに抽出

## 実装内容
PR #544 の CodeRabbit レビューで指摘された2件のスコープ外改善を実施。

### 1. embedding-service 未使用 `dimensions` 関連参照削除
- `EmbeddingConfig` interfaceから `dimensions` フィールドを削除
- `EmbeddingService` の初期化処理から `dimensions: env.EMBEDDING_DIMENSIONS` を削除
- `env.ts` の `config.embedding.dimensions` アクセサを削除
- `EMBEDDING_DIMENSIONS` の env schema定義は未変更

### 2. local-llm タグパース重複解消
- `parseSummaryAndTags()` と `parseDetailedSummary()` の重複タグパースロジックを `parseTagLine()` privateメソッドに抽出
- タグ分割・trim・30文字制限・`normalizeTag()` 適用の既存挙動はそのまま維持

### 非スコープ
- gemini.ts の同系統タグパース重複（別Issue対応）
- `normalizeTag()` マップの共通化（タグ結果に影響するため別Issue対応）

## テスト結果
- ESLint: PASS
- TypeScript型チェック: PASS
- Security Audit: PASS (0 vulnerabilities)
- Docker本番ビルド: PASS
- embedding-service.test.ts: PASS (7/7 tests)
- local-llm 変更は既存ロジックの抽出のみで挙動変更なし（追加テストなし）

## チェックリスト
- [x] テスト通過
- [x] 破壊的変更なし
- [x] cross-review実施済み（Codex Light Tier）

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リファクタリング
* タグ解析ロジックの重複を排除し、コード構造を整理しました
* 埋め込み機能の設定インターフェイスを簡潔にしました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->