### PR TITLE
fix(deps): Dependabotセキュリティアラート3件対応（hono/follow-redirects）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,4 +196,5 @@ backups/
 dump.rdb
 .aigne/
 .docker-ci-build-timestamp
+.last-verify-timestamp
 .codex

--- a/package-lock.json
+++ b/package-lock.json
@@ -1948,9 +1948,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -13180,9 +13180,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -13890,9 +13890,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -279,6 +279,9 @@
     "defu": "6.1.6",
     "better-call": {
       "zod": "$zod"
-    }
+    },
+    "hono": "4.12.14",
+    "@hono/node-server": "1.19.13",
+    "follow-redirects": "1.16.0"
   }
 }


### PR DESCRIPTION
## 概要

- Dependabotオープンアラート3件（全てMedium）を `package.json` overrides で解消
- 先行PR #570 / #554 / #550 と同パターン（直接依存の更新だけでは解消できないため overrides 必須）
- アプリケーションコード変更なし、`package.json` + `package-lock.json` のみ

## 実装内容

### overrides 追加

| パッケージ | 脆弱バージョン | パッチ版 | 依存経路 | scope |
|-----------|--------------|---------|---------|-------|
| hono | 4.12.12 | 4.12.14 | prisma > @prisma/dev | development |
| @hono/node-server | 1.19.11 | 1.19.13 | prisma > @prisma/dev | development |
| follow-redirects | 1.15.11 | 1.16.0 | axios | runtime |

### 脆弱性詳細

- **hono (#77)**: JSX Attribute HTML Injection (hono/jsx SSR)
- **@hono/node-server (#75)**: Middleware bypass via repeated slashes in serveStatic
- **follow-redirects (#76)**: Auth headers leak on cross-domain redirect

hono系2件は Prisma CLI（devDependency）経由のためプロダクション無影響。follow-redirects のみ axios経由のランタイム依存。

### 選択理由（overrides方式）

- 現行の axios@1.15.0 では `follow-redirects: ^1.15.11` 指定のままで、直接依存の更新だけでは今回の解消条件を満たせない
- prisma@7.7.0 が解決する現行の @prisma/dev では @hono/node-server が 1.19.11 に固定されるため、直接依存の更新だけでは解消できず overrides が必要
- overrides方式は先行PR（nodemailer, defu等）と一貫した保守パターン

## テスト結果（verifyフェーズ）

- `npm run lint`: 0 errors / 0 warnings
- `npm run type-check`: PASS
- `npm audit --production --audit-level=high`: **0 vulnerabilities**
- `npm run docker:build`: SUCCESS（Next.js 全ページビルド）
- `TEST_FILE="__tests__/fetchers/ai/qiita-ai.test.ts" npm run docker:test:file`: 6 passed, 1 skipped（axios経路のランタイム確認）
- `npm ls hono @hono/node-server follow-redirects`: 3件ともoverriddenを確認

## チェックリスト

- [x] テスト通過
- [x] ドキュメント更新不要（依存更新のみ）
- [x] 破壊的変更なし（パッチ/マイナーバンプ、SemVer互換）

Fixes #75, #76, #77 (Dependabot alerts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 複数の主要なライブラリのバージョンをピン留めしました。これにより、依存関係の互換性を確保し、アプリケーションの安定性を向上させることができます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->