### PR TITLE
feat(personalization): Issue #578 パーソナライズ経路の段階別計測基盤導入

### DIFF
--- a/__mocks__/lib/cache/redis-cache.ts
+++ b/__mocks__/lib/cache/redis-cache.ts
@@ -14,6 +14,18 @@ export class RedisCache {
   getOrSetWithLock<T>(_key: string, fetcher: () => Promise<T>): Promise<T> {
     return fetcher();
   }
+  async getOrSetWithLockWithMeta<T>(
+    _key: string,
+    fetcher: () => Promise<T>
+  ): Promise<{
+    value: T;
+    cacheHit: boolean;
+    waitedMs: number;
+    timedOut: boolean;
+  }> {
+    const value = await fetcher();
+    return { value, cacheHit: false, waitedMs: 0, timedOut: false };
+  }
   invalidatePattern(_pattern: string): Promise<void> {
     return Promise.resolve();
   }

--- a/__tests__/lib/personalization/category-filter-service.test.ts
+++ b/__tests__/lib/personalization/category-filter-service.test.ts
@@ -45,13 +45,26 @@ jest.mock('@/lib/personalization/filters/candidate-extractor', () => {
     getCategoryCentroids: async (
       db: any,
       categoryIds: string[]
-    ): Promise<any[]> => {
-      return db.$queryRaw`
+    ): Promise<{
+      centroids: any[];
+      cacheHit: boolean;
+      fetchMs: number;
+      lockWaitMs: number;
+      lockTimedOut: boolean;
+    }> => {
+      const centroids = await db.$queryRaw`
         SELECT id, slug, "centroidEmbedding"::text as centroid_embedding
         FROM "InterestCategory"
         WHERE id = ANY(${categoryIds}::text[])
           AND "centroidEmbedding" IS NOT NULL
       `;
+      return {
+        centroids,
+        cacheHit: false,
+        fetchMs: 0,
+        lockWaitMs: 0,
+        lockTimedOut: false,
+      };
     },
     getEmbeddingCandidates: (...args: any[]) => {
       // If mockGetEmbeddingCandidates has an implementation, use it (for pLimit tests).

--- a/app/api/articles/handlers/get.ts
+++ b/app/api/articles/handlers/get.ts
@@ -346,10 +346,21 @@ async function executePersonalizedQuery(
     let cached: CachedPersonalizationResult | null = null;
     try {
       cached = await measureAsync('personalization.cache_get', async (span) => {
-        const result =
-          await personalizationCache.get<CachedPersonalizationResult>(cacheKey);
-        span.setAttribute('cacheHit', result !== null);
-        return result;
+        try {
+          const result =
+            await personalizationCache.get<CachedPersonalizationResult>(
+              cacheKey
+            );
+          span.setAttribute('cacheHit', result !== null);
+          return result;
+        } catch (err) {
+          span.setAttribute('cacheError', true);
+          span.setAttribute(
+            'cacheErrorMessage',
+            err instanceof Error ? err.message : String(err)
+          );
+          throw err;
+        }
       });
     } catch (cacheError) {
       logger.warn(

--- a/app/api/articles/handlers/get.ts
+++ b/app/api/articles/handlers/get.ts
@@ -26,6 +26,7 @@ import type {
   PersonalizedSortBy,
 } from '@/lib/personalization/types';
 import logger from '@/lib/logger';
+import { measureAsync } from '@/lib/personalization/tracing';
 
 import {
   buildSelectFields,
@@ -344,8 +345,12 @@ async function executePersonalizedQuery(
     // Try cache first; skip caching if result is a fallback (appliedCategories empty)
     let cached: CachedPersonalizationResult | null = null;
     try {
-      cached =
-        await personalizationCache.get<CachedPersonalizationResult>(cacheKey);
+      cached = await measureAsync('personalization.cache_get', async (span) => {
+        const result =
+          await personalizationCache.get<CachedPersonalizationResult>(cacheKey);
+        span.setAttribute('cacheHit', result !== null);
+        return result;
+      });
     } catch (cacheError) {
       logger.warn(
         { err: cacheError },
@@ -391,13 +396,16 @@ async function executePersonalizedQuery(
     const personalizedArticles = await withDbTiming(
       metrics,
       () =>
-        prisma.article.findMany({
-          where: {
-            id: { in: personalizedIds },
-            isHidden: false,
-            summaryComputedAt: { not: null },
-          },
-          select: selectFields,
+        measureAsync('article.fetch_by_ids', async (span) => {
+          span.setAttribute('idCount', personalizedIds.length);
+          return prisma.article.findMany({
+            where: {
+              id: { in: personalizedIds },
+              isHidden: false,
+              summaryComputedAt: { not: null },
+            },
+            select: selectFields,
+          });
         }),
       'db_query'
     );

--- a/app/api/articles/handlers/get.ts
+++ b/app/api/articles/handlers/get.ts
@@ -354,11 +354,11 @@ async function executePersonalizedQuery(
           span.setAttribute('cacheHit', result !== null);
           return result;
         } catch (err) {
+          // Defensive: RedisCache.get() currently swallows Redis errors and returns null,
+          // so this branch is rarely hit. Kept to distinguish future error paths from
+          // genuine cache misses. Message is omitted to avoid leaking secrets/keys
+          // into the trace backend; recordException captures the full error event.
           span.setAttribute('cacheError', true);
-          span.setAttribute(
-            'cacheErrorMessage',
-            err instanceof Error ? err.message : String(err)
-          );
           throw err;
         }
       });

--- a/lib/cache/redis-cache.ts
+++ b/lib/cache/redis-cache.ts
@@ -274,22 +274,34 @@ export class RedisCache {
   }
 
   /**
-   * Helper method to handle cache with fallback and lock (stampede protection)
-   * Uses SETNX-based locking to prevent multiple concurrent fetches for the same key
+   * Helper method to handle cache with fallback and lock (stampede protection),
+   * returning observability metadata alongside the cached/fetched value.
+   *
+   * Returned metadata:
+   *   - value: The cached or freshly fetched value
+   *   - cacheHit: true if the value was served from cache on the first lookup
+   *   - waitedMs: Milliseconds spent waiting in the lock-poll loop (0 if lock was acquired immediately or cache hit)
+   *   - timedOut: true if the lock-wait loop reached maxWaitTime and fell back to a direct fetch
    */
-  async getOrSetWithLock<T>(
+  async getOrSetWithLockWithMeta<T>(
     key: string,
     fetcher: () => Promise<T>,
-    ttl?: number
-  ): Promise<T> {
+    options?: { ttl?: number }
+  ): Promise<{
+    value: T;
+    cacheHit: boolean;
+    waitedMs: number;
+    timedOut: boolean;
+  }> {
     const lockTTL = 30; // Lock TTL in seconds
     const maxWaitTime = 5000; // Max wait time in milliseconds
     const pollInterval = 100; // Poll interval in milliseconds
+    const ttl = options?.ttl;
 
     // Try to get from cache first
     const cached = await this.get<T>(key);
     if (cached !== null) {
-      return cached;
+      return { value: cached, cacheHit: true, waitedMs: 0, timedOut: false };
     }
 
     const lockKey = `${key}:lock`;
@@ -314,7 +326,12 @@ export class RedisCache {
           fetcherExecuted = true;
           const fresh = await fetcher();
           await this.set(key, fresh, ttl);
-          return fresh;
+          return {
+            value: fresh,
+            cacheHit: false,
+            waitedMs: 0,
+            timedOut: false,
+          };
         } catch (fetchError) {
           // Fetcher failed while holding lock - log and re-throw without calling fetcher again
           logger.warn(
@@ -339,23 +356,34 @@ export class RedisCache {
           }
         }
       } else {
-        // Lock not acquired - poll for cached value
+        // Lock not acquired - poll for cached value and measure wait time
+        const waitStart = process.hrtime.bigint();
         const startTime = Date.now();
         while (Date.now() - startTime < maxWaitTime) {
           await new Promise((resolve) => setTimeout(resolve, pollInterval));
 
           const newCached = await this.get<T>(key);
           if (newCached !== null) {
-            return newCached;
+            const waitedMs =
+              Number(process.hrtime.bigint() - waitStart) / 1_000_000;
+            return {
+              value: newCached,
+              cacheHit: false,
+              waitedMs,
+              timedOut: false,
+            };
           }
         }
 
         // Timeout - fallback to direct fetch (without caching to avoid race)
+        const waitedMs =
+          Number(process.hrtime.bigint() - waitStart) / 1_000_000;
         logger.warn(
           { key: hashSensitiveValue(key), maxWaitTime },
           'Lock wait timeout, falling back to direct fetch'
         );
-        return await fetcher();
+        const value = await fetcher();
+        return { value, cacheHit: false, waitedMs, timedOut: true };
       }
     } catch (error) {
       // If fetcher already executed and threw, re-throw instead of calling fetcher again
@@ -367,7 +395,25 @@ export class RedisCache {
         { err: error, key: hashSensitiveValue(key) },
         'getOrSetWithLock error, falling back to direct fetch'
       );
-      return await fetcher();
+      const value = await fetcher();
+      return { value, cacheHit: false, waitedMs: 0, timedOut: false };
     }
+  }
+
+  /**
+   * Helper method to handle cache with fallback and lock (stampede protection)
+   * Uses SETNX-based locking to prevent multiple concurrent fetches for the same key.
+   *
+   * For observability metadata (cacheHit / waitedMs / timedOut), use getOrSetWithLockWithMeta instead.
+   */
+  async getOrSetWithLock<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    ttl?: number
+  ): Promise<T> {
+    const { value } = await this.getOrSetWithLockWithMeta<T>(key, fetcher, {
+      ttl,
+    });
+    return value;
   }
 }

--- a/lib/cache/redis-cache.ts
+++ b/lib/cache/redis-cache.ts
@@ -382,8 +382,13 @@ export class RedisCache {
           { key: hashSensitiveValue(key), maxWaitTime },
           'Lock wait timeout, falling back to direct fetch'
         );
-        const value = await fetcher();
-        return { value, cacheHit: false, waitedMs, timedOut: true };
+        try {
+          fetcherExecuted = true;
+          const value = await fetcher();
+          return { value, cacheHit: false, waitedMs, timedOut: true };
+        } catch (fetchError) {
+          throw fetchError;
+        }
       }
     } catch (error) {
       // If fetcher already executed and threw, re-throw instead of calling fetcher again
@@ -395,8 +400,13 @@ export class RedisCache {
         { err: error, key: hashSensitiveValue(key) },
         'getOrSetWithLock error, falling back to direct fetch'
       );
-      const value = await fetcher();
-      return { value, cacheHit: false, waitedMs: 0, timedOut: false };
+      try {
+        fetcherExecuted = true;
+        const value = await fetcher();
+        return { value, cacheHit: false, waitedMs: 0, timedOut: false };
+      } catch (fetchError) {
+        throw fetchError;
+      }
     }
   }
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,5 +1,6 @@
 import pino from 'pino';
 import crypto from 'crypto';
+import { trace } from '@opentelemetry/api';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const isTest = process.env.NODE_ENV === 'test' || !!process.env.JEST_WORKER_ID;
@@ -151,6 +152,14 @@ const logger = pino({
     level: (label) => {
       return { level: label.toUpperCase() };
     },
+  },
+
+  // Automatically inject traceId/spanId from active OTEL span into every log record.
+  // When a log is emitted outside an active span (e.g. batch scripts), the mixin
+  // returns {} and no traceId/spanId fields are added — this is the expected behaviour.
+  mixin: () => {
+    const ctx = trace.getActiveSpan()?.spanContext();
+    return ctx?.traceId ? { traceId: ctx.traceId, spanId: ctx.spanId } : {};
   },
 
   serializers: {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,6 +1,6 @@
 import pino from 'pino';
 import crypto from 'crypto';
-import { trace } from '@opentelemetry/api';
+import { trace, isSpanContextValid } from '@opentelemetry/api';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const isTest = process.env.NODE_ENV === 'test' || !!process.env.JEST_WORKER_ID;
@@ -155,11 +155,15 @@ const logger = pino({
   },
 
   // Automatically inject traceId/spanId from active OTEL span into every log record.
-  // When a log is emitted outside an active span (e.g. batch scripts), the mixin
-  // returns {} and no traceId/spanId fields are added — this is the expected behaviour.
+  // Uses isSpanContextValid() to avoid emitting the all-zero NoopSpan context
+  // (32 '0' traceId) when OTEL SDK is not initialized (batch scripts, tests).
+  // NOTE: pino's default mixinMergeStrategy is Object.assign(mergedObject, mixin),
+  // so if a log call explicitly passes `traceId`/`spanId`, the mixin value wins.
   mixin: () => {
     const ctx = trace.getActiveSpan()?.spanContext();
-    return ctx?.traceId ? { traceId: ctx.traceId, spanId: ctx.spanId } : {};
+    return ctx && isSpanContextValid(ctx)
+      ? { traceId: ctx.traceId, spanId: ctx.spanId }
+      : {};
   },
 
   serializers: {

--- a/lib/personalization/category-filter-service.ts
+++ b/lib/personalization/category-filter-service.ts
@@ -9,6 +9,7 @@ import { PrismaClient } from '@/lib/prisma-exports';
 import { prisma } from '@/lib/prisma';
 import pLimit from 'p-limit';
 import { logger } from '@/lib/logger';
+import { measureAsync, hrtimeDiffMs } from './tracing';
 import type {
   PersonalizedFilterOptions,
   ScoredArticle,
@@ -80,12 +81,183 @@ export class CategoryFilterService {
       'Starting personalized article filtering'
     );
 
-    try {
-      // Step 0: Get category centroids
-      const centroids = await getCategoryCentroids(this.db, categoryIds);
+    return measureAsync('personalization.filterArticles', async (span) => {
+      span.setAttributes({
+        categoryCount: categoryIds.length,
+        periodMonths,
+        limit,
+        offset,
+      });
 
-      if (centroids.length === 0) {
-        logger.warn({ categoryIds }, 'No centroids found for categories');
+      try {
+        // Step 0: Get category centroids
+        const {
+          centroids,
+          cacheHit: centroidsCacheHit,
+          fetchMs: centroidsFetchMs,
+          lockWaitMs: centroidsLockWaitMs,
+        } = await getCategoryCentroids(this.db, categoryIds);
+
+        span.setAttributes({
+          centroidsCacheHit,
+          centroidsFetchMs,
+          centroidsLockWaitMs,
+        });
+
+        if (centroids.length === 0) {
+          logger.warn({ categoryIds }, 'No centroids found for categories');
+          span.setAttributes({
+            fallback: true,
+            fallbackReason: 'no_centroids',
+          });
+          return this.getFallbackResults(
+            periodMonths,
+            limit,
+            offset,
+            startTime,
+            options.excludeSourceIds
+          );
+        }
+
+        const mode = centroids.length === 1 ? 'single' : 'multi-or';
+        span.setAttribute('mode', mode);
+
+        // Branch: single category vs multiple categories
+        let qualifiedArticles: ScoredArticleWithMeta[];
+        let candidateCount: number;
+        let additionalLogInfo: Record<string, unknown> = {};
+        let multiTimings: {
+          perCategoryMs: number[];
+          perCategoryResultCounts: number[];
+          multiSettleWaitMs: number;
+          multiMergeMs: number;
+        } | null = null;
+
+        if (centroids.length === 1) {
+          const result = await this.filterArticlesSingleCategory(
+            options,
+            centroids[0]
+          );
+          if (result.candidates.length === 0) {
+            logger.warn('No embedding candidates found');
+            span.setAttributes({
+              fallback: true,
+              fallbackReason: 'no_candidates_single',
+            });
+            return this.getFallbackResults(
+              periodMonths,
+              limit,
+              offset,
+              startTime,
+              options.excludeSourceIds
+            );
+          }
+          qualifiedArticles = result.articles;
+          candidateCount = result.candidates.length;
+        } else {
+          const result = await this.filterArticlesMultiCategory(
+            options,
+            centroids
+          );
+          if (result.mergedCount === 0) {
+            span.setAttributes({
+              fallback: true,
+              fallbackReason: 'no_candidates_multi',
+            });
+            return this.getFallbackResults(
+              periodMonths,
+              limit,
+              offset,
+              startTime,
+              options.excludeSourceIds
+            );
+          }
+          qualifiedArticles = result.articles;
+          candidateCount = result.mergedCount;
+          multiTimings = {
+            perCategoryMs: result.perCategoryMs,
+            perCategoryResultCounts: result.perCategoryResultCounts,
+            multiSettleWaitMs: result.multiSettleWaitMs,
+            multiMergeMs: result.multiMergeMs,
+          };
+          additionalLogInfo = {
+            candidatesPerCategory: result.perCategoryResultCounts,
+          };
+          span.setAttributes({
+            multiSettleWaitMs: result.multiSettleWaitMs,
+            multiMergeMs: result.multiMergeMs,
+          });
+        }
+
+        // Apply requested sort + pagination (measure score aggregation time)
+        const scoreAggStart = process.hrtime.bigint();
+        const sortedArticles = sortArticles(
+          qualifiedArticles,
+          sortBy,
+          sortOrder
+        );
+        const filtered = sortedArticles.slice(offset, offset + limit);
+        const scoreAggregationMs = hrtimeDiffMs(scoreAggStart);
+
+        span.setAttribute('scoreAggregationMs', scoreAggregationMs);
+
+        const totalMatched = qualifiedArticles.length;
+        const queryMs = Date.now() - startTime; // Preserved for backward compatibility
+
+        logger.info(
+          {
+            timing: {
+              centroids: centroidsFetchMs + centroidsLockWaitMs,
+              scoreAggregation: scoreAggregationMs,
+              ...(multiTimings
+                ? {
+                    multiSettleWait: multiTimings.multiSettleWaitMs,
+                    multiMerge: multiTimings.multiMergeMs,
+                    perCategoryMs: multiTimings.perCategoryMs,
+                    perCategoryResultCounts:
+                      multiTimings.perCategoryResultCounts,
+                  }
+                : {}),
+            },
+            categoryCount: categoryIds.length,
+            candidateCount,
+            queryMs,
+            mode,
+            ...additionalLogInfo,
+          },
+          'personalization.filter.timing'
+        );
+
+        logger.info(
+          {
+            categoryIds,
+            candidateCount,
+            filteredCount: filtered.length,
+            totalMatched,
+            queryMs,
+            mode,
+            ...additionalLogInfo,
+          },
+          'Personalized filtering completed'
+        );
+
+        return {
+          articles: filtered,
+          meta: {
+            filterMode: 'category',
+            appliedCategories: categoryIds,
+            periodMonths,
+            totalMatched,
+            queryMs,
+          },
+        };
+      } catch (error) {
+        const errName = error instanceof Error ? error.name : 'UnknownError';
+        span.setAttributes({
+          fallback: true,
+          fallbackReason: `error_${errName}`,
+        });
+        logger.error({ err: error, categoryIds }, 'Failed to filter articles');
         return this.getFallbackResults(
           periodMonths,
           limit,
@@ -94,95 +266,7 @@ export class CategoryFilterService {
           options.excludeSourceIds
         );
       }
-
-      // Branch: single category vs multiple categories
-      let qualifiedArticles: ScoredArticleWithMeta[];
-      let candidateCount: number;
-      let additionalLogInfo: Record<string, unknown> = {};
-
-      if (centroids.length === 1) {
-        const result = await this.filterArticlesSingleCategory(
-          options,
-          centroids[0]
-        );
-        if (result.candidates.length === 0) {
-          logger.warn('No embedding candidates found');
-          return this.getFallbackResults(
-            periodMonths,
-            limit,
-            offset,
-            startTime,
-            options.excludeSourceIds
-          );
-        }
-        qualifiedArticles = result.articles;
-        candidateCount = result.candidates.length;
-      } else {
-        const result = await this.filterArticlesMultiCategory(
-          options,
-          centroids
-        );
-        if (result.mergedCount === 0) {
-          return this.getFallbackResults(
-            periodMonths,
-            limit,
-            offset,
-            startTime,
-            options.excludeSourceIds
-          );
-        }
-        qualifiedArticles = result.articles;
-        candidateCount = result.mergedCount;
-        additionalLogInfo = {
-          candidatesPerCategory: result.candidatesPerCategory,
-        };
-      }
-
-      // Apply requested sort
-      const sortedArticles = sortArticles(qualifiedArticles, sortBy, sortOrder);
-
-      // Apply pagination
-      const filtered = sortedArticles.slice(offset, offset + limit);
-
-      const totalMatched = qualifiedArticles.length;
-      const queryMs = Date.now() - startTime;
-
-      logger.info(
-        {
-          categoryIds,
-          candidateCount,
-          filteredCount: filtered.length,
-          totalMatched,
-          queryMs,
-          mode: centroids.length === 1 ? 'single' : 'multi-or',
-          ...additionalLogInfo,
-        },
-        'Personalized filtering completed'
-      );
-
-      return {
-        articles: filtered,
-        meta: {
-          filterMode: 'category',
-          appliedCategories: categoryIds,
-          periodMonths,
-          totalMatched,
-          queryMs,
-        },
-      };
-    } catch (error) {
-      logger.error(
-        { err: error, categoryIds },
-        'Failed to filter articles'
-      );
-      return this.getFallbackResults(
-        periodMonths,
-        limit,
-        offset,
-        startTime,
-        options.excludeSourceIds
-      );
-    }
+    });
   }
 
   /**
@@ -267,7 +351,12 @@ export class CategoryFilterService {
   ): Promise<{
     articles: ScoredArticleWithMeta[];
     mergedCount: number;
+    /** @deprecated use perCategoryResultCounts */
     candidatesPerCategory: number[];
+    perCategoryResultCounts: number[];
+    perCategoryMs: number[];
+    multiSettleWaitMs: number;
+    multiMergeMs: number;
   }> {
     const { categoryIds, periodMonths, limit, offset = 0 } = options;
 
@@ -291,30 +380,40 @@ export class CategoryFilterService {
         ? pLimit(maxConcurrency)
         : null;
 
-    const searchPromises = centroids.map((c) => {
-      const search = () =>
-        getEmbeddingCandidates(
+    // Wrap each per-category search with hrtime measurement
+    const perCategoryStartTimes = centroids.map(() => process.hrtime.bigint());
+    const searchPromises = centroids.map((c, i) => {
+      const search = async () => {
+        const result = await getEmbeddingCandidates(
           this.db,
           c.centroid_embedding!,
           periodMonths,
           kPerCategory,
           options.excludeSourceIds
         );
+        return { result, elapsedMs: hrtimeDiffMs(perCategoryStartTimes[i]) };
+      };
       return concurrencyLimit ? concurrencyLimit(search) : search();
     });
+
+    const settleStart = process.hrtime.bigint();
     const settledResults = await Promise.allSettled(searchPromises);
+    const multiSettleWaitMs = hrtimeDiffMs(settleStart);
 
     const categoryResults: EmbeddingCandidate[][] = [];
+    const perCategoryMs: number[] = [];
     const failedCategories: number[] = [];
 
-    settledResults.forEach((result, index) => {
-      if (result.status === 'fulfilled') {
-        categoryResults.push(result.value);
+    settledResults.forEach((settled, index) => {
+      if (settled.status === 'fulfilled') {
+        categoryResults.push(settled.value.result);
+        perCategoryMs.push(settled.value.elapsedMs);
       } else {
         failedCategories.push(index);
         categoryResults.push([]);
+        perCategoryMs.push(0);
         logger.warn(
-          { categoryIndex: index, err: result.reason },
+          { categoryIndex: index, err: settled.reason },
           'Category search failed, continuing with other categories'
         );
       }
@@ -331,6 +430,7 @@ export class CategoryFilterService {
     }
 
     // Merge results: keep max similarity per article
+    const mergeStart = process.hrtime.bigint();
     const mergedMap = new Map<string, EmbeddingCandidate>();
     for (const results of categoryResults) {
       for (const candidate of results) {
@@ -343,13 +443,22 @@ export class CategoryFilterService {
         }
       }
     }
+    const multiMergeMs = hrtimeDiffMs(mergeStart);
 
     const merged = Array.from(mergedMap.values());
-    const candidatesPerCategory = categoryResults.map((r) => r.length);
+    const perCategoryResultCounts = categoryResults.map((r) => r.length);
 
     if (merged.length === 0) {
       logger.warn('No candidates found in OR search');
-      return { articles: [], mergedCount: 0, candidatesPerCategory };
+      return {
+        articles: [],
+        mergedCount: 0,
+        candidatesPerCategory: perCategoryResultCounts,
+        perCategoryResultCounts,
+        perCategoryMs,
+        multiSettleWaitMs,
+        multiMergeMs,
+      };
     }
 
     const candidatesWithTags = await checkTagMatches(
@@ -366,7 +475,11 @@ export class CategoryFilterService {
     return {
       articles: qualifiedArticles,
       mergedCount: merged.length,
-      candidatesPerCategory,
+      candidatesPerCategory: perCategoryResultCounts,
+      perCategoryResultCounts,
+      perCategoryMs,
+      multiSettleWaitMs,
+      multiMergeMs,
     };
   }
 

--- a/lib/personalization/category-filter-service.ts
+++ b/lib/personalization/category-filter-service.ts
@@ -96,12 +96,14 @@ export class CategoryFilterService {
           cacheHit: centroidsCacheHit,
           fetchMs: centroidsFetchMs,
           lockWaitMs: centroidsLockWaitMs,
+          lockTimedOut: centroidsLockTimedOut,
         } = await getCategoryCentroids(this.db, categoryIds);
 
         span.setAttributes({
           centroidsCacheHit,
           centroidsFetchMs,
           centroidsLockWaitMs,
+          centroidsLockTimedOut,
         });
 
         if (centroids.length === 0) {
@@ -207,7 +209,9 @@ export class CategoryFilterService {
         logger.info(
           {
             timing: {
-              centroids: centroidsFetchMs + centroidsLockWaitMs,
+              // centroidsFetchMs already includes lockWaitMs (wall-clock); don't double count.
+              centroids: centroidsFetchMs,
+              centroidsLockWait: centroidsLockWaitMs,
               scoreAggregation: scoreAggregationMs,
               ...(multiTimings
                 ? {
@@ -380,10 +384,12 @@ export class CategoryFilterService {
         ? pLimit(maxConcurrency)
         : null;
 
-    // Wrap each per-category search with hrtime measurement
-    const perCategoryStartTimes = centroids.map(() => process.hrtime.bigint());
-    const searchPromises = centroids.map((c, i) => {
+    // Wrap each per-category search with hrtime measurement.
+    // Capture start time INSIDE the closure so pLimit queue-wait time is
+    // excluded from the measured per-category elapsed ms.
+    const searchPromises = centroids.map((c) => {
       const search = async () => {
+        const start = process.hrtime.bigint();
         const result = await getEmbeddingCandidates(
           this.db,
           c.centroid_embedding!,
@@ -391,7 +397,7 @@ export class CategoryFilterService {
           kPerCategory,
           options.excludeSourceIds
         );
-        return { result, elapsedMs: hrtimeDiffMs(perCategoryStartTimes[i]) };
+        return { result, elapsedMs: hrtimeDiffMs(start) };
       };
       return concurrencyLimit ? concurrencyLimit(search) : search();
     });

--- a/lib/personalization/filters/candidate-extractor.ts
+++ b/lib/personalization/filters/candidate-extractor.ts
@@ -82,6 +82,7 @@ export type CategoryCentroidRow = {
  *   - cacheHit: true if served from Redis cache on the first lookup
  *   - fetchMs: Wall-clock ms from call start to resolution (includes lock wait)
  *   - lockWaitMs: Ms spent waiting in the Redis lock poll loop (0 if cache hit or lock acquired)
+ *   - lockTimedOut: true if the Redis lock wait reached maxWaitTime and fell back to direct fetch
  */
 export async function getCategoryCentroids(
   db: PrismaClient,
@@ -91,10 +92,11 @@ export async function getCategoryCentroids(
   cacheHit: boolean;
   fetchMs: number;
   lockWaitMs: number;
+  lockTimedOut: boolean;
 }> {
   const cacheKey = `centroids:${categoryIds.slice().sort().join(',')}`;
 
-  return measureAsync('personalization.centroids', async () => {
+  return measureAsync('personalization.centroids', async (span) => {
     const fetchStart = process.hrtime.bigint();
     const meta = await centroidCache.getOrSetWithLockWithMeta<
       CategoryCentroidRow[]
@@ -113,11 +115,19 @@ export async function getCategoryCentroids(
     );
     const fetchMs = hrtimeDiffMs(fetchStart);
 
+    span.setAttributes({
+      cacheHit: meta.cacheHit,
+      fetchMs,
+      lockWaitMs: meta.waitedMs,
+      lockTimedOut: meta.timedOut,
+    });
+
     return {
       centroids: meta.value,
       cacheHit: meta.cacheHit,
       fetchMs,
       lockWaitMs: meta.waitedMs,
+      lockTimedOut: meta.timedOut,
     };
   });
 }

--- a/lib/personalization/filters/candidate-extractor.ts
+++ b/lib/personalization/filters/candidate-extractor.ts
@@ -8,6 +8,7 @@ import { PrismaClient, Prisma } from '@/lib/prisma-exports';
 import { DEFAULT_SCORE_PARAMETERS } from '../types';
 import { RedisCache } from '@/lib/cache/redis-cache';
 import { logger } from '@/lib/logger';
+import { measureAsync, hrtimeDiffMs } from '../tracing';
 
 /** Module-level singleton for centroid cache (TTL: 1 hour) */
 const centroidCache = new RedisCache({
@@ -75,26 +76,50 @@ export type CategoryCentroidRow = {
 
 /**
  * Get category centroids from database, with Redis cache (TTL: 1 hour).
+ *
+ * Returns metadata for observability in addition to the centroid rows:
+ *   - centroids: The centroid rows
+ *   - cacheHit: true if served from Redis cache on the first lookup
+ *   - fetchMs: Wall-clock ms from call start to resolution (includes lock wait)
+ *   - lockWaitMs: Ms spent waiting in the Redis lock poll loop (0 if cache hit or lock acquired)
  */
 export async function getCategoryCentroids(
   db: PrismaClient,
   categoryIds: string[]
-): Promise<CategoryCentroidRow[]> {
+): Promise<{
+  centroids: CategoryCentroidRow[];
+  cacheHit: boolean;
+  fetchMs: number;
+  lockWaitMs: number;
+}> {
   const cacheKey = `centroids:${categoryIds.slice().sort().join(',')}`;
 
-  return centroidCache.getOrSetWithLock<CategoryCentroidRow[]>(
-    cacheKey,
-    () =>
-      db.$queryRaw<CategoryCentroidRow[]>`
-        SELECT
-          id,
-          slug,
-          "centroidEmbedding"::text as centroid_embedding
-        FROM "InterestCategory"
-        WHERE id = ANY(${categoryIds}::text[])
-          AND "centroidEmbedding" IS NOT NULL
-      `
-  );
+  return measureAsync('personalization.centroids', async () => {
+    const fetchStart = process.hrtime.bigint();
+    const meta = await centroidCache.getOrSetWithLockWithMeta<
+      CategoryCentroidRow[]
+    >(
+      cacheKey,
+      () =>
+        db.$queryRaw<CategoryCentroidRow[]>`
+          SELECT
+            id,
+            slug,
+            "centroidEmbedding"::text as centroid_embedding
+          FROM "InterestCategory"
+          WHERE id = ANY(${categoryIds}::text[])
+            AND "centroidEmbedding" IS NOT NULL
+        `
+    );
+    const fetchMs = hrtimeDiffMs(fetchStart);
+
+    return {
+      centroids: meta.value,
+      cacheHit: meta.cacheHit,
+      fetchMs,
+      lockWaitMs: meta.waitedMs,
+    };
+  });
 }
 
 /**
@@ -130,13 +155,23 @@ export async function getEmbeddingCandidates(
   // Stage 1: Pure kNN query on partial HNSW index (no JOINs, no extra filters)
   // The partial index on embeddingKey = 'summary' enables HNSW usage here.
   type Stage1Row = { articleId: string; sim_emb: number };
-  const stage1Results = await db.$queryRaw<Stage1Row[]>`
-    SELECT "articleId", 1 - (embedding <=> ${centroid}::vector) AS sim_emb
-    FROM "ArticleEmbedding"
-    WHERE "embeddingKey" = 'summary'::"EmbeddingKey"
-    ORDER BY embedding <=> ${centroid}::vector
-    LIMIT ${effectiveLimit}
-  `;
+  const stage1Results = await measureAsync(
+    'personalization.stage1_knn',
+    async (span) => {
+      const rows = await db.$queryRaw<Stage1Row[]>`
+        SELECT "articleId", 1 - (embedding <=> ${centroid}::vector) AS sim_emb
+        FROM "ArticleEmbedding"
+        WHERE "embeddingKey" = 'summary'::"EmbeddingKey"
+        ORDER BY embedding <=> ${centroid}::vector
+        LIMIT ${effectiveLimit}
+      `;
+      span.setAttributes({
+        effectiveLimit,
+        stage1ResultCount: rows.length,
+      });
+      return rows;
+    }
+  );
 
   if (stage1Results.length === 0) {
     return [];
@@ -150,43 +185,51 @@ export async function getEmbeddingCandidates(
     ','
   );
 
-  const result = await db.$queryRaw<RawEmbeddingCandidate[]>`
-    SELECT
-      a.id,
-      a.title,
-      a.url,
-      a."publishedAt" as published_at,
-      a."createdAt" as created_at,
-      a."qualityScore" as quality_score,
-      a."bookmarks" as bookmarks,
-      a."userVotes" as user_votes,
-      a."sourceId" as source_id,
-      a.summary,
-      a.thumbnail as thumbnail_url,
-      s1.sim_emb
-    FROM (VALUES ${valuesClause}) AS s1("articleId", sim_emb)
-    INNER JOIN "Article" a ON a.id = s1."articleId"
-    WHERE a."summaryComputedAt" IS NOT NULL
-      AND a."isHidden" = false
-      ${periodFilter}
-      ${sourceExcludeFilter}
-      AND s1.sim_emb >= ${DEFAULT_MIN_SIMILARITY}
-  `;
+  const mapped = await measureAsync(
+    'personalization.stage2_fetch',
+    async (span) => {
+      const result = await db.$queryRaw<RawEmbeddingCandidate[]>`
+        SELECT
+          a.id,
+          a.title,
+          a.url,
+          a."publishedAt" as published_at,
+          a."createdAt" as created_at,
+          a."qualityScore" as quality_score,
+          a."bookmarks" as bookmarks,
+          a."userVotes" as user_votes,
+          a."sourceId" as source_id,
+          a.summary,
+          a.thumbnail as thumbnail_url,
+          s1.sim_emb
+        FROM (VALUES ${valuesClause}) AS s1("articleId", sim_emb)
+        INNER JOIN "Article" a ON a.id = s1."articleId"
+        WHERE a."summaryComputedAt" IS NOT NULL
+          AND a."isHidden" = false
+          ${periodFilter}
+          ${sourceExcludeFilter}
+          AND s1.sim_emb >= ${DEFAULT_MIN_SIMILARITY}
+      `;
 
-  const mapped = result.map((row) => ({
-    id: row.id,
-    title: row.title,
-    url: row.url,
-    publishedAt: new Date(row.published_at),
-    createdAt: new Date(row.created_at),
-    qualityScore: row.quality_score ?? 0,
-    bookmarks: row.bookmarks ?? 0,
-    userVotes: row.user_votes ?? 0,
-    sourceId: row.source_id,
-    summary: row.summary,
-    thumbnailUrl: row.thumbnail_url,
-    embeddingSimilarity: row.sim_emb,
-  }));
+      const rows = result.map((row) => ({
+        id: row.id,
+        title: row.title,
+        url: row.url,
+        publishedAt: new Date(row.published_at),
+        createdAt: new Date(row.created_at),
+        qualityScore: row.quality_score ?? 0,
+        bookmarks: row.bookmarks ?? 0,
+        userVotes: row.user_votes ?? 0,
+        sourceId: row.source_id,
+        summary: row.summary,
+        thumbnailUrl: row.thumbnail_url,
+        embeddingSimilarity: row.sim_emb,
+      }));
+
+      span.setAttribute('stage2ResultCount', rows.length);
+      return rows;
+    }
+  );
 
   // Monitor for potential recall issues after topK reduction
   if (mapped.length < 10 && effectiveLimit >= 50) {
@@ -211,20 +254,26 @@ export async function checkTagMatches(
     return [];
   }
 
-  const articleIds = candidates.map((c) => c.id);
+  return measureAsync('personalization.tag_match', async (span) => {
+    span.setAttribute('candidateCount', candidates.length);
 
-  const matchingArticles = await db.$queryRaw<{ article_id: string }[]>`
-    SELECT DISTINCT at."A" as article_id
-    FROM "_ArticleToTag" at
-    INNER JOIN "TagCategoryMapping" tcm ON at."B" = tcm."tagId"
-    WHERE at."A" = ANY(${articleIds}::text[])
-      AND tcm."categoryId" = ANY(${categoryIds}::text[])
-  `;
+    const articleIds = candidates.map((c) => c.id);
 
-  const matchingSet = new Set(matchingArticles.map((r) => r.article_id));
+    const matchingArticles = await db.$queryRaw<{ article_id: string }[]>`
+        SELECT DISTINCT at."A" as article_id
+        FROM "_ArticleToTag" at
+        INNER JOIN "TagCategoryMapping" tcm ON at."B" = tcm."tagId"
+        WHERE at."A" = ANY(${articleIds}::text[])
+          AND tcm."categoryId" = ANY(${categoryIds}::text[])
+      `;
 
-  return candidates.map((c) => ({
-    ...c,
-    hasTagMatch: matchingSet.has(c.id),
-  }));
+    const matchingSet = new Set(matchingArticles.map((r) => r.article_id));
+    const result = candidates.map((c) => ({
+      ...c,
+      hasTagMatch: matchingSet.has(c.id),
+    }));
+
+    span.setAttribute('matchedCount', matchingSet.size);
+    return result;
+  });
 }

--- a/lib/personalization/tracing.ts
+++ b/lib/personalization/tracing.ts
@@ -44,7 +44,7 @@ export async function measureAsync<T>(
     try {
       return await fn(span);
     } catch (err) {
-      span.recordException(err as Error);
+      span.recordException(err instanceof Error ? err : String(err));
       span.setStatus({ code: SpanStatusCode.ERROR });
       throw err;
     } finally {

--- a/lib/personalization/tracing.ts
+++ b/lib/personalization/tracing.ts
@@ -45,7 +45,10 @@ export async function measureAsync<T>(
       return await fn(span);
     } catch (err) {
       span.recordException(err instanceof Error ? err : String(err));
-      span.setStatus({ code: SpanStatusCode.ERROR });
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: err instanceof Error ? err.message : String(err),
+      });
       throw err;
     } finally {
       span.end();

--- a/lib/personalization/tracing.ts
+++ b/lib/personalization/tracing.ts
@@ -15,6 +15,7 @@
 
 import { trace, SpanStatusCode } from '@opentelemetry/api';
 import type { Span, AttributeValue } from '@opentelemetry/api';
+import { sanitizeError } from '@/lib/logger';
 
 export { Span };
 
@@ -45,9 +46,19 @@ export async function measureAsync<T>(
       return await fn(span);
     } catch (err) {
       span.recordException(err instanceof Error ? err : String(err));
+      // Sanitize the message (strips API keys / bearer tokens) before sending
+      // to the trace backend so secrets that leak into an error path don't end
+      // up in Grafana/Tempo.
+      const sanitized = sanitizeError(err);
+      const sanitizedMessage =
+        typeof sanitized === 'object' &&
+        sanitized !== null &&
+        'message' in sanitized
+          ? String((sanitized as { message: unknown }).message)
+          : String(err);
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: err instanceof Error ? err.message : String(err),
+        message: sanitizedMessage,
       });
       throw err;
     } finally {

--- a/lib/personalization/tracing.ts
+++ b/lib/personalization/tracing.ts
@@ -1,0 +1,64 @@
+/**
+ * Personalization Tracing Utilities
+ *
+ * Shared OTEL tracer and helper functions for the personalization pipeline.
+ * All span lifecycle management is handled via measureAsync() to prevent
+ * span.end() leaks.
+ *
+ * TraceQL examples (Grafana Cloud):
+ *   { name="personalization.filterArticles" && duration > 2s }
+ *   { name="personalization.stage2_fetch" } | select(duration)
+ *   { name="personalization.filterArticles" && span.centroidsLockWaitMs > 500 }
+ *   { name="personalization.filterArticles" && span.fallback=true }
+ *   { name="personalization.filterArticles" && !span.fallback }
+ */
+
+import { trace, SpanStatusCode } from '@opentelemetry/api';
+import type { Span, AttributeValue } from '@opentelemetry/api';
+
+export { Span };
+
+/**
+ * Named tracer for the personalization pipeline.
+ * All personalization spans are grouped under the 'personalization' instrumentation scope.
+ */
+export const tracer = trace.getTracer('personalization');
+
+/**
+ * Wrap an async function in an OTEL span.
+ * Handles exception recording, status propagation, and span.end() automatically.
+ *
+ * @param spanName - The span name (e.g. 'personalization.stage1_knn')
+ * @param fn - Async function receiving the span for attribute setting
+ * @param attributes - Optional initial attributes set before fn is called
+ */
+export async function measureAsync<T>(
+  spanName: string,
+  fn: (span: Span) => Promise<T>,
+  attributes?: Record<string, AttributeValue>
+): Promise<T> {
+  return tracer.startActiveSpan(spanName, async (span) => {
+    if (attributes) {
+      span.setAttributes(attributes);
+    }
+    try {
+      return await fn(span);
+    } catch (err) {
+      span.recordException(err as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw err;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+/**
+ * Convert a process.hrtime.bigint() start timestamp to elapsed milliseconds.
+ *
+ * @param start - Value from process.hrtime.bigint() at the start of the measurement
+ * @returns Elapsed time in milliseconds (fractional)
+ */
+export function hrtimeDiffMs(start: bigint): number {
+  return Number(process.hrtime.bigint() - start) / 1_000_000;
+}

--- a/lib/services/digest-service.ts
+++ b/lib/services/digest-service.ts
@@ -157,11 +157,11 @@ export class DigestService {
           span.setAttribute('cacheHit', result !== null);
           return result;
         } catch (err) {
+          // Defensive: RedisCache.get() currently swallows Redis errors and returns null,
+          // so this branch is rarely hit. Kept to distinguish future error paths from
+          // genuine cache misses. Message is omitted to avoid leaking secrets/keys
+          // into the trace backend; recordException captures the full error event.
           span.setAttribute('cacheError', true);
-          span.setAttribute(
-            'cacheErrorMessage',
-            err instanceof Error ? err.message : String(err)
-          );
           throw err;
         }
       });

--- a/lib/services/digest-service.ts
+++ b/lib/services/digest-service.ts
@@ -8,6 +8,7 @@
 import { PrismaClient } from '@/lib/prisma-exports';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logger';
+import { measureAsync, hrtimeDiffMs } from '@/lib/personalization/tracing';
 import { RedisCache } from '@/lib/cache/redis-cache';
 import {
   CategoryFilterService,
@@ -150,7 +151,11 @@ export class DigestService {
     // 1. Check cache
     const cacheKey = `digest:${userId}:${period}`;
     try {
-      const cached = await this.cache.get<DigestResponse>(cacheKey);
+      const cached = await measureAsync('digest.cache_get', async (span) => {
+        const result = await this.cache.get<DigestResponse>(cacheKey);
+        span.setAttribute('cacheHit', result !== null);
+        return result;
+      });
       if (cached) {
         logger.info({ userId, period }, 'Digest cache hit');
         // Restore Date objects from JSON serialization
@@ -204,15 +209,25 @@ export class DigestService {
         where: { userId, scope: 'digest' },
         select: { categoryId: true },
       }),
-      this.filterService.getActiveCategories().catch((error) => {
-        logger.warn(
-          { err: error, userId },
-          'getActiveCategories failed, falling back to empty list'
-        );
-        return [] as Awaited<
-          ReturnType<CategoryFilterService['getActiveCategories']>
-        >;
-      }),
+      (async () => {
+        const t0 = process.hrtime.bigint();
+        try {
+          const result = await this.filterService.getActiveCategories();
+          logger.info(
+            { timing: { activeCategoriesFetchMs: hrtimeDiffMs(t0) } },
+            'getActiveCategories timing'
+          );
+          return result;
+        } catch (error) {
+          logger.warn(
+            { err: error, userId },
+            'getActiveCategories failed, falling back to empty list'
+          );
+          return [] as Awaited<
+            ReturnType<CategoryFilterService['getActiveCategories']>
+          >;
+        }
+      })(),
     ]);
     const categoryIds = preferences.map((p) => p.categoryId);
 
@@ -346,31 +361,36 @@ export class DigestService {
       const cutoff = getPeriodCutoff(period);
 
       // Filter for unread articles within period, with source enabled and content not null
-      const rows = await this.db.$queryRaw<RawArticleRow[]>`
-        SELECT
-          a.id,
-          a.title,
-          a.url,
-          a.summary,
-          a.thumbnail,
-          a."publishedAt",
-          a."qualityScore",
-          a."sourceId"
-        FROM "Article" a
-        JOIN "Source" s ON a."sourceId" = s.id AND s.enabled = true
-        WHERE a.id = ANY(${candidateIds})
-          AND a.content IS NOT NULL
-          AND a."isHidden" = false
-          AND a."publishedAt" >= ${cutoff}
-          AND NOT EXISTS (
-            SELECT 1 FROM "ArticleView" av
-            WHERE av."userId" = ${userId}
-              AND av."articleId" = a.id
-              AND av."isRead" = true
-          )
-        ORDER BY array_position(${candidateIds}, a.id)
-        LIMIT ${limit}
-      `;
+      const rows = await measureAsync('digest.post_filter', async (span) => {
+        span.setAttribute('articleIdCount', candidateIds.length);
+        const result = await this.db.$queryRaw<RawArticleRow[]>`
+          SELECT
+            a.id,
+            a.title,
+            a.url,
+            a.summary,
+            a.thumbnail,
+            a."publishedAt",
+            a."qualityScore",
+            a."sourceId"
+          FROM "Article" a
+          JOIN "Source" s ON a."sourceId" = s.id AND s.enabled = true
+          WHERE a.id = ANY(${candidateIds})
+            AND a.content IS NOT NULL
+            AND a."isHidden" = false
+            AND a."publishedAt" >= ${cutoff}
+            AND NOT EXISTS (
+              SELECT 1 FROM "ArticleView" av
+              WHERE av."userId" = ${userId}
+                AND av."articleId" = a.id
+                AND av."isRead" = true
+            )
+          ORDER BY array_position(${candidateIds}, a.id)
+          LIMIT ${limit}
+        `;
+        span.setAttribute('filteredCount', result.length);
+        return result;
+      });
 
       if (rows.length === 0) {
         return { articles: [], ok: !filterFellBack };

--- a/lib/services/digest-service.ts
+++ b/lib/services/digest-service.ts
@@ -152,9 +152,18 @@ export class DigestService {
     const cacheKey = `digest:${userId}:${period}`;
     try {
       const cached = await measureAsync('digest.cache_get', async (span) => {
-        const result = await this.cache.get<DigestResponse>(cacheKey);
-        span.setAttribute('cacheHit', result !== null);
-        return result;
+        try {
+          const result = await this.cache.get<DigestResponse>(cacheKey);
+          span.setAttribute('cacheHit', result !== null);
+          return result;
+        } catch (err) {
+          span.setAttribute('cacheError', true);
+          span.setAttribute(
+            'cacheErrorMessage',
+            err instanceof Error ? err.message : String(err)
+          );
+          throw err;
+        }
       });
       if (cached) {
         logger.info({ userId, period }, 'Digest cache hit');
@@ -179,15 +188,7 @@ export class DigestService {
     });
 
     if (preferenceCount === 0) {
-      const allCategories = await this.filterService
-        .getActiveCategories()
-        .catch((error) => {
-          logger.warn(
-            { err: error, userId },
-            'getActiveCategories failed, falling back to empty list'
-          );
-          return [];
-        });
+      const allCategories = await this.getActiveCategoriesWithTiming(userId);
       const emptyResponse: DigestResponse = {
         period,
         sections: [
@@ -209,25 +210,7 @@ export class DigestService {
         where: { userId, scope: 'digest' },
         select: { categoryId: true },
       }),
-      (async () => {
-        const t0 = process.hrtime.bigint();
-        try {
-          const result = await this.filterService.getActiveCategories();
-          logger.info(
-            { timing: { activeCategoriesFetchMs: hrtimeDiffMs(t0) } },
-            'getActiveCategories timing'
-          );
-          return result;
-        } catch (error) {
-          logger.warn(
-            { err: error, userId },
-            'getActiveCategories failed, falling back to empty list'
-          );
-          return [] as Awaited<
-            ReturnType<CategoryFilterService['getActiveCategories']>
-          >;
-        }
-      })(),
+      this.getActiveCategoriesWithTiming(userId),
     ]);
     const categoryIds = preferences.map((p) => p.categoryId);
 
@@ -534,6 +517,32 @@ export class DigestService {
     } catch (error) {
       logger.error({ err: error, userId }, 'Failed to get missed articles');
       return { articles: [], ok: false };
+    }
+  }
+
+  /**
+   * Fetch all active categories with timing instrumentation and error fallback.
+   * Consolidated helper used in both the preference-empty path and the Promise.all path.
+   */
+  private async getActiveCategoriesWithTiming(
+    userId: string
+  ): Promise<
+    Awaited<ReturnType<CategoryFilterService['getActiveCategories']>>
+  > {
+    const t0 = process.hrtime.bigint();
+    try {
+      const result = await this.filterService.getActiveCategories();
+      logger.info(
+        { timing: { activeCategoriesFetchMs: hrtimeDiffMs(t0) } },
+        'getActiveCategories timing'
+      );
+      return result;
+    } catch (error) {
+      logger.warn(
+        { err: error, userId },
+        'getActiveCategories failed, falling back to empty list'
+      );
+      return [];
     }
   }
 


### PR DESCRIPTION
## 概要

- パーソナライズ経路 (`CategoryFilterService.filterArticles` + 外側の personalization cache / article hydration / digest post-filter) に段階別 OTEL span と timing ログを追加
- pino logger に OTEL mixin を追加し、Grafana Cloud で Trace ↔ Loki ログを相互ジャンプ可能に
- RedisCache に `getOrSetWithLockWithMeta()` を新設し、centroid 取得の lock_wait 時間を観測可能に

Closes #578

## 背景

本番でダイジェスト/ホームパーソナライズが 3-5 秒かかる問題の真因特定に向けた計測基盤整備。既存の OTEL → Grafana Cloud パイプラインは Route 単位 (`GET /api/articles`) の親 span しか記録されておらず、`filterArticles` 内部 (Stage1 kNN / Stage2 fetch / tag match / score aggregation) や外側 (cache hit/miss / article hydration / digest post-filter) の内訳が可視化できなかった。本 PR は計測追加のみでロジック変更なし、既存 `queryMs` ログも後方互換のため維持する。

親ロードマップ: #576 (Tier 2 P1)。後続の Issue #579 (EXPLAIN ANALYZE ベースライン) と合わせて真因を特定し、最適化 Issue 群 (Tier 6) に繋げる。

## 実装内容

### 新規ファイル

- `lib/personalization/tracing.ts` — OTEL 共通ユーティリティ
  - `tracer = trace.getTracer('personalization')`
  - `measureAsync<T>(spanName, fn, attributes?)` — span ライフサイクル (attributes / recordException / setStatus / end) を隠蔽する async 専用ラッパー
  - `hrtimeDiffMs(start)` — `process.hrtime.bigint()` → ms 変換

### span 追加箇所 (計 9 種)

| span 名 | 追加ファイル |
|---------|-------------|
| `personalization.filterArticles` (親) | `category-filter-service.ts` |
| `personalization.centroids` | `candidate-extractor.ts` |
| `personalization.stage1_knn` | `candidate-extractor.ts` |
| `personalization.stage2_fetch` | `candidate-extractor.ts` |
| `personalization.tag_match` | `candidate-extractor.ts` |
| `personalization.cache_get` | `get.ts` |
| `article.fetch_by_ids` | `get.ts` |
| `digest.cache_get` | `digest-service.ts` |
| `digest.post_filter` | `digest-service.ts` |

### 親 span の timing 属性

- `centroidsCacheHit`, `centroidsFetchMs`, `centroidsLockWaitMs`, `centroidsLockTimedOut`
- `scoreAggregationMs` (sort + slice 含む)
- multi-category 時: `multiSettleWaitMs`, `multiMergeMs`
- fallback 経路: `fallback=true` + `fallbackReason` (`no_centroids` / `no_candidates_single` / `no_candidates_multi` / `error_*`)

### timing ログ (`personalization.filter.timing`) にのみ出力

- `perCategoryMs: number[]`, `perCategoryResultCounts: number[]` (per-category 集約、percentile は Grafana/TraceQL 側で横断集計)
- `digest-service.ts` からは `activeCategoriesFetchMs` も別ログとして出力

### logger mixin (trace-log correlation)

`lib/logger.ts` に pino `mixin` を追加し、active span があれば `traceId` / `spanId` を全ログ記録に自動注入。`isSpanContextValid()` で NoopSpan の all-zero traceId は除外。Grafana Cloud で Trace ↔ Loki ログの相互ジャンプが可能になる。

### RedisCache 観測 API

`lib/cache/redis-cache.ts` に `getOrSetWithLockWithMeta<T>()` を追加。戻り値に `{ value, cacheHit, waitedMs, timedOut }` を含む。既存 `getOrSetWithLock()` は内部委譲の薄いラッパーで後方互換を維持。

## Grafana TraceQL クエリ例

```
# 2秒超のパーソナライズ call を抽出
{ name="personalization.filterArticles" && duration > 2s }

# Stage2 所要時間の分布
{ name="personalization.stage2_fetch" } | select(duration)

# centroid lock_wait 500ms 以上
{ name="personalization.filterArticles" && span.centroidsLockWaitMs > 500 }

# fallback 経路のみ (正常経路と分離)
{ name="personalization.filterArticles" && span.fallback=true }
```

## テスト結果

- `__tests__/lib/personalization/category-filter-service.test.ts`: 41 passed
- `__tests__/lib/cache/redis-cache.test.ts`: 10 passed
- `__tests__/lib/services/digest-service.test.ts`: 20 passed
- 合計 **71 tests passed / 0 failed**
- `tsc --noEmit`: 0 errors
- `npm run lint`: 0 errors, 0 warnings
- `npm audit --production --audit-level=high`: 0 vulnerabilities
- `npm run docker:build`: Success

## Cross-Review 反映 (Full Tier)

Codex + Devil's Advocate + typescript-reviewer の 13 指摘 → 11 反映 / 2 対応不要。主な反映:

- `timing.centroids` 二重計上修正 (`fetchMs` 既に lock wait 含む)
- per-category 計測の pLimit キュー待ち混入除去 (start 取得を closure 内へ移動)
- `err as Error` unsafe cast 除去 (`err instanceof Error ? err : String(err)`)
- pino mixin の NoopSpan all-zero traceId 除外 (`isSpanContextValid()`)
- `lockTimedOut` を `getCategoryCentroids` 戻り値経由で span 属性へパススルー
- テストモックの型不一致修正 (`getCategoryCentroids` 戻り値形状更新)
- `__mocks__/lib/cache/redis-cache.ts` に `getOrSetWithLockWithMeta` スタブ追加

## 破壊的変更

なし。`getCategoryCentroids` の戻り値型は `CategoryCentroidRow[]` → `{ centroids, cacheHit, fetchMs, lockWaitMs, lockTimedOut }` に変更したが、呼び出し元は `category-filter-service.ts` 1 箇所のみで追従済み (export はされているが内部 API 扱い)。

## チェックリスト

- [x] テスト通過 (71 tests)
- [x] ドキュメント更新不要 (計測追加のみ)
- [x] 破壊的変更なし (外部 public API 不変)
- [x] PII 方針準拠 (新規追加した span には `userId` を含めず、親 span には `categoryCount` を付与)

## 残タスク (別 Issue)

- 本番デプロイ後の実 Trace 確認、Grafana Cloud Free tier 使用量観測 (1 週間)
- `/dashboard/performance` への personalization セクション追加
- 真因特定後の最適化 Issue 発行 (Tier 6、#579 と合わせて)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * システム全体の監視可能性を強化し、キャッシュヒット率、処理時間、ロック待機時間などの詳細なテレメトリ追跡を実装しました。
  * パーソナライゼーションパイプラインの各段階に包括的なトレーシングを追加し、パフォーマンス分析を向上させました。
  * キャッシュ操作から取得メトリクスを拡張し、より詳細なシステムヘルスモニタリングを実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->