### PR TITLE
fix(article): ViewTrackerに未認証ガードを追加し不要な401を防止

### DIFF
--- a/__tests__/components/article/view-tracker.test.tsx
+++ b/__tests__/components/article/view-tracker.test.tsx
@@ -1,0 +1,136 @@
+import { render, act } from '@testing-library/react';
+import { ViewTracker } from '@/components/article/view-tracker';
+import { authClient } from '@/lib/auth/auth-client';
+
+jest.mock('@/lib/auth/auth-client', () => ({
+  authClient: {
+    useSession: jest.fn().mockReturnValue({ data: null, isPending: false }),
+    signIn: { email: jest.fn(), social: jest.fn() },
+    signOut: jest.fn(),
+    signUp: { email: jest.fn() },
+  },
+  useSession: jest.fn().mockReturnValue({ data: null, isPending: false }),
+  signIn: jest.fn(),
+  signOut: jest.fn(),
+  signUp: jest.fn(),
+}));
+
+const mockedUseSession = jest.mocked(authClient.useSession);
+
+const ARTICLE_ID = 'article-123';
+const API_URL = '/api/article-views';
+
+describe('ViewTracker', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+
+    mockedUseSession.mockReturnValue({
+      data: { user: { id: 'user-1' }, session: {} },
+      isPending: false,
+    } as any);
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ viewId: 'view-1' }),
+    });
+
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('records view after 1500ms when authenticated', async () => {
+    render(<ViewTracker articleId={ARTICLE_ID} />);
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      API_URL,
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ articleId: ARTICLE_ID }),
+      })
+    );
+  });
+
+  it('does not fetch when unauthenticated (session is null)', () => {
+    mockedUseSession.mockReturnValue({ data: null, isPending: false } as any);
+
+    render(<ViewTracker articleId={ARTICLE_ID} />);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when session has no user id', () => {
+    mockedUseSession.mockReturnValue({
+      data: { session: {} },
+      isPending: false,
+    } as any);
+
+    render(<ViewTracker articleId={ARTICLE_ID} />);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when unmounted before 1500ms delay', () => {
+    const { unmount } = render(<ViewTracker articleId={ARTICLE_ID} />);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('re-evaluates when session becomes available after initial render', async () => {
+    mockedUseSession.mockReturnValue({ data: null, isPending: false } as any);
+    const { rerender } = render(<ViewTracker articleId={ARTICLE_ID} />);
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    mockedUseSession.mockReturnValue({
+      data: { user: { id: 'user-1' }, session: {} },
+      isPending: false,
+    } as any);
+    rerender(<ViewTracker articleId={ARTICLE_ID} />);
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(API_URL, expect.any(Object));
+  });
+});

--- a/__tests__/components/article/view-tracker.test.tsx
+++ b/__tests__/components/article/view-tracker.test.tsx
@@ -22,6 +22,7 @@ const API_URL = '/api/article-views';
 
 describe('ViewTracker', () => {
   let consoleErrorSpy: jest.SpyInstance;
+  const originalFetch = global.fetch;
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -43,17 +44,14 @@ describe('ViewTracker', () => {
   afterEach(() => {
     jest.useRealTimers();
     jest.restoreAllMocks();
+    global.fetch = originalFetch;
   });
 
   it('records view after 1500ms when authenticated', async () => {
     render(<ViewTracker articleId={ARTICLE_ID} />);
 
-    act(() => {
-      jest.advanceTimersByTime(1500);
-    });
     await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(1500);
     });
 
     expect(global.fetch).toHaveBeenCalledWith(
@@ -92,6 +90,7 @@ describe('ViewTracker', () => {
     });
 
     expect(global.fetch).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 
   it('does not fetch when unmounted before 1500ms delay', () => {
@@ -123,12 +122,8 @@ describe('ViewTracker', () => {
     } as any);
     rerender(<ViewTracker articleId={ARTICLE_ID} />);
 
-    act(() => {
-      jest.advanceTimersByTime(1500);
-    });
     await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(1500);
     });
 
     expect(global.fetch).toHaveBeenCalledWith(API_URL, expect.any(Object));

--- a/components/article/view-tracker.tsx
+++ b/components/article/view-tracker.tsx
@@ -1,16 +1,19 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { authClient } from '@/lib/auth/auth-client';
 
 interface ViewTrackerProps {
   articleId: string;
 }
 
 export function ViewTracker({ articleId }: ViewTrackerProps) {
+  const { data: session } = authClient.useSession();
   const hasRecordedRef = useRef(false);
   const prevArticleIdRef = useRef(articleId);
 
   useEffect(() => {
+    if (!session?.user?.id) return;
     if (prevArticleIdRef.current !== articleId) {
       hasRecordedRef.current = false;
       prevArticleIdRef.current = articleId;
@@ -55,7 +58,7 @@ export function ViewTracker({ articleId }: ViewTrackerProps) {
       clearTimeout(timeoutId);
       controller.abort();
     };
-  }, [articleId]);
+  }, [articleId, session?.user?.id]);
 
   return null;
 }


### PR DESCRIPTION
## 概要
- 未認証ユーザーが記事詳細ページを閲覧した際、`POST /api/article-views` が呼ばれて 401 が返り、コンソールに `[ViewTracker] Server error: 401` が出ていた問題を修正
- `ViewTracker` に Better Auth の `useSession()` ガードを追加。同ディレクトリの `ReadTracker` と同じパターンに統一
- 認証ガードの回帰テストを新規追加（これまで ViewTracker にテストが無く、検出機会がなかった）

## 実装内容
- `components/article/view-tracker.tsx` (+4/-1): `authClient.useSession()` の結果で early return し、未認証時は fetch を発行しない。依存配列に `session?.user?.id` を追加し、ログイン直後に有効化されるようにする
- `__tests__/components/article/view-tracker.test.tsx` (+136): 5ケースの回帰テスト（認証時fetch / 未認証時noop / user id欠落時noop / 1500ms前unmount時noop / セッション後付与時の再評価）
- ISR設定を維持するため、Server Component (`app/articles/[id]/page.tsx`) および API route (`app/api/article-views/route.ts`) は未変更

## 設計上の検討事項（参考）
- 採用案: Client Component内で `useSession()` ガード → ISR互換、プロジェクト標準パターン（ReadTrackerに一致）
- 非採用: API側で未認証を204化（認証契約の変更で影響範囲が大きい）
- 非採用: Server Componentで `auth()` 呼び出し（ISRキャッシュが無効化される）

## テスト結果
- Jest (DOM): 5/5 PASS
- ESLint: 0 errors, 0 warnings
- TypeScript (\`tsc --noEmit\`): PASS
- \`npm audit --production --audit-level=high\`: 0 vulnerabilities
- Docker production build: PASS

## チェックリスト
- [x] テスト通過
- [x] 破壊的変更なし
- [x] ReadTrackerの既存パターンと整合

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 記事ビュー追跡機能が認証ユーザーからのビューのみを記録するよう改善されました。

* **Tests**
  * 記事ビュー追跡機能の包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->