### PR TITLE
fix(auth): proxy.ts の旧 Auth.js Cookie 名を Better Auth 定数参照に修正 (#577)

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -7,6 +7,7 @@ import {
   isCSRFExemptPath,
   requiresCSRFProtection,
 } from '@/lib/middleware/csrf-protection';
+import { AUTH_COOKIES } from '@/lib/config/auth-cookies';
 
 // Optional Basic Auth (enabled when env is set)
 function needsBasicAuth(): boolean {
@@ -89,8 +90,7 @@ export async function proxy(request: NextRequest) {
 
   if (isProtectedPath || isProtectedApiPath) {
     // セッションチェック（cookieベース）
-    const sessionCookie = request.cookies.get('authjs.session-token') || 
-                         request.cookies.get('__Secure-authjs.session-token');
+    const sessionCookie = request.cookies.get(AUTH_COOKIES.sessionToken);
 
     if (!sessionCookie) {
       // APIルートの場合は401を返す


### PR DESCRIPTION
## 概要
- PR #572 (Auth.js → Better Auth v1.6.2 移行) で更新漏れとなった `proxy.ts` L92-93 の旧Cookie名ハードコードを、既存の `AUTH_COOKIES.sessionToken` 定数参照に置換
- Better Auth セッションユーザーが保護パス (`/api/favorites`, `/profile`, `/favorites`, `/history`, `/digest`) で過剰 401 / リダイレクトされる不具合を解消
- ルートハンドラ側は `withUserValidation` で DB 直接検証しているため認証バイパスは発生していなかった（過剰拒否方向のみの不具合）

Closes #577

## 実装内容
- `proxy.ts` に `import { AUTH_COOKIES } from '@/lib/config/auth-cookies';` を追加
- L92-93 の `request.cookies.get('authjs.session-token') || request.cookies.get('__Secure-authjs.session-token')` を `request.cookies.get(AUTH_COOKIES.sessionToken)` に置換
- 差分: +2 / -2 行（1ファイル）
- 動作差分: `AUTH_COOKIES.sessionToken` は `NODE_ENV === 'production'` のとき `__Secure-better-auth.session_token`、それ以外で `better-auth.session_token` を返す。Better Auth v1.6.2 も環境により片方のみ発行するため整合
- アプリコード内では旧 `authjs.session-token` 参照が proxy.ts のみであることを grep で確認済み（`with-rate-limit.ts:193` は既に定数参照）。`docs/api/rag-search-api.md` に旧Cookie名が残るが本PRのスコープ外

## テスト結果
VERIFY フェーズで全チェック通過:
- Lint: 0 errors
- Type-check: 通過
- Security audit: 0 vulnerabilities
- Docker build: 通過
- Tests:
  - \`__tests__/middleware.node.test.ts\`: 18 passed
  - \`__tests__/api/middleware-order.test.ts\`: 15 passed
- Diff review: 意図通り、debug残留・秘密情報なし

## チェックリスト
- [x] テスト通過
- [x] 破壊的変更なし
- [x] Fast Track 適用（単一ファイル・ロジック変更なし・DBスキーマ変更なし）

## 関連
- Parent Issue: #576
- Auth.js → Better Auth 移行: PR #572
- 調査レポート: \`.workflow/docs/investigate/investigate_20260418_152955_231_issue577_proxy_cookie_fix.md\`
- 計画書: \`.workflow/docs/plan/plan_20260418_153054_994_issue577_proxy_cookie_fix.md\`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * セッション管理の内部実装を改善しました。ユーザーの操作や動作に変わりはありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->