### PR TITLE
fix(summary): トランザクションタイムアウト修正 — PrismaClient統一+timeout明示

### DIFF
--- a/__tests__/unit/services/summary/batch-processor.test.ts
+++ b/__tests__/unit/services/summary/batch-processor.test.ts
@@ -79,8 +79,11 @@ function makePrismaMock(existingTags: string[] = []) {
         update: articleUpdate,
         findUniqueOrThrow: articleFindUniqueOrThrow,
       },
-      $transaction: jest.fn((fn: (tx: typeof txClient) => Promise<void>) =>
-        fn(txClient)
+      $transaction: jest.fn(
+        (
+          fn: (tx: typeof txClient) => Promise<void>,
+          _options?: { timeout?: number }
+        ) => fn(txClient)
       ),
     } as unknown as import('@prisma/client').PrismaClient,
     articleUpdate,

--- a/__tests__/unit/services/summary/batch-processor.test.ts
+++ b/__tests__/unit/services/summary/batch-processor.test.ts
@@ -23,6 +23,7 @@ jest.mock('@/lib/logger', () => ({
 }));
 
 import { processArticleWithTimeout } from '@/lib/services/summary/batch-processor';
+import { env } from '@/lib/config/env';
 import type { ArticleWithSource } from '@/types/models';
 
 /** ArticleWithSource のミニマムなスタブを生成するヘルパー */
@@ -303,7 +304,7 @@ describe('batch-processor', () => {
 
         expect(prisma.$transaction).toHaveBeenCalledWith(
           expect.any(Function),
-          { timeout: expect.any(Number) }
+          { timeout: env.DB_TRANSACTION_TIMEOUT }
         );
       });
     });

--- a/__tests__/unit/services/summary/batch-processor.test.ts
+++ b/__tests__/unit/services/summary/batch-processor.test.ts
@@ -278,5 +278,31 @@ describe('batch-processor', () => {
         );
       });
     });
+
+    describe('transaction timeout configuration', () => {
+      it('should pass DB_TRANSACTION_TIMEOUT to $transaction options', async () => {
+        const { prisma, articleUpdate } = makePrismaMock();
+        const article = makeArticle('article-timeout-check');
+
+        const generateSummaryAndTags = jest.fn().mockResolvedValue({
+          summary: 'テスト要約。',
+          detailedSummary: '・テスト詳細',
+          translatedTitle: undefined,
+          tags: [],
+        });
+
+        await processArticleWithTimeout(
+          article,
+          '記事の本文',
+          generateSummaryAndTags,
+          prisma
+        );
+
+        expect(prisma.$transaction).toHaveBeenCalledWith(
+          expect.any(Function),
+          { timeout: expect.any(Number) }
+        );
+      });
+    });
   });
 });

--- a/lib/services/summary/batch-processor.ts
+++ b/lib/services/summary/batch-processor.ts
@@ -158,24 +158,27 @@ async function processArticle(
     article.id
   );
 
-  await prisma.$transaction(async (tx) => {
-    await tx.article.update({
-      where: { id: article.id },
-      data: {
-        summary: result.summary,
-        detailedSummary: result.detailedSummary,
-        translatedTitle: result.translatedTitle,
-        summaryVersion: SUMMARY_VERSION.CURRENT,
-        summaryComputedAt: new Date(),
-        summaryError: null,
-        skipReason: null,
-      },
-    });
+  await prisma.$transaction(
+    async (tx) => {
+      await tx.article.update({
+        where: { id: article.id },
+        data: {
+          summary: result.summary,
+          detailedSummary: result.detailedSummary,
+          translatedTitle: result.translatedTitle,
+          summaryVersion: SUMMARY_VERSION.CURRENT,
+          summaryComputedAt: new Date(),
+          summaryError: null,
+          skipReason: null,
+        },
+      });
 
-    if (result.tags != null) {
-      await updateArticleTags(tx, article.id, result.tags);
-    }
-  });
+      if (result.tags != null) {
+        await updateArticleTags(tx, article.id, result.tags);
+      }
+    },
+    { timeout: env.DB_TRANSACTION_TIMEOUT }
+  );
 
   try {
     await cacheInvalidator.onArticleUpdated(article.id, {

--- a/lib/services/summary/summary-orchestrator.ts
+++ b/lib/services/summary/summary-orchestrator.ts
@@ -136,24 +136,27 @@ export async function regenerateSummaries(
               article.id
             );
 
-            await prisma.$transaction(async (tx) => {
-              await tx.article.update({
-                where: { id: article.id },
-                data: {
-                  summary: result.summary,
-                  detailedSummary: result.detailedSummary,
-                  translatedTitle: result.translatedTitle,
-                  summaryVersion: SUMMARY_VERSION.CURRENT,
-                  summaryComputedAt: new Date(),
-                  summaryError: null,
-                  skipReason: null,
-                },
-              });
+            await prisma.$transaction(
+              async (tx) => {
+                await tx.article.update({
+                  where: { id: article.id },
+                  data: {
+                    summary: result.summary,
+                    detailedSummary: result.detailedSummary,
+                    translatedTitle: result.translatedTitle,
+                    summaryVersion: SUMMARY_VERSION.CURRENT,
+                    summaryComputedAt: new Date(),
+                    summaryError: null,
+                    skipReason: null,
+                  },
+                });
 
-              if (result.tags != null) {
-                await updateArticleTags(tx, article.id, result.tags);
-              }
-            });
+                if (result.tags != null) {
+                  await updateArticleTags(tx, article.id, result.tags);
+                }
+              },
+              { timeout: env.DB_TRANSACTION_TIMEOUT }
+            );
 
             logger.info(
               { articleId: article.id, title: article.title.substring(0, 50) },
@@ -250,24 +253,27 @@ export async function regenerateSummaries(
           article.id
         );
 
-        await prisma.$transaction(async (tx) => {
-          await tx.article.update({
-            where: { id: article.id },
-            data: {
-              summary: result.summary,
-              detailedSummary: result.detailedSummary,
-              translatedTitle: result.translatedTitle,
-              summaryVersion: SUMMARY_VERSION.CURRENT,
-              summaryComputedAt: new Date(),
-              summaryError: null,
-              skipReason: null,
-            },
-          });
+        await prisma.$transaction(
+          async (tx) => {
+            await tx.article.update({
+              where: { id: article.id },
+              data: {
+                summary: result.summary,
+                detailedSummary: result.detailedSummary,
+                translatedTitle: result.translatedTitle,
+                summaryVersion: SUMMARY_VERSION.CURRENT,
+                summaryComputedAt: new Date(),
+                summaryError: null,
+                skipReason: null,
+              },
+            });
 
-          if (result.tags != null) {
-            await updateArticleTags(tx, article.id, result.tags);
-          }
-        });
+            if (result.tags != null) {
+              await updateArticleTags(tx, article.id, result.tags);
+            }
+          },
+          { timeout: env.DB_TRANSACTION_TIMEOUT }
+        );
 
         logger.info(
           { articleId: article.id, title: article.title.substring(0, 50) },
@@ -306,10 +312,7 @@ export async function regenerateSummaries(
 
     return { generated, errors, skipped };
   } catch (error) {
-    logger.error(
-      { err: error },
-      'Fatal error in regeneration'
-    );
+    logger.error({ err: error }, 'Fatal error in regeneration');
     throw error;
   }
 }
@@ -402,24 +405,27 @@ export async function generateMissingSummaries(
           article.id
         );
 
-        await prisma.$transaction(async (tx) => {
-          await tx.article.update({
-            where: { id: article.id },
-            data: {
-              summary: result.summary,
-              detailedSummary: result.detailedSummary,
-              translatedTitle: result.translatedTitle,
-              summaryVersion: SUMMARY_VERSION.CURRENT,
-              summaryComputedAt: new Date(),
-              summaryError: null,
-              skipReason: null,
-            },
-          });
+        await prisma.$transaction(
+          async (tx) => {
+            await tx.article.update({
+              where: { id: article.id },
+              data: {
+                summary: result.summary,
+                detailedSummary: result.detailedSummary,
+                translatedTitle: result.translatedTitle,
+                summaryVersion: SUMMARY_VERSION.CURRENT,
+                summaryComputedAt: new Date(),
+                summaryError: null,
+                skipReason: null,
+              },
+            });
 
-          if (result.tags != null) {
-            await updateArticleTags(tx, article.id, result.tags);
-          }
-        });
+            if (result.tags != null) {
+              await updateArticleTags(tx, article.id, result.tags);
+            }
+          },
+          { timeout: env.DB_TRANSACTION_TIMEOUT }
+        );
 
         logger.info(
           { articleId: article.id, title: article.title.substring(0, 50) },
@@ -519,20 +525,14 @@ export async function generateMissingSummaries(
         });
       }
     } catch (dbError) {
-      logger.warn(
-        { err: dbError },
-        'Failed to record skip reasons'
-      );
+      logger.warn({ err: dbError }, 'Failed to record skip reasons');
     }
 
     logger.info({ generated, skipped, errors }, 'Missing summaries completed');
 
     return { generated, errors, skipped };
   } catch (error) {
-    logger.error(
-      { err: error },
-      'Fatal error in missing summaries generation'
-    );
+    logger.error({ err: error }, 'Fatal error in missing summaries generation');
     throw error;
   }
 }

--- a/scripts/maintenance/generate-summaries.ts
+++ b/scripts/maintenance/generate-summaries.ts
@@ -1,9 +1,7 @@
-import { PrismaClient } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
 import { SummaryManager } from '@/lib/services/summary/summary-manager';
 import { createNotifierFromEnv } from '@/lib/notification';
 import type { ArticleInfo } from '@/lib/notification/types';
-
-const prisma = new PrismaClient();
 
 interface GenerateResult {
   generated: number;
@@ -85,7 +83,7 @@ async function generateSummaries(options: GenerateSummariesOptions = {}): Promis
     console.error('❌ 要約生成でエラーが発生しました:', error instanceof Error ? error.message : String(error));
     throw error;
   } finally {
-    await prisma.$disconnect();
+    // prisma singleton is managed by lib/prisma.ts (graceful shutdown handlers)
   }
 }
 


### PR DESCRIPTION
## 概要
- 本番環境の記事収集パイプラインで要約生成時のPrismaトランザクションがタイムアウト（5000ms）する問題を修正
- `generate-summaries.ts`の素のPrismaClientを`@/lib/prisma`シングルトンに統一し、設定済みの10000msタイムアウトを適用
- 防御的強化として`$transaction`呼び出しに明示的なtimeoutオプションを追加

## 実装内容
### インシデント是正
- `scripts/maintenance/generate-summaries.ts`: `new PrismaClient()` → `import { prisma } from '@/lib/prisma'` に変更。`$disconnect()` を除去（シングルトンはlib/prisma.tsのgraceful shutdownで管理）

### 防御的強化（defense-in-depth）
- `lib/services/summary/batch-processor.ts`: `$transaction()`の第2引数に`{ timeout: env.DB_TRANSACTION_TIMEOUT }`を追加（1箇所）
- `lib/services/summary/summary-orchestrator.ts`: `$transaction()`に`timeout`を追加（3箇所）。あわせてlogger呼び出しの整形のみ実施（機能変更なし）

### テスト追加
- `__tests__/unit/services/summary/batch-processor.test.ts`: `$transaction`にtimeout引数が渡されることを検証するテスト追加

## テスト結果
- Build: PASS (`npm run docker:build`)
- Type Check: PASS (`npm run type-check`)
- Lint: PASS (`npm run lint`)
- Unit Test: 6/6 PASS (`TEST_FILE="__tests__/unit/services/summary/batch-processor.test.ts" npm run docker:test:file`)
- Security Audit: PASS (`npm audit --production --audit-level=high`)

## 根本原因
`collect-feeds.ts` → `generate-summaries.ts` の要約生成経路で、`generate-summaries.ts`が`new PrismaClient()`を設定なしで生成。`database-config.ts`の`transactionOptions`（timeout: 10000ms）が適用されず、Prismaデフォルトの5000msが使われていた。

## チェックリスト
- [x] テスト通過
- [x] cross-review実施済み（INVESTIGATE/PLAN/IMPLEMENT各フェーズ）
- [x] 破壊的変更なし
- [x] DB変更なし

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * 概要生成処理のデータベーストランザクションで明示的なタイムアウト設定を導入し、処理の安定性を向上しました。
  * データベース接続のライフサイクル管理を統一・最適化してリソース使用を効率化しました。
  * ログ出力のフォーマットを簡潔化して可読性を向上しました。

* **テスト**
  * トランザクション呼び出しの振る舞いを検証するユニットテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->