### PR TITLE
feat(personalization): パーソナライズ機能パフォーマンス改善（BN1-BN5）

### DIFF
--- a/__mocks__/lib/cache/redis-cache.ts
+++ b/__mocks__/lib/cache/redis-cache.ts
@@ -10,4 +10,11 @@ export class RedisCache {
   exists = jest.fn().mockResolvedValue(false);
   clear = jest.fn().mockResolvedValue(true);
   disconnect = jest.fn().mockResolvedValue(undefined);
+  // Non-async pass-through stub. NOT jest.fn() to survive clearAllMocks between tests.
+  getOrSetWithLock<T>(_key: string, fetcher: () => Promise<T>): Promise<T> {
+    return fetcher();
+  }
+  invalidatePattern(_pattern: string): Promise<void> {
+    return Promise.resolve();
+  }
 }

--- a/__tests__/lib/personalization/category-filter-service.test.ts
+++ b/__tests__/lib/personalization/category-filter-service.test.ts
@@ -34,6 +34,36 @@ jest.mock('@/lib/prisma', () => ({
   prisma: mockPrisma,
 }));
 
+// Mock candidate-extractor: bypass centroidCache + make getEmbeddingCandidates overridable for pLimit tests
+const mockGetEmbeddingCandidates = jest.fn();
+jest.mock('@/lib/personalization/filters/candidate-extractor', () => {
+  const actual = jest.requireActual(
+    '@/lib/personalization/filters/candidate-extractor'
+  );
+  return {
+    ...actual,
+    getCategoryCentroids: async (
+      db: any,
+      categoryIds: string[]
+    ): Promise<any[]> => {
+      return db.$queryRaw`
+        SELECT id, slug, "centroidEmbedding"::text as centroid_embedding
+        FROM "InterestCategory"
+        WHERE id = ANY(${categoryIds}::text[])
+          AND "centroidEmbedding" IS NOT NULL
+      `;
+    },
+    getEmbeddingCandidates: (...args: any[]) => {
+      // If mockGetEmbeddingCandidates has an implementation, use it (for pLimit tests).
+      // Otherwise, delegate to actual implementation (for all other tests).
+      if (mockGetEmbeddingCandidates.getMockImplementation()) {
+        return mockGetEmbeddingCandidates(...args);
+      }
+      return actual.getEmbeddingCandidates(...args);
+    },
+  };
+});
+
 // Mock logger
 jest.mock('@/lib/logger', () => ({
   logger: {
@@ -50,6 +80,9 @@ describe('CategoryFilterService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // mockResolvedValue (non-Once) persists through clearAllMocks — reset individually
+    mockPrisma.article.findMany.mockReset().mockResolvedValue([]);
+    mockPrisma.article.count.mockReset().mockResolvedValue(0);
     service = new CategoryFilterService(mockPrisma as any);
   });
 
@@ -324,7 +357,10 @@ describe('CategoryFilterService', () => {
       // Mock centroid query
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockCentroids) // getCategoryCentroids
-        .mockResolvedValueOnce(mockCandidates) // getEmbeddingCandidates
+        .mockResolvedValueOnce(
+          mockCandidates.map((c) => ({ articleId: c.id, sim_emb: c.sim_emb }))
+        ) // Stage 1: kNN
+        .mockResolvedValueOnce(mockCandidates) // Stage 2: data fetch
         .mockResolvedValueOnce([{ article_id: 'art-1' }]); // checkTagMatches
 
       const result = await service.filterArticles({
@@ -406,7 +442,10 @@ describe('CategoryFilterService', () => {
 
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockCentroids)
-        .mockResolvedValueOnce(lowSimCandidates)
+        .mockResolvedValueOnce(
+          lowSimCandidates.map((c) => ({ articleId: c.id, sim_emb: c.sim_emb }))
+        ) // Stage 1: kNN
+        .mockResolvedValueOnce(lowSimCandidates) // Stage 2: data fetch
         .mockResolvedValueOnce([]);
 
       const result = await service.filterArticles({
@@ -423,7 +462,10 @@ describe('CategoryFilterService', () => {
     it('should apply offset correctly', async () => {
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockCentroids)
-        .mockResolvedValueOnce(mockCandidates)
+        .mockResolvedValueOnce(
+          mockCandidates.map((c) => ({ articleId: c.id, sim_emb: c.sim_emb }))
+        ) // Stage 1: kNN
+        .mockResolvedValueOnce(mockCandidates) // Stage 2: data fetch
         .mockResolvedValueOnce([]);
 
       const result = await service.filterArticles({
@@ -441,7 +483,10 @@ describe('CategoryFilterService', () => {
     it('should honor sortBy when provided', async () => {
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockCentroids)
-        .mockResolvedValueOnce(mockCandidates)
+        .mockResolvedValueOnce(
+          mockCandidates.map((c) => ({ articleId: c.id, sim_emb: c.sim_emb }))
+        ) // Stage 1: kNN
+        .mockResolvedValueOnce(mockCandidates) // Stage 2: data fetch
         .mockResolvedValueOnce([]);
 
       const result = await service.filterArticles({
@@ -533,8 +578,20 @@ describe('CategoryFilterService', () => {
     it('should use max similarity when article appears in multiple category results', async () => {
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockMultiCentroids)
-        .mockResolvedValueOnce(mockCandidatesFrontend)
-        .mockResolvedValueOnce(mockCandidatesBackend)
+        .mockResolvedValueOnce(
+          mockCandidatesFrontend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // cat-1 Stage 1: kNN
+        .mockResolvedValueOnce(
+          mockCandidatesBackend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // cat-2 Stage 1: kNN (interleaved - all S1 first)
+        .mockResolvedValueOnce(mockCandidatesFrontend) // cat-1 Stage 2: data fetch
+        .mockResolvedValueOnce(mockCandidatesBackend) // cat-2 Stage 2: data fetch
         .mockResolvedValueOnce([]);
 
       const result = await service.filterArticles({
@@ -560,9 +617,15 @@ describe('CategoryFilterService', () => {
     it('should handle empty results from one category gracefully', async () => {
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockMultiCentroids)
-        .mockResolvedValueOnce(mockCandidatesFrontend)
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([]);
+        .mockResolvedValueOnce(
+          mockCandidatesFrontend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // cat-1 Stage 1: kNN
+        .mockResolvedValueOnce([]) // cat-2 Stage 1: empty → early return (interleaved)
+        .mockResolvedValueOnce(mockCandidatesFrontend) // cat-1 Stage 2: data fetch (no cat-2 S2 since S1 was empty)
+        .mockResolvedValueOnce([]); // checkTagMatches
 
       const result = await service.filterArticles({
         categoryIds: ['cat-1', 'cat-2'],
@@ -602,8 +665,20 @@ describe('CategoryFilterService', () => {
       const excludeSourceIds = ['arxiv-source-id'];
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockMultiCentroids)
-        .mockResolvedValueOnce(mockCandidatesFrontend)
-        .mockResolvedValueOnce(mockCandidatesBackend)
+        .mockResolvedValueOnce(
+          mockCandidatesFrontend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // cat-1 Stage 1: kNN
+        .mockResolvedValueOnce(
+          mockCandidatesBackend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // cat-2 Stage 1: kNN (interleaved - all S1 first)
+        .mockResolvedValueOnce(mockCandidatesFrontend) // cat-1 Stage 2: data fetch
+        .mockResolvedValueOnce(mockCandidatesBackend) // cat-2 Stage 2: data fetch
         .mockResolvedValueOnce([]);
 
       await service.filterArticles({
@@ -613,11 +688,12 @@ describe('CategoryFilterService', () => {
         excludeSourceIds,
       });
 
-      // getEmbeddingCandidates is called via $queryRaw (2nd and 3rd calls)
+      // getEmbeddingCandidates Stage 2 calls contain sourceId exclude filter
+      // NEW layout: calls[0]=centroids, calls[1]=cat1-s1, calls[2]=cat2-s1, calls[3]=cat1-s2, calls[4]=cat2-s2, calls[5]=checkTagMatches
       // $queryRaw receives tagged template args: [stringsArray, ...values]
       // Prisma.sql fragments are passed as objects with {strings, values} structure
-      const secondCallValues = mockPrisma.$queryRaw.mock.calls[1].slice(1);
-      const thirdCallValues = mockPrisma.$queryRaw.mock.calls[2].slice(1);
+      const cat1Stage2Values = mockPrisma.$queryRaw.mock.calls[3].slice(1);
+      const cat2Stage2Values = mockPrisma.$queryRaw.mock.calls[4].slice(1);
 
       // The sourceExcludeFilter is a Prisma.sql fragment containing the excludeSourceIds
       const findExcludeFragment = (values: unknown[]) =>
@@ -632,15 +708,15 @@ describe('CategoryFilterService', () => {
             )
         );
 
-      const secondFragment = findExcludeFragment(secondCallValues);
-      const thirdFragment = findExcludeFragment(thirdCallValues);
+      const cat1Fragment = findExcludeFragment(cat1Stage2Values);
+      const cat2Fragment = findExcludeFragment(cat2Stage2Values);
 
-      expect(secondFragment).toBeDefined();
-      expect(secondFragment!.values).toEqual(
+      expect(cat1Fragment).toBeDefined();
+      expect(cat1Fragment!.values).toEqual(
         expect.arrayContaining([excludeSourceIds])
       );
-      expect(thirdFragment).toBeDefined();
-      expect(thirdFragment!.values).toEqual(
+      expect(cat2Fragment).toBeDefined();
+      expect(cat2Fragment!.values).toEqual(
         expect.arrayContaining([excludeSourceIds])
       );
     });
@@ -653,7 +729,13 @@ describe('CategoryFilterService', () => {
 
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockSingleCentroids) // getCategoryCentroids
-        .mockResolvedValueOnce(mockCandidatesFrontend) // getEmbeddingCandidates
+        .mockResolvedValueOnce(
+          mockCandidatesFrontend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // Stage 1: kNN
+        .mockResolvedValueOnce(mockCandidatesFrontend) // Stage 2: data fetch
         .mockResolvedValueOnce([]); // checkTagMatches
 
       await service.filterArticles({
@@ -663,11 +745,12 @@ describe('CategoryFilterService', () => {
         excludeSourceIds,
       });
 
-      // getEmbeddingCandidates is the 2nd $queryRaw call
-      const secondCallValues = mockPrisma.$queryRaw.mock.calls[1].slice(1);
+      // getEmbeddingCandidates Stage 2 is the 3rd $queryRaw call (index=2)
+      // Stage 2 contains the sourceId exclude filter (Stage 1 is pure kNN without filters)
+      const stage2CallValues = mockPrisma.$queryRaw.mock.calls[2].slice(1);
 
       // Find the Prisma.sql fragment containing sourceId exclude filter
-      const excludeFragment = secondCallValues.find(
+      const excludeFragment = stage2CallValues.find(
         (v: unknown): v is { strings: string[]; values: unknown[] } =>
           typeof v === 'object' &&
           v !== null &&
@@ -717,7 +800,13 @@ describe('CategoryFilterService', () => {
       // Test embedding path: no excludeSourceIds in SQL
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockSingleCentroids) // getCategoryCentroids
-        .mockResolvedValueOnce(mockCandidatesFrontend) // getEmbeddingCandidates
+        .mockResolvedValueOnce(
+          mockCandidatesFrontend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // Stage 1: kNN
+        .mockResolvedValueOnce(mockCandidatesFrontend) // Stage 2: data fetch
         .mockResolvedValueOnce([]); // checkTagMatches
 
       await service.filterArticles({
@@ -727,11 +816,11 @@ describe('CategoryFilterService', () => {
         // excludeSourceIds is not specified
       });
 
-      // getEmbeddingCandidates is the 2nd $queryRaw call
-      const secondCallValues = mockPrisma.$queryRaw.mock.calls[1].slice(1);
+      // Stage 2 is the 3rd $queryRaw call (index=2) — check no sourceId exclude fragment
+      const stage2CallValues = mockPrisma.$queryRaw.mock.calls[2].slice(1);
 
       // When excludeSourceIds is undefined, Prisma.empty is used (no sourceId exclude fragment)
-      const excludeFragment = secondCallValues.find(
+      const excludeFragment = stage2CallValues.find(
         (v: unknown): v is { strings: string[]; values: unknown[] } =>
           typeof v === 'object' &&
           v !== null &&
@@ -794,7 +883,13 @@ describe('CategoryFilterService', () => {
 
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockSingleCentroids) // getCategoryCentroids
-        .mockResolvedValueOnce(mockCandidatesFrontend) // getEmbeddingCandidates
+        .mockResolvedValueOnce(
+          mockCandidatesFrontend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // Stage 1: kNN
+        .mockResolvedValueOnce(mockCandidatesFrontend) // Stage 2: data fetch
         .mockResolvedValueOnce([]); // checkTagMatches
 
       await service.filterArticles({
@@ -804,11 +899,11 @@ describe('CategoryFilterService', () => {
         excludeSourceIds: [], // empty array
       });
 
-      // getEmbeddingCandidates is the 2nd $queryRaw call
-      const secondCallValues = mockPrisma.$queryRaw.mock.calls[1].slice(1);
+      // Stage 2 is the 3rd $queryRaw call (index=2) — check no sourceId exclude fragment
+      const stage2CallValues = mockPrisma.$queryRaw.mock.calls[2].slice(1);
 
       // Empty array should not add exclude filter (Prisma.empty is used)
-      const excludeFragment = secondCallValues.find(
+      const excludeFragment = stage2CallValues.find(
         (v: unknown): v is { strings: string[]; values: unknown[] } =>
           typeof v === 'object' &&
           v !== null &&
@@ -842,8 +937,20 @@ describe('CategoryFilterService', () => {
     it('should apply tag boost from any matching category (OR)', async () => {
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockMultiCentroids)
-        .mockResolvedValueOnce(mockCandidatesFrontend)
-        .mockResolvedValueOnce(mockCandidatesBackend)
+        .mockResolvedValueOnce(
+          mockCandidatesFrontend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // cat-1 Stage 1: kNN
+        .mockResolvedValueOnce(
+          mockCandidatesBackend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // cat-2 Stage 1: kNN (interleaved - all S1 first)
+        .mockResolvedValueOnce(mockCandidatesFrontend) // cat-1 Stage 2: data fetch
+        .mockResolvedValueOnce(mockCandidatesBackend) // cat-2 Stage 2: data fetch
         .mockResolvedValueOnce([{ article_id: 'art-1' }]);
 
       const result = await service.filterArticles({
@@ -895,11 +1002,17 @@ describe('CategoryFilterService', () => {
 
     it('topK指定時はDEFAULT_TOP_K_CANDIDATESが使われず指定値がgetEmbeddingCandidatesに渡される', async () => {
       // topK=50 を指定する
-      // getEmbeddingCandidates は $queryRaw の 2回目の呼び出し（1回目はgetCategoryCentroids）
-      // template literal の LIMIT 値として topK=50 が渡される
+      // Stage 1 は $queryRaw の 2回目の呼び出し（1回目はgetCategoryCentroids）
+      // template literal の LIMIT 値として topK=50 が Stage 1 に渡される
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockSingleCentroid) // getCategoryCentroids
-        .mockResolvedValueOnce(mockCandidatesSimple) // getEmbeddingCandidates
+        .mockResolvedValueOnce(
+          mockCandidatesSimple.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // Stage 1: kNN (LIMIT=50)
+        .mockResolvedValueOnce(mockCandidatesSimple) // Stage 2: data fetch
         .mockResolvedValueOnce([]); // checkTagMatches
 
       await service.filterArticles({
@@ -909,9 +1022,8 @@ describe('CategoryFilterService', () => {
         topK: 50,
       });
 
-      // $queryRaw の 2回目呼び出し (index=1) が getEmbeddingCandidates
+      // $queryRaw の Stage 1 呼び出し (index=1) に LIMIT 値が入る
       // template literal は $queryRaw(strings, ...values) 形式で呼ばれる
-      // LIMIT ${effectiveLimit} の値が calls[1] の最後の引数に入る
       const embeddingCandidateCallArgs = mockPrisma.$queryRaw.mock.calls[1];
       // template literalの値 (strings以外の引数) を取得
       const templateValues = embeddingCandidateCallArgs.slice(1);
@@ -921,33 +1033,47 @@ describe('CategoryFilterService', () => {
       expect(templateValues).toContain(50);
     });
 
-    it('topK未指定時はDEFAULT_TOP_K_CANDIDATES(1000)がLIMITとして渡される', async () => {
+    it('topK未指定時はDEFAULT_TOP_K_CANDIDATES(200)がLIMITとして渡される', async () => {
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockSingleCentroid) // getCategoryCentroids
-        .mockResolvedValueOnce(mockCandidatesSimple) // getEmbeddingCandidates
+        .mockResolvedValueOnce(
+          mockCandidatesSimple.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // Stage 1: kNN (LIMIT=1000)
+        .mockResolvedValueOnce(mockCandidatesSimple) // Stage 2: data fetch
         .mockResolvedValueOnce([]); // checkTagMatches
 
       await service.filterArticles({
         categoryIds: ['cat-1'],
         periodMonths: 12,
         limit: 5,
-        // topK: 未指定 → DEFAULT_TOP_K_CANDIDATES = 1000
+        // topK: 未指定 → DEFAULT_TOP_K_CANDIDATES = 200
       });
 
+      // Stage 1 呼び出し (index=1) に LIMIT 値が入る
       const embeddingCandidateCallArgs = mockPrisma.$queryRaw.mock.calls[1];
       const templateValues = embeddingCandidateCallArgs.slice(1);
 
-      // DEFAULT_TOP_K_CANDIDATES=1000 が LIMIT 句に渡される
-      expect(templateValues).toContain(1000);
+      // DEFAULT_TOP_K_CANDIDATES=200 が LIMIT 句に渡される
+      expect(templateValues).toContain(200);
     });
 
     it('topK指定時はmulti-categoryでtopKが総予算としてperCategoryに分配される', async () => {
       // topK=90, 3カテゴリ → kPerCategory = Math.max(30, Math.floor(90/3)) = Math.max(30, 30) = 30
+      const stage1Simple = mockCandidatesSimple.map((c) => ({
+        articleId: c.id,
+        sim_emb: c.sim_emb,
+      }));
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockMultiCentroids3) // getCategoryCentroids
-        .mockResolvedValueOnce(mockCandidatesSimple) // cat-1 getEmbeddingCandidates
-        .mockResolvedValueOnce(mockCandidatesSimple) // cat-2 getEmbeddingCandidates
-        .mockResolvedValueOnce(mockCandidatesSimple) // cat-3 getEmbeddingCandidates
+        .mockResolvedValueOnce(stage1Simple) // cat-1 Stage 1: kNN (LIMIT=30)
+        .mockResolvedValueOnce(stage1Simple) // cat-2 Stage 1: kNN (LIMIT=30) (interleaved - all S1 first)
+        .mockResolvedValueOnce(stage1Simple) // cat-3 Stage 1: kNN (LIMIT=30)
+        .mockResolvedValueOnce(mockCandidatesSimple) // cat-1 Stage 2: data fetch
+        .mockResolvedValueOnce(mockCandidatesSimple) // cat-2 Stage 2: data fetch
+        .mockResolvedValueOnce(mockCandidatesSimple) // cat-3 Stage 2: data fetch
         .mockResolvedValueOnce([]); // checkTagMatches
 
       await service.filterArticles({
@@ -957,7 +1083,7 @@ describe('CategoryFilterService', () => {
         topK: 90,
       });
 
-      // $queryRaw の 2〜4回目が各カテゴリのgetEmbeddingCandidates
+      // Stage 1 は calls[1], calls[2], calls[3] (各カテゴリの kNN クエリ - 全S1が先に来る)
       // それぞれ kPerCategory=30 が LIMIT として渡されることを確認
       for (const callIndex of [1, 2, 3]) {
         const callArgs = mockPrisma.$queryRaw.mock.calls[callIndex];
@@ -968,11 +1094,18 @@ describe('CategoryFilterService', () => {
 
     it('topK指定時のperCategory分配: topKがカテゴリ数より少なくても最低30が保証される', async () => {
       // topK=10, 3カテゴリ → kPerCategory = Math.max(30, Math.floor(10/3)) = Math.max(30, 3) = 30
+      const stage1Simple = mockCandidatesSimple.map((c) => ({
+        articleId: c.id,
+        sim_emb: c.sim_emb,
+      }));
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockMultiCentroids3) // getCategoryCentroids
-        .mockResolvedValueOnce(mockCandidatesSimple) // cat-1
-        .mockResolvedValueOnce(mockCandidatesSimple) // cat-2
-        .mockResolvedValueOnce(mockCandidatesSimple) // cat-3
+        .mockResolvedValueOnce(stage1Simple) // cat-1 Stage 1: kNN (LIMIT=30)
+        .mockResolvedValueOnce(stage1Simple) // cat-2 Stage 1: kNN (LIMIT=30) (interleaved - all S1 first)
+        .mockResolvedValueOnce(stage1Simple) // cat-3 Stage 1: kNN (LIMIT=30)
+        .mockResolvedValueOnce(mockCandidatesSimple) // cat-1 Stage 2: data fetch
+        .mockResolvedValueOnce(mockCandidatesSimple) // cat-2 Stage 2: data fetch
+        .mockResolvedValueOnce(mockCandidatesSimple) // cat-3 Stage 2: data fetch
         .mockResolvedValueOnce([]); // checkTagMatches
 
       await service.filterArticles({
@@ -982,6 +1115,7 @@ describe('CategoryFilterService', () => {
         topK: 10,
       });
 
+      // Stage 1 は calls[1], calls[2], calls[3] (各カテゴリの kNN クエリ - 全S1が先に来る)
       // 最低30が保証される
       for (const callIndex of [1, 2, 3]) {
         const callArgs = mockPrisma.$queryRaw.mock.calls[callIndex];
@@ -1052,12 +1186,58 @@ describe('CategoryFilterService', () => {
     ];
 
     it('maxConcurrency指定時もカテゴリ数 > maxConcurrency で全カテゴリの結果が返る', async () => {
-      // 3カテゴリ, maxConcurrency=2 → 順次処理されるが最終的に全結果がマージされる
+      // Mock getEmbeddingCandidates directly to avoid pLimit interleaving issues with $queryRaw mock order
+      const candidatesByCentroid: Record<string, any[]> = {
+        '[0.5,0.5,0]': mockCandidatesFrontend.map((c) => ({
+          id: c.id,
+          title: c.title,
+          url: c.url,
+          publishedAt: c.published_at,
+          createdAt: c.created_at,
+          qualityScore: c.quality_score ?? 0,
+          bookmarks: c.bookmarks ?? 0,
+          userVotes: c.user_votes ?? 0,
+          sourceId: c.source_id,
+          summary: c.summary,
+          thumbnailUrl: c.thumbnail_url,
+          embeddingSimilarity: c.sim_emb,
+        })),
+        '[0,0.5,0.5]': mockCandidatesBackend.map((c) => ({
+          id: c.id,
+          title: c.title,
+          url: c.url,
+          publishedAt: c.published_at,
+          createdAt: c.created_at,
+          qualityScore: c.quality_score ?? 0,
+          bookmarks: c.bookmarks ?? 0,
+          userVotes: c.user_votes ?? 0,
+          sourceId: c.source_id,
+          summary: c.summary,
+          thumbnailUrl: c.thumbnail_url,
+          embeddingSimilarity: c.sim_emb,
+        })),
+        '[0.5,0,0.5]': mockCandidatesInfra.map((c) => ({
+          id: c.id,
+          title: c.title,
+          url: c.url,
+          publishedAt: c.published_at,
+          createdAt: c.created_at,
+          qualityScore: c.quality_score ?? 0,
+          bookmarks: c.bookmarks ?? 0,
+          userVotes: c.user_votes ?? 0,
+          sourceId: c.source_id,
+          summary: c.summary,
+          thumbnailUrl: c.thumbnail_url,
+          embeddingSimilarity: c.sim_emb,
+        })),
+      };
+      mockGetEmbeddingCandidates.mockImplementation(
+        async (_db: any, centroid: string) =>
+          candidatesByCentroid[centroid] ?? []
+      );
+
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockCentroids3) // getCategoryCentroids
-        .mockResolvedValueOnce(mockCandidatesFrontend) // cat-1
-        .mockResolvedValueOnce(mockCandidatesBackend) // cat-2
-        .mockResolvedValueOnce(mockCandidatesInfra) // cat-3
         .mockResolvedValueOnce([]); // checkTagMatches
 
       const result = await service.filterArticles({
@@ -1067,7 +1247,9 @@ describe('CategoryFilterService', () => {
         maxConcurrency: 2,
       });
 
-      // 全3カテゴリの記事が取得され、ユニーク3件になる
+      // Reset mock for other tests
+      mockGetEmbeddingCandidates.mockReset();
+
       const articleIds = result.articles.map((a) => a.articleId);
       expect(articleIds).toContain('art-1');
       expect(articleIds).toContain('art-2');
@@ -1077,6 +1259,7 @@ describe('CategoryFilterService', () => {
 
     it('maxConcurrency >= カテゴリ数の場合はPromise.allSettledで並列実行され全結果が返る', async () => {
       // 2カテゴリ, maxConcurrency=5 → maxConcurrency >= centroids.length なので通常のPromise.allSettled
+      // 実行順: cat1-S1 → cat2-S1 (interleaved) → cat1-S2 → cat2-S2
       const mockCentroids2 = [
         { id: 'cat-1', slug: 'frontend', centroid_embedding: '[0.5,0.5,0]' },
         { id: 'cat-2', slug: 'backend', centroid_embedding: '[0,0.5,0.5]' },
@@ -1084,8 +1267,20 @@ describe('CategoryFilterService', () => {
 
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockCentroids2) // getCategoryCentroids
-        .mockResolvedValueOnce(mockCandidatesFrontend) // cat-1
-        .mockResolvedValueOnce(mockCandidatesBackend) // cat-2
+        .mockResolvedValueOnce(
+          mockCandidatesFrontend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // cat-1 Stage 1: kNN
+        .mockResolvedValueOnce(
+          mockCandidatesBackend.map((c) => ({
+            articleId: c.id,
+            sim_emb: c.sim_emb,
+          }))
+        ) // cat-2 Stage 1: kNN (interleaved - all S1 first)
+        .mockResolvedValueOnce(mockCandidatesFrontend) // cat-1 Stage 2: data fetch
+        .mockResolvedValueOnce(mockCandidatesBackend) // cat-2 Stage 2: data fetch
         .mockResolvedValueOnce([]); // checkTagMatches
 
       const result = await service.filterArticles({
@@ -1104,11 +1299,36 @@ describe('CategoryFilterService', () => {
     it('maxConcurrency指定時にカテゴリ検索が一部失敗しても他のカテゴリ結果は返る', async () => {
       const { logger } = jest.requireMock('@/lib/logger');
 
+      // Mock getEmbeddingCandidates: cat-2 fails, cat-1 and cat-3 succeed
+      const toEmbeddingCandidate = (c: any) => ({
+        id: c.id,
+        title: c.title,
+        url: c.url,
+        publishedAt: c.published_at,
+        createdAt: c.created_at,
+        qualityScore: c.quality_score ?? 0,
+        bookmarks: c.bookmarks ?? 0,
+        userVotes: c.user_votes ?? 0,
+        sourceId: c.source_id,
+        summary: c.summary,
+        thumbnailUrl: c.thumbnail_url,
+        embeddingSimilarity: c.sim_emb,
+      });
+      const candidatesByCentroid: Record<string, any> = {
+        '[0.5,0.5,0]': mockCandidatesFrontend.map(toEmbeddingCandidate),
+        '[0,0.5,0.5]': 'FAIL', // cat-2 fails
+        '[0.5,0,0.5]': mockCandidatesInfra.map(toEmbeddingCandidate),
+      };
+      mockGetEmbeddingCandidates.mockImplementation(
+        async (_db: any, centroid: string) => {
+          const result = candidatesByCentroid[centroid];
+          if (result === 'FAIL') throw new Error('DB error');
+          return result ?? [];
+        }
+      );
+
       mockPrisma.$queryRaw
         .mockResolvedValueOnce(mockCentroids3) // getCategoryCentroids
-        .mockResolvedValueOnce(mockCandidatesFrontend) // cat-1: 成功
-        .mockRejectedValueOnce(new Error('DB error')) // cat-2: 失敗
-        .mockResolvedValueOnce(mockCandidatesInfra) // cat-3: 成功
         .mockResolvedValueOnce([]); // checkTagMatches
 
       const result = await service.filterArticles({
@@ -1117,6 +1337,9 @@ describe('CategoryFilterService', () => {
         limit: 10,
         maxConcurrency: 2,
       });
+
+      // Reset mock for other tests
+      mockGetEmbeddingCandidates.mockReset();
 
       // cat-2 は失敗するが cat-1, cat-3 の結果は取得できる
       const articleIds = result.articles.map((a) => a.articleId);

--- a/app/api/articles/handlers/get.ts
+++ b/app/api/articles/handlers/get.ts
@@ -13,6 +13,7 @@ import {
   LayeredCache,
   type ArticleQueryParams,
 } from '@/lib/cache/layered-cache';
+import { RedisCache } from '@/lib/cache/redis-cache';
 import { auth } from '@/lib/auth/auth';
 import {
   MetricsCollector,
@@ -47,6 +48,10 @@ import {
 
 // Initialize Layered cache system for articles
 const cache = new LayeredCache();
+const personalizationCache = new RedisCache({
+  ttl: 300,
+  namespace: 'personalization',
+});
 
 /**
  * Parse query parameters from request
@@ -315,8 +320,43 @@ async function executePersonalizedQuery(
         : undefined,
     };
 
+    // Build cache key from personalization-specific parameters only
+    const sortedCategoryIds = personalizationOptions.categoryIds
+      .slice()
+      .sort()
+      .join(',');
+    const excludeKey =
+      personalizationOptions.excludeSourceIds?.slice().sort().join(',') ||
+      'none';
+    const cacheKey = `ids:${sortedCategoryIds}:p${personalizationOptions.periodMonths}:${personalizationOptions.sortBy}:${personalizationOptions.sortOrder}:page${page}:lim${limit}:excl${excludeKey}`;
+
+    type CachedPersonalizationResult = {
+      articles: Array<{
+        articleId: string;
+        embeddingSimilarity: number;
+        tagBoost: number;
+        recencyDecay: number;
+        finalScore: number;
+      }>;
+      meta: { totalMatched: number; queryMs?: number };
+    };
+
     const { articles: scoredArticles, meta: personalizationMeta } =
-      await categoryFilterService.filterArticles(personalizationOptions);
+      await personalizationCache.getOrSetWithLock<CachedPersonalizationResult>(
+        cacheKey,
+        async () => {
+          const result = await categoryFilterService.filterArticles(
+            personalizationOptions
+          );
+          return {
+            articles: result.articles,
+            meta: {
+              totalMatched: result.meta?.totalMatched ?? 0,
+              queryMs: result.meta?.queryMs,
+            },
+          };
+        }
+      );
 
     const personalizedIds = scoredArticles.map((article) => article.articleId);
 

--- a/app/api/articles/handlers/get.ts
+++ b/app/api/articles/handlers/get.ts
@@ -342,8 +342,16 @@ async function executePersonalizedQuery(
     };
 
     // Try cache first; skip caching if result is a fallback (appliedCategories empty)
-    const cached =
-      await personalizationCache.get<CachedPersonalizationResult>(cacheKey);
+    let cached: CachedPersonalizationResult | null = null;
+    try {
+      cached =
+        await personalizationCache.get<CachedPersonalizationResult>(cacheKey);
+    } catch (cacheError) {
+      logger.warn(
+        { err: cacheError },
+        'Personalization cache get failed, proceeding without cache'
+      );
+    }
     let scoredArticles: CachedPersonalizationResult['articles'];
     let personalizationMeta: CachedPersonalizationResult['meta'];
 
@@ -361,10 +369,14 @@ async function executePersonalizedQuery(
       };
       // Only cache real personalization results (appliedCategories is empty for fallback)
       if ((result.meta?.appliedCategories?.length ?? 0) > 0) {
-        await personalizationCache.set(cacheKey, {
-          articles: scoredArticles,
-          meta: personalizationMeta,
-        });
+        try {
+          await personalizationCache.set(cacheKey, {
+            articles: scoredArticles,
+            meta: personalizationMeta,
+          });
+        } catch (cacheError) {
+          logger.warn({ err: cacheError }, 'Personalization cache set failed');
+        }
       }
     }
 
@@ -403,15 +415,20 @@ async function executePersonalizedQuery(
         Boolean(article)
       );
 
-    const totalMatched =
-      personalizationMeta?.totalMatched ?? personalizedIds.length;
+    // Post-filter (isHidden, summaryComputedAt) may exclude some cached IDs
+    const filteredOutCount = personalizedIds.length - orderedItems.length;
+    const adjustedTotal = Math.max(
+      0,
+      (personalizationMeta?.totalMatched ?? personalizedIds.length) -
+        filteredOutCount
+    );
 
     return {
       items: orderedItems as ArticleWithRelations[],
-      total: totalMatched,
+      total: adjustedTotal,
       page,
       limit,
-      totalPages: Math.ceil(totalMatched / limit),
+      totalPages: Math.ceil(adjustedTotal / limit),
     };
   } catch (error) {
     logger.error(

--- a/app/api/articles/handlers/get.ts
+++ b/app/api/articles/handlers/get.ts
@@ -341,22 +341,32 @@ async function executePersonalizedQuery(
       meta: { totalMatched: number; queryMs?: number };
     };
 
-    const { articles: scoredArticles, meta: personalizationMeta } =
-      await personalizationCache.getOrSetWithLock<CachedPersonalizationResult>(
-        cacheKey,
-        async () => {
-          const result = await categoryFilterService.filterArticles(
-            personalizationOptions
-          );
-          return {
-            articles: result.articles,
-            meta: {
-              totalMatched: result.meta?.totalMatched ?? 0,
-              queryMs: result.meta?.queryMs,
-            },
-          };
-        }
+    // Try cache first; skip caching if result is a fallback (appliedCategories empty)
+    const cached =
+      await personalizationCache.get<CachedPersonalizationResult>(cacheKey);
+    let scoredArticles: CachedPersonalizationResult['articles'];
+    let personalizationMeta: CachedPersonalizationResult['meta'];
+
+    if (cached) {
+      scoredArticles = cached.articles;
+      personalizationMeta = cached.meta;
+    } else {
+      const result = await categoryFilterService.filterArticles(
+        personalizationOptions
       );
+      scoredArticles = result.articles;
+      personalizationMeta = {
+        totalMatched: result.meta?.totalMatched ?? 0,
+        queryMs: result.meta?.queryMs,
+      };
+      // Only cache real personalization results (appliedCategories is empty for fallback)
+      if ((result.meta?.appliedCategories?.length ?? 0) > 0) {
+        await personalizationCache.set(cacheKey, {
+          articles: scoredArticles,
+          meta: personalizationMeta,
+        });
+      }
+    }
 
     const personalizedIds = scoredArticles.map((article) => article.articleId);
 
@@ -370,7 +380,11 @@ async function executePersonalizedQuery(
       metrics,
       () =>
         prisma.article.findMany({
-          where: { id: { in: personalizedIds } },
+          where: {
+            id: { in: personalizedIds },
+            isHidden: false,
+            summaryComputedAt: { not: null },
+          },
           select: selectFields,
         }),
       'db_query'

--- a/app/components/home/home-client-infinite.tsx
+++ b/app/components/home/home-client-infinite.tsx
@@ -125,6 +125,7 @@ export function HomeClientInfinite({
     filterEnabled: isPersonalized,
     periodMonths: personalizedPeriod,
     hasPreferences,
+    isLoading: isLoadingPreferences,
   } = usePersonalizationPreferences();
 
   // カテゴリの変更を検出
@@ -236,10 +237,13 @@ export function HomeClientInfinite({
     isLoading,
     isError,
     refetch,
-  } = useInfiniteArticles({
-    ...filters,
-    includeUserData: true, // Include favorites and read status in API response
-  });
+  } = useInfiniteArticles(
+    {
+      ...filters,
+      includeUserData: true, // Include favorites and read status in API response
+    },
+    { enabled: !isLoadingPreferences }
+  );
 
   // ページごとの記事を1つの配列にフラット化（重複除去付き）
   const allArticles = useMemo(() => {

--- a/app/hooks/use-infinite-articles.ts
+++ b/app/hooks/use-infinite-articles.ts
@@ -42,7 +42,10 @@ interface ArticlesResponse {
 
 type InfiniteArticlesData = InfiniteData<ArticlesResponse, number>;
 
-export function useInfiniteArticles(filters: ArticleFilters) {
+export function useInfiniteArticles(
+  filters: ArticleFilters,
+  options?: { enabled?: boolean }
+) {
   const queryClient = useQueryClient();
   const prevFilterKeyRef = useRef<string>('');
   const totalCountRef = useRef<number | undefined>(undefined);
@@ -394,6 +397,7 @@ export function useInfiniteArticles(filters: ArticleFilters) {
     refetchInterval: false, // 自動リフェッチを無効化
     retry: 1, // リトライ回数を制限
     retryDelay: 1000, // リトライ間隔を設定
+    enabled: options?.enabled,
   });
 
   return infiniteQuery;

--- a/lib/personalization/filters/candidate-extractor.ts
+++ b/lib/personalization/filters/candidate-extractor.ts
@@ -6,9 +6,16 @@
 
 import { PrismaClient, Prisma } from '@prisma/client';
 import { DEFAULT_SCORE_PARAMETERS } from '../types';
+import { RedisCache } from '@/lib/cache/redis-cache';
+
+/** Module-level singleton for centroid cache (TTL: 1 hour) */
+const centroidCache = new RedisCache({
+  ttl: 3600,
+  namespace: 'personalization',
+});
 
 /** Legacy default for embedding candidates (kept for API compatibility; not used in threshold mode) */
-export const DEFAULT_TOP_K_CANDIDATES = 1000;
+export const DEFAULT_TOP_K_CANDIDATES = 200;
 
 /** Minimum similarity threshold to include in results (derived from ScoreParameters) */
 export const DEFAULT_MIN_SIMILARITY =
@@ -66,23 +73,27 @@ export type CategoryCentroidRow = {
 };
 
 /**
- * Get category centroids from database.
+ * Get category centroids from database, with Redis cache (TTL: 1 hour).
  */
 export async function getCategoryCentroids(
   db: PrismaClient,
   categoryIds: string[]
 ): Promise<CategoryCentroidRow[]> {
-  const result = await db.$queryRaw<CategoryCentroidRow[]>`
-    SELECT
-      id,
-      slug,
-      "centroidEmbedding"::text as centroid_embedding
-    FROM "InterestCategory"
-    WHERE id = ANY(${categoryIds}::text[])
-      AND "centroidEmbedding" IS NOT NULL
-  `;
+  const cacheKey = `centroids:${categoryIds.slice().sort().join(',')}`;
 
-  return result;
+  return centroidCache.getOrSetWithLock<CategoryCentroidRow[]>(
+    cacheKey,
+    () =>
+      db.$queryRaw<CategoryCentroidRow[]>`
+        SELECT
+          id,
+          slug,
+          "centroidEmbedding"::text as centroid_embedding
+        FROM "InterestCategory"
+        WHERE id = ANY(${categoryIds}::text[])
+          AND "centroidEmbedding" IS NOT NULL
+      `
+  );
 }
 
 /**
@@ -112,11 +123,31 @@ export async function getEmbeddingCandidates(
       ? Prisma.sql`AND a."sourceId" != ALL(${excludeSourceIds}::text[])`
       : Prisma.empty;
 
-  // Use threshold-based filtering with topK limit
-  const maxDistance = 1 - DEFAULT_MIN_SIMILARITY;
-
   // Apply guard rail: limit topK to safety cap
   const effectiveLimit = Math.min(topK, DEFAULT_THRESHOLD_RESULT_LIMIT);
+
+  // Stage 1: Pure kNN query on partial HNSW index (no JOINs, no extra filters)
+  // The partial index on embeddingKey = 'summary' enables HNSW usage here.
+  type Stage1Row = { articleId: string; sim_emb: number };
+  const stage1Results = await db.$queryRaw<Stage1Row[]>`
+    SELECT "articleId", 1 - (embedding <=> ${centroid}::vector) AS sim_emb
+    FROM "ArticleEmbedding"
+    WHERE "embeddingKey" = 'summary'::"EmbeddingKey"
+    ORDER BY embedding <=> ${centroid}::vector
+    LIMIT ${effectiveLimit}
+  `;
+
+  if (stage1Results.length === 0) {
+    return [];
+  }
+
+  // Stage 2: Data fetch + filtering using Stage 1 results via VALUES clause
+  const valuesClause = Prisma.join(
+    stage1Results.map(
+      (r) => Prisma.sql`(${r.articleId}::text, ${r.sim_emb}::float8)`
+    ),
+    ','
+  );
 
   const result = await db.$queryRaw<RawEmbeddingCandidate[]>`
     SELECT
@@ -131,17 +162,14 @@ export async function getEmbeddingCandidates(
       a."sourceId" as source_id,
       a.summary,
       a.thumbnail as thumbnail_url,
-      1 - (ae.embedding <=> ${centroid}::vector) AS sim_emb
-    FROM "Article" a
-    INNER JOIN "ArticleEmbedding" ae ON a.id = ae."articleId"
-    WHERE ae."embeddingKey" = 'summary'::"EmbeddingKey"
-      AND a."summaryComputedAt" IS NOT NULL
+      s1.sim_emb
+    FROM (VALUES ${valuesClause}) AS s1("articleId", sim_emb)
+    INNER JOIN "Article" a ON a.id = s1."articleId"
+    WHERE a."summaryComputedAt" IS NOT NULL
       AND a."isHidden" = false
-      AND (ae.embedding <=> ${centroid}::vector) < ${maxDistance}
       ${periodFilter}
       ${sourceExcludeFilter}
-    ORDER BY ae.embedding <=> ${centroid}::vector
-    LIMIT ${effectiveLimit}
+      AND s1.sim_emb >= ${DEFAULT_MIN_SIMILARITY}
   `;
 
   return result.map((row) => ({

--- a/lib/personalization/filters/candidate-extractor.ts
+++ b/lib/personalization/filters/candidate-extractor.ts
@@ -7,6 +7,7 @@
 import { PrismaClient, Prisma } from '@prisma/client';
 import { DEFAULT_SCORE_PARAMETERS } from '../types';
 import { RedisCache } from '@/lib/cache/redis-cache';
+import { logger } from '@/lib/logger';
 
 /** Module-level singleton for centroid cache (TTL: 1 hour) */
 const centroidCache = new RedisCache({
@@ -172,7 +173,7 @@ export async function getEmbeddingCandidates(
       AND s1.sim_emb >= ${DEFAULT_MIN_SIMILARITY}
   `;
 
-  return result.map((row) => ({
+  const mapped = result.map((row) => ({
     id: row.id,
     title: row.title,
     url: row.url,
@@ -186,6 +187,16 @@ export async function getEmbeddingCandidates(
     thumbnailUrl: row.thumbnail_url,
     embeddingSimilarity: row.sim_emb,
   }));
+
+  // Monitor for potential recall issues after topK reduction
+  if (mapped.length < 10 && effectiveLimit >= 50) {
+    logger.warn(
+      { candidateCount: mapped.length, effectiveLimit },
+      'Low candidate count relative to topK limit — potential recall issue'
+    );
+  }
+
+  return mapped;
 }
 
 /**

--- a/prisma/migrations/20260406080419_add_partial_hnsw_summary_index/migration.sql
+++ b/prisma/migrations/20260406080419_add_partial_hnsw_summary_index/migration.sql
@@ -1,0 +1,12 @@
+-- Partial HNSW index for summary embeddings only
+-- Rationale: existing full HNSW (idx_article_embedding_hnsw_cosine) is not used
+-- when WHERE embeddingKey = 'summary' filter is present. This partial index
+-- enables HNSW usage in a 2-stage query pattern.
+-- Using non-CONCURRENTLY for Prisma migration compatibility.
+-- For production, consider running CONCURRENTLY manually during low-traffic hours.
+
+CREATE INDEX IF NOT EXISTS "idx_article_embedding_hnsw_summary"
+ON "ArticleEmbedding"
+USING hnsw (embedding vector_cosine_ops)
+WITH (m = 16, ef_construction = 64)
+WHERE "embeddingKey" = 'summary'::"EmbeddingKey";

--- a/scripts/personalization/compute-centroids.ts
+++ b/scripts/personalization/compute-centroids.ts
@@ -24,6 +24,7 @@
 
 import { CentroidService } from '../../lib/personalization/centroid-service';
 import { prisma } from '../../lib/prisma';
+import { RedisCache } from '../../lib/cache/redis-cache';
 
 // =============================================================================
 // CLI Argument Parsing
@@ -217,6 +218,13 @@ async function main(): Promise<void> {
 
   const elapsed = Date.now() - startTime;
   console.log(`\nCompleted in ${elapsed}ms`);
+
+  // Invalidate centroid cache after successful computation
+  if (!options.dryRun && !options.statsOnly) {
+    const centroidCache = new RedisCache({ ttl: 3600, namespace: 'personalization' });
+    await centroidCache.invalidatePattern('centroids:*');
+    console.log('Centroid cache invalidated');
+  }
 
   // Show final stats
   const finalStats = await service.getCentroidStats();

--- a/scripts/personalization/compute-centroids.ts
+++ b/scripts/personalization/compute-centroids.ts
@@ -219,11 +219,16 @@ async function main(): Promise<void> {
   const elapsed = Date.now() - startTime;
   console.log(`\nCompleted in ${elapsed}ms`);
 
-  // Invalidate centroid cache after successful computation
+  // Invalidate centroid and personalization caches after successful computation
   if (!options.dryRun && !options.statsOnly) {
-    const centroidCache = new RedisCache({ ttl: 3600, namespace: 'personalization' });
-    await centroidCache.invalidatePattern('centroids:*');
-    console.log('Centroid cache invalidated');
+    try {
+      const centroidCache = new RedisCache({ ttl: 3600, namespace: 'personalization' });
+      await centroidCache.invalidatePattern('centroids:*');
+      await centroidCache.invalidatePattern('ids:*');
+      console.log('Centroid and personalization caches invalidated');
+    } catch (e) {
+      console.warn('Cache invalidation failed (non-fatal):', e);
+    }
   }
 
   // Show final stats


### PR DESCRIPTION
## 概要
- パーソナライズ有効時のホームページ表示レイテンシ改善を狙う最適化を実装（キャッシュヒット時の短縮を想定）
- 5件のボトルネック（BN1-BN5）を一括対応
- Issue #567（趣向ステータス機能）の前提条件

## 実装内容

### BN1: パーソナライズパスRedisキャッシュ（get.ts）
- filterArticles()が返すスコア済みarticleId列とmetaをRedisにキャッシュ（TTL 5分）
- fallback結果はキャッシュしない（appliedCategories判定）
- findManyにisHidden/summaryComputedAtフィルタ追加（キャッシュ鮮度問題対策）

### BN2: partial HNSWインデックス + 2段階分離クエリ（candidate-extractor.ts + migration）
- embeddingKey='summary'のpartial HNSWインデックス作成
- getEmbeddingCandidatesを2段階クエリに変更（Stage1: pure kNN, Stage2: VALUES JOINでdata fetch）

### BN3: centroidキャッシュ（candidate-extractor.ts + compute-centroids.ts）
- getCategoryCentroids()にRedis getOrSetWithLockキャッシュ追加（TTL 1時間）
- compute-centroids.tsで再計算後にcentroids:* + ids:*を同時invalidate（try-catch付き）

### BN4: topK削減（candidate-extractor.ts）
- DEFAULT_TOP_K_CANDIDATES を1000→200に削減

### BN5: クライアント二重フェッチ排除（home-client-infinite.tsx + use-infinite-articles.ts）
- usePersonalizationPreferencesのisLoadingでuseInfiniteArticlesのenabledを制御
- preferences解決前のフェッチを防止

## テスト結果
- category-filter-service.test.ts: 41/41 PASS
- category-filter.test.ts: 10/10 PASS
- route.test.ts: 14/14 PASS
- Lint: 0 errors, 0 warnings
- Type-check: PASS
- Build: PASS
- Security audit: 0 vulnerabilities

## マイグレーション注意
- partial HNSWインデックスはnon-CONCURRENTLYで作成（Prisma互換）
- 構築時間は環境依存のため、staging/productionで事前計測推奨
- 本番環境では低トラフィック時間帯にデプロイ推奨

## チェックリスト
- [x] テスト通過
- [x] cross-review実施（Full Tier: Codex + DA + database-reviewer + typescript-reviewer）
- [x] Critical/Warning指摘対応済み
- [x] 破壊的変更なし

Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * パーソナライズ記事ランキングをキャッシュし、キャッシュヒット時の応答を速くしました。

* **Refactor**
  * ユーザープリファレンス読み込み中は記事取得を抑制する制御を追加しました。
  * 候補抽出フローを二段階に見直し、抽出効率とフィルタ精度を改善しました。
  * デフォルトの候補上限を見直しました。

* **Chores**
  * 部分インデックスを追加し検索性能を強化しました。
  * センチロイド計算スクリプトでキャッシュ無効化処理を追加しました。

* **Tests**
  * 候補抽出周りのテストとモックを安定化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->