### PR TITLE
fix(home): パーソナライズ設定ロード中の空状態フラッシュを修正

### DIFF
--- a/app/components/home/home-client-infinite.tsx
+++ b/app/components/home/home-client-infinite.tsx
@@ -125,7 +125,7 @@ export function HomeClientInfinite({
     filterEnabled: isPersonalized,
     periodMonths: personalizedPeriod,
     hasPreferences,
-    isLoading: isLoadingPreferences,
+    isLoadingPreferences,
   } = usePersonalizationPreferences();
 
   // カテゴリの変更を検出
@@ -358,7 +358,7 @@ export function HomeClientInfinite({
           />
         )}
 
-        {isLoading && !isCategoryChanging ? (
+        {(isLoading || isLoadingPreferences) && !isCategoryChanging ? (
           <LoadingSpinner message="記事を読み込んでいます..." />
         ) : allArticles.length > 0 ? (
           <div className="relative">


### PR DESCRIPTION
## 概要
- トップ画面の初回表示時に「記事が見つかりませんでした」が一瞬表示される問題を修正
- パーソナライズ設定ロード中のレンダリング条件を修正し、ローディングスピナーを表示するように変更

## 背景・原因
`usePersonalizationPreferences()`の`isLoading`（categories + preferences両方のOR）を`isLoadingPreferences`としてエイリアスし、`enabled: !isLoadingPreferences`で記事クエリを制御していた。TanStack Query v5では`enabled: false`時に`isLoading = false`（`isPending && isFetching = true && false`）となるため、レンダリング条件が空状態にフォールスルーしていた。

## 実装内容
1. destructuringを`isLoading: isLoadingPreferences`から`isLoadingPreferences`に変更（preferencesQueryのみを参照、categoriesQuery完了の不要な待機を排除）
2. レンダリング条件を`isLoading && !isCategoryChanging`から`(isLoading || isLoadingPreferences) && !isCategoryChanging`に変更（設定ロード中もスピナーを表示）

## テスト結果
- Docker本番ビルド: 成功（TypeScript型チェック含む）
- ESLint: 0 errors, 0 warnings
- TypeScript型チェック: 0 errors
- 対応テストファイル: なし（既存テストなし）

## チェックリスト
- [x] ビルド通過
- [x] lint/型チェック通過
- [x] 破壊的変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 記事読み込み中だけでなく、パーソナライズ設定の読み込み中もローディングインジケーターが表示されるように改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->