### PR TITLE
fix(enrichers): hatena_blog_dev の CONTENT_FETCH_FAILED 率低下対策

### DIFF
--- a/lib/config/env.ts
+++ b/lib/config/env.ts
@@ -190,6 +190,7 @@ const envSchema = z
     }, z.number().int().min(1).default(5)),
     POST_SAVE_ENRICH_TIMEOUT_MS: safeCoerceInt(10000),
     POST_SAVE_ENRICH_SLEEP_MS: safeCoerceInt(0),
+    HATENA_BLOG_DEV_ENRICH_SLEEP_MS: safeCoerceInt(2500),
     SKIP_POST_SAVE_ENRICHMENT: z.enum(['0', '1']).optional().default('0'),
 
     // Fetchers

--- a/lib/enrichers/__tests__/hatena.test.ts
+++ b/lib/enrichers/__tests__/hatena.test.ts
@@ -1,0 +1,53 @@
+import { HatenaContentEnricher, HATENA_CUSTOM_DOMAINS } from '../hatena';
+
+describe('HatenaContentEnricher', () => {
+  const enricher = new HatenaContentEnricher();
+
+  describe('canHandle - Hatena native domains', () => {
+    it.each([
+      'https://example.hatenablog.com/entry/123',
+      'https://user.hatenablog.jp/entry',
+      'https://hatenablog.com/foo',
+      'https://b.hatena.ne.jp/entry',
+    ])('should match %s', (url) => {
+      expect(enricher.canHandle(url)).toBe(true);
+    });
+  });
+
+  describe('canHandle - custom domain allowlist', () => {
+    it.each(HATENA_CUSTOM_DOMAINS)(
+      'should match custom domain %s',
+      (domain) => {
+        expect(enricher.canHandle(`https://${domain}/article/1`)).toBe(true);
+      }
+    );
+
+    it('should NOT match subdomains of a custom-allowed domain', () => {
+      // allowlist は厳密一致（完全一致のみ）
+      expect(enricher.canHandle('https://sub.caddi.tech/entry')).toBe(false);
+    });
+
+    it('should NOT match unrelated domain', () => {
+      expect(enricher.canHandle('https://example.com/article')).toBe(false);
+    });
+
+    it('should return false for invalid URL', () => {
+      expect(enricher.canHandle('not-a-url')).toBe(false);
+    });
+  });
+
+  describe('HATENA_CUSTOM_DOMAINS', () => {
+    it('should exclude domains owned by dedicated enrichers', () => {
+      // HatenaContentEnricher より前方に配置されている専用 enricher との重複は禁止
+      const excluded = [
+        'techblog.zozo.com',
+        'techblog.recruit.co.jp',
+        'tech.pepabo.com',
+        'developer.hatenastaff.com',
+      ];
+      for (const d of excluded) {
+        expect(HATENA_CUSTOM_DOMAINS).not.toContain(d);
+      }
+    });
+  });
+});

--- a/lib/enrichers/__tests__/index.test.ts
+++ b/lib/enrichers/__tests__/index.test.ts
@@ -213,6 +213,54 @@ describe('ContentEnricherFactory', () => {
     );
   });
 
+  describe('HatenaContentEnricher custom domain allowlist', () => {
+    it.each([
+      'https://tech.every.tv/article',
+      'https://caddi.tech/entry/123',
+      'https://tech.gunosy.io/entry/2024',
+      'https://mackerel.io/blog/entry',
+      'https://tech.askul.co.jp/article',
+      'https://blogs.networld.co.jp/entry',
+      'https://tech.nri-net.com/post',
+      'https://tech.talentx.co.jp/entry',
+      'https://blog.serverworks.co.jp/article',
+      'https://developer.so-tech.co.jp/entry',
+    ])('should return HatenaContentEnricher for custom domain %s', (url) => {
+      const enricher = factory.getEnricher(url);
+      expect(enricher?.constructor.name).toBe('HatenaContentEnricher');
+    });
+
+    // 専用 enricher 管轄ドメインは Hatena ではなく各専用 enricher が返ることを確認
+    // (HatenaContentEnricher は factory 内で後方に配置されているため、先行する専用 enricher が優先される)
+    it.each([
+      {
+        url: 'https://techblog.zozo.com/entry/test',
+        expected: 'ZOZOContentEnricher',
+      },
+      {
+        url: 'https://tech.pepabo.com/2024/01/test',
+        expected: 'PepaboContentEnricher',
+      },
+      {
+        url: 'https://developer.hatenastaff.com/entry',
+        expected: 'HatenaDeveloperContentEnricher',
+      },
+    ])(
+      'should prefer dedicated enricher over Hatena for $url',
+      ({ url, expected }) => {
+        const enricher = factory.getEnricher(url);
+        expect(enricher?.constructor.name).toBe(expected);
+      }
+    );
+
+    it('should NOT match unknown domain as Hatena', () => {
+      const enricher = factory.getEnricher(
+        'https://example-unknown.com/article'
+      );
+      expect(enricher?.constructor.name).toBe('GenericContentEnricher');
+    });
+  });
+
   describe('AnthropicNewsEnricher boundary', () => {
     it('should NOT match /newsroom path', () => {
       const enricher = factory.getEnricher(

--- a/lib/enrichers/base.ts
+++ b/lib/enrichers/base.ts
@@ -112,20 +112,23 @@ export abstract class BaseContentEnricher implements IContentEnricher {
     externalSignal?: AbortSignal
   ): Promise<string> {
     let lastError: Error | null = null;
+    let previousWas429 = false;
 
     for (let attempt = 0; attempt < this.maxRetries; attempt++) {
       try {
-        if (attempt > 0) {
-          // リトライ時は指数バックオフ（最大2秒）
+        // 直前が 429 の場合は loop 冒頭の exponential backoff を skip
+        // (429 path の sleep のみ適用し、実質 1.5 秒リトライを守るため)
+        if (attempt > 0 && !previousWas429) {
           await this.delay(
             Math.min(this.retryDelay * Math.pow(2, attempt - 1), 2000),
             externalSignal
           );
         }
+        previousWas429 = false;
 
-        // AbortSignal.timeout() は自動クリーンアップされ、any() は listener を内部管理するため
-        // 旧実装の setTimeout + clearTimeout による timer leak バグ (catch パスでclearされない)
-        // を本構造で根本的に解消する
+        // AbortSignal.timeout() は catch 経路で旧実装にあった
+        // setTimeout+clearTimeout の leak を回避する（ただし成功/外部 abort 時の
+        // timeout signal 自体は明示 dispose できない点に留意）
         const signal = this.composeSignal(externalSignal, 15000);
         const response = await fetch(url, {
           headers: {
@@ -140,6 +143,7 @@ export abstract class BaseContentEnricher implements IContentEnricher {
         if (response.status === 429) {
           // Rate limit: 短縮 (1.5秒)。呼び出し側の source 別 sleep で本質的な rate 制御を行う
           await this.delay(1500, externalSignal);
+          previousWas429 = true;
           continue;
         }
 

--- a/lib/enrichers/base.ts
+++ b/lib/enrichers/base.ts
@@ -142,12 +142,23 @@ export abstract class BaseContentEnricher implements IContentEnricher {
 
         if (response.status === 429) {
           // Rate limit: 短縮 (1.5秒)。呼び出し側の source 別 sleep で本質的な rate 制御を行う
+          // 接続プールの socket 保持を避けるため body を drain してから retry
+          try {
+            await response.body?.cancel();
+          } catch {
+            // body drain 失敗は retry 判定に影響させない
+          }
           await this.delay(1500, externalSignal);
           previousWas429 = true;
           continue;
         }
 
         if (!response.ok) {
+          try {
+            await response.body?.cancel();
+          } catch {
+            // body drain 失敗は元の HTTP error を優先
+          }
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
 

--- a/lib/enrichers/base.ts
+++ b/lib/enrichers/base.ts
@@ -22,9 +22,10 @@ export interface IContentEnricher {
   /**
    * URLから記事の本文とサムネイルを取得
    * @param url 記事のURL
+   * @param signal 外部abort signal (optional、呼び出し側でtimeout連携時に使用)
    * @returns エンリッチされたコンテンツ。取得失敗時はnull
    */
-  enrich(url: string): Promise<EnrichedContent | null>;
+  enrich(url: string, signal?: AbortSignal): Promise<EnrichedContent | null>;
 
   /**
    * このエンリッチャーが処理可能なURLかを判定
@@ -43,9 +44,12 @@ export abstract class BaseContentEnricher implements IContentEnricher {
   protected retryDelay = 1000; // 1秒
 
   // 既定実装: セレクタベースで本文抽出
-  async enrich(url: string): Promise<EnrichedContent | null> {
+  async enrich(
+    url: string,
+    signal?: AbortSignal
+  ): Promise<EnrichedContent | null> {
     try {
-      const html = await this.fetchWithRetry(url);
+      const html = await this.fetchWithRetry(url, signal);
       const $ = cheerio.load(html);
 
       // 不要要素を削除
@@ -100,21 +104,29 @@ export abstract class BaseContentEnricher implements IContentEnricher {
 
   /**
    * リトライ機能付きのfetch
+   * @param url 取得するURL
+   * @param externalSignal 外部abort signal (呼び出し側のtimeout等と連動)
    */
-  protected async fetchWithRetry(url: string): Promise<string> {
+  protected async fetchWithRetry(
+    url: string,
+    externalSignal?: AbortSignal
+  ): Promise<string> {
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt < this.maxRetries; attempt++) {
       try {
         if (attempt > 0) {
-          // リトライ時は指数バックオフ
-          await this.delay(this.retryDelay * Math.pow(2, attempt - 1));
+          // リトライ時は指数バックオフ（最大2秒）
+          await this.delay(
+            Math.min(this.retryDelay * Math.pow(2, attempt - 1), 2000),
+            externalSignal
+          );
         }
 
-        // Timeout using AbortController (15 seconds)
-        const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), 15000);
-
+        // AbortSignal.timeout() は自動クリーンアップされ、any() は listener を内部管理するため
+        // 旧実装の setTimeout + clearTimeout による timer leak バグ (catch パスでclearされない)
+        // を本構造で根本的に解消する
+        const signal = this.composeSignal(externalSignal, 15000);
         const response = await fetch(url, {
           headers: {
             'User-Agent':
@@ -122,14 +134,12 @@ export abstract class BaseContentEnricher implements IContentEnricher {
             Accept: 'text/html,application/xhtml+xml',
             'Accept-Language': 'ja,en;q=0.9',
           },
-          signal: controller.signal,
+          signal,
         });
 
-        clearTimeout(timeout);
-
         if (response.status === 429) {
-          // Rate limit エラー時は長めに待機
-          await this.delay(30000);
+          // Rate limit: 短縮 (1.5秒)。呼び出し側の source 別 sleep で本質的な rate 制御を行う
+          await this.delay(1500, externalSignal);
           continue;
         }
 
@@ -140,15 +150,31 @@ export abstract class BaseContentEnricher implements IContentEnricher {
         const html = await response.text();
 
         // レート制限のための待機
-        await this.delay(this.rateLimit);
+        await this.delay(this.rateLimit, externalSignal);
 
         return html;
       } catch (_error) {
         lastError = _error as Error;
+        // 外部signalがabortされている場合は即時終了
+        if (externalSignal?.aborted) {
+          throw lastError;
+        }
       }
     }
 
     throw lastError || new Error('Failed to fetch content');
+  }
+
+  /**
+   * 外部signalとper-fetch timeoutを合成
+   */
+  protected composeSignal(
+    externalSignal: AbortSignal | undefined,
+    timeoutMs: number
+  ): AbortSignal {
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    if (!externalSignal) return timeoutSignal;
+    return AbortSignal.any([externalSignal, timeoutSignal]);
   }
 
   /**
@@ -194,10 +220,24 @@ export abstract class BaseContentEnricher implements IContentEnricher {
   }
 
   /**
-   * 遅延処理
+   * 遅延処理（abort signal 対応）
    */
-  protected delay(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+  protected delay(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(signal.reason ?? new Error('Aborted'));
+        return;
+      }
+      const timer = setTimeout(() => {
+        if (onAbort) signal?.removeEventListener('abort', onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        reject(signal?.reason ?? new Error('Aborted'));
+      };
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
   }
 
   /**

--- a/lib/enrichers/generic.ts
+++ b/lib/enrichers/generic.ts
@@ -28,14 +28,16 @@ export class GenericContentEnricher extends BaseContentEnricher {
     externalSignal?: AbortSignal
   ): Promise<EnrichmentResult | null> {
     const maxRetries = 2;
+    let previousWas429 = false;
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
-        if (attempt > 1) {
-          // retry 間は短縮 (最大2秒)
+        // 直前が 429 の場合は loop 冒頭の backoff を skip (実質 1.5 秒リトライを守る)
+        if (attempt > 1 && !previousWas429) {
           const waitTime = Math.min(1000 * Math.pow(2, attempt - 1), 2000);
           await this.delay(waitTime, externalSignal);
         }
+        previousWas429 = false;
 
         if (externalSignal?.aborted) {
           return null;
@@ -60,6 +62,7 @@ export class GenericContentEnricher extends BaseContentEnricher {
           if (response.status === 429) {
             // 429 時の sleep 短縮 (1.5秒)。呼び出し側の source 別 sleep で本質的な rate 制御
             await this.delay(1500, externalSignal);
+            previousWas429 = true;
             continue;
           }
           if (attempt === maxRetries) {

--- a/lib/enrichers/generic.ts
+++ b/lib/enrichers/generic.ts
@@ -59,6 +59,13 @@ export class GenericContentEnricher extends BaseContentEnricher {
         });
 
         if (!response.ok) {
+          // 接続プールの socket 保持を避けるため body を drain してから retry/return
+          try {
+            await response.body?.cancel();
+          } catch {
+            // body drain 失敗は retry/failure 判定に影響させない
+          }
+
           if (response.status === 429) {
             // 429 時の sleep 短縮 (1.5秒)。呼び出し側の source 別 sleep で本質的な rate 制御
             await this.delay(1500, externalSignal);

--- a/lib/enrichers/generic.ts
+++ b/lib/enrichers/generic.ts
@@ -23,16 +23,25 @@ export class GenericContentEnricher extends BaseContentEnricher {
     return true;
   }
 
-  async enrich(url: string): Promise<EnrichmentResult | null> {
-    const maxRetries = 3;
+  async enrich(
+    url: string,
+    externalSignal?: AbortSignal
+  ): Promise<EnrichmentResult | null> {
+    const maxRetries = 2;
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
       try {
         if (attempt > 1) {
-          const waitTime = Math.min(1000 * Math.pow(2, attempt - 1), 10000);
-          await new Promise((resolve) => setTimeout(resolve, waitTime));
+          // retry 間は短縮 (最大2秒)
+          const waitTime = Math.min(1000 * Math.pow(2, attempt - 1), 2000);
+          await this.delay(waitTime, externalSignal);
         }
 
+        if (externalSignal?.aborted) {
+          return null;
+        }
+
+        const signal = this.composeSignal(externalSignal, 30000);
         const response = await fetch(url, {
           headers: {
             'User-Agent':
@@ -44,12 +53,13 @@ export class GenericContentEnricher extends BaseContentEnricher {
             DNT: '1',
           },
           redirect: 'follow',
-          signal: AbortSignal.timeout(30000),
+          signal,
         });
 
         if (!response.ok) {
           if (response.status === 429) {
-            await new Promise((resolve) => setTimeout(resolve, 10000));
+            // 429 時の sleep 短縮 (1.5秒)。呼び出し側の source 別 sleep で本質的な rate 制御
+            await this.delay(1500, externalSignal);
             continue;
           }
           if (attempt === maxRetries) {

--- a/lib/enrichers/hatena.ts
+++ b/lib/enrichers/hatena.ts
@@ -7,6 +7,30 @@ import { BaseContentEnricher, EnrichedContent } from './base';
 import * as cheerio from 'cheerio';
 import { isUrlFromDomain } from '@/lib/utils/url/url-validator';
 
+/**
+ * Hatena Blog 独自ドメイン allowlist
+ * hatena.blog/dev/entries 経由で収集される企業技術ブログで、
+ * 専用 enricher が存在しない（= generic に流れる）ドメインを Hatena 扱いにする。
+ *
+ * 除外済み（専用 enricher 管轄）:
+ *   - techblog.zozo.com (ZOZOContentEnricher)
+ *   - techblog.recruit.co.jp (RecruitContentEnricher)
+ *   - tech.pepabo.com (PepaboContentEnricher)
+ *   - developer.hatenastaff.com (HatenaDeveloperContentEnricher)
+ */
+export const HATENA_CUSTOM_DOMAINS: readonly string[] = [
+  'tech.every.tv',
+  'caddi.tech',
+  'tech.gunosy.io',
+  'mackerel.io',
+  'tech.askul.co.jp',
+  'blogs.networld.co.jp',
+  'tech.nri-net.com',
+  'tech.talentx.co.jp',
+  'blog.serverworks.co.jp',
+  'developer.so-tech.co.jp',
+];
+
 export class HatenaContentEnricher extends BaseContentEnricher {
   /**
    * はてなブックマーク記事のURLかチェック
@@ -16,9 +40,18 @@ export class HatenaContentEnricher extends BaseContentEnricher {
     try {
       const hostname = new URL(url).hostname;
       // Hatenaドメインのみを対象（完全一致またはサブドメイン）
-      return hostname === 'hatena.ne.jp' || hostname.endsWith('.hatena.ne.jp') ||
-             hostname === 'hatenablog.com' || hostname.endsWith('.hatenablog.com') ||
-             hostname === 'hatenablog.jp' || hostname.endsWith('.hatenablog.jp');
+      if (
+        hostname === 'hatena.ne.jp' ||
+        hostname.endsWith('.hatena.ne.jp') ||
+        hostname === 'hatenablog.com' ||
+        hostname.endsWith('.hatenablog.com') ||
+        hostname === 'hatenablog.jp' ||
+        hostname.endsWith('.hatenablog.jp')
+      ) {
+        return true;
+      }
+      // Hatena 独自ドメインの allowlist
+      return HATENA_CUSTOM_DOMAINS.includes(hostname);
     } catch {
       // URL解析失敗時は対象外
       return false;
@@ -28,19 +61,21 @@ export class HatenaContentEnricher extends BaseContentEnricher {
   /**
    * 記事ページから本文とサムネイルを取得
    */
-  async enrich(url: string): Promise<EnrichedContent | null> {
+  async enrich(
+    url: string,
+    signal?: AbortSignal
+  ): Promise<EnrichedContent | null> {
     try {
-      
       // はてなブックマークのURLの場合はスキップ
       if (isUrlFromDomain(url, 'b.hatena.ne.jp')) {
         return null;
       }
-      
-      const html = await this.fetchWithRetry(url);
-      
+
+      const html = await this.fetchWithRetry(url, signal);
+
       // サムネイルを取得
       const thumbnail = this.extractThumbnail(html);
-      
+
       // 汎用的なセレクタで本文を取得
       const selectors = [
         // 一般的な記事セレクタ
@@ -56,54 +91,52 @@ export class HatenaContentEnricher extends BaseContentEnricher {
         '#main-content',
         'main article',
         'main .content',
-        
+
         // 技術ブログ特有のセレクタ
-        '.markdown-body',          // GitHub風
-        '.prose',                  // Tailwind系
+        '.markdown-body', // GitHub風
+        '.prose', // Tailwind系
         '.article-text',
         '.blog-post-content',
         '.post-entry',
-        
+
         // Qiita系
         '.it-MdContent',
         '.mdContent',
-        
+
         // note系
         '.note-body',
         '.p-note__body',
-        
+
         // Medium系
         '.postArticle-content',
         'article section',
-        
+
         // WordPress系
         '.entry-content',
         '.post-content',
         '.the-content',
         '#content',
       ];
-      
+
       const content = this.sanitizeContent(html, selectors);
-      
+
       // コンテンツが取得できたか確認
       if (!this.isContentSufficient(content, 500)) {
-        
         // より広範囲を取得する試み
         const fallbackContent = this.extractWithFallback(html);
         if (this.isContentSufficient(fallbackContent, 500)) {
           return { content: fallbackContent, thumbnail };
         }
-        
+
         // コンテンツが不十分でもサムネイルがあれば返す
         if (thumbnail) {
           return { content: content || null, thumbnail };
         }
-        
+
         return null;
       }
-      
+
       return { content, thumbnail };
-      
     } catch (_error) {
       return null;
     }
@@ -114,7 +147,7 @@ export class HatenaContentEnricher extends BaseContentEnricher {
    */
   private extractWithFallback(html: string): string {
     const $ = cheerio.load(html);
-    
+
     // 不要な要素を削除
     $('script').remove();
     $('style').remove();
@@ -136,10 +169,10 @@ export class HatenaContentEnricher extends BaseContentEnricher {
     $('.banner').remove();
     $('.widget').remove();
     $('.menu').remove();
-    
+
     // 優先順位: article > main > .container > #wrapper > body
     let content = '';
-    
+
     const articleContent = $('article');
     if (articleContent.length > 0) {
       content = articleContent.text();
@@ -157,7 +190,7 @@ export class HatenaContentEnricher extends BaseContentEnricher {
         }
       }
     }
-    
+
     // テキストのクリーンアップ
     return content
       .replace(/\s+/g, ' ')

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -160,16 +160,6 @@ async function runWithTimeout<T>(
   task: (signal: AbortSignal) => Promise<T>,
   timeoutMs: number,
   timeoutMessage: string
-): Promise<T>;
-async function runWithTimeout<T>(
-  task: () => Promise<T>,
-  timeoutMs: number,
-  timeoutMessage: string
-): Promise<T>;
-async function runWithTimeout<T>(
-  task: ((signal: AbortSignal) => Promise<T>) | (() => Promise<T>),
-  timeoutMs: number,
-  timeoutMessage: string
 ): Promise<T> {
   let timeoutId: NodeJS.Timeout | undefined;
   const controller = new AbortController();
@@ -185,9 +175,7 @@ async function runWithTimeout<T>(
   try {
     // Call the task in a microtask so the timeout is armed even if the task body
     // does heavy synchronous work before its first await.
-    const taskPromise = Promise.resolve().then(() =>
-      (task as (signal: AbortSignal) => Promise<T>)(controller.signal)
-    );
+    const taskPromise = Promise.resolve().then(() => task(controller.signal));
     return await Promise.race([taskPromise, timeoutPromise]);
   } finally {
     if (timeoutId) {
@@ -241,6 +229,8 @@ async function processSource({
     const fetchTimeoutMs = sourceName === 'arXiv AI' ? ARXIV_TIMEOUT_MS : defaultTimeoutMs;
     const timeoutMessage = `Fetcher timeout after ${fetchTimeoutMs}ms for ${sourceName}`;
     const { articles, errors } = await runWithTimeout(
+      // fetcher.fetch() は signal を直接受け取らないが、runWithTimeout が timeout 時に
+      // Promise.race で reject するため後方互換で動作する
       () => fetcher.fetch(),
       fetchTimeoutMs,
       timeoutMessage

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -127,6 +127,19 @@ const debugLog = (message: string) => {
 
 const POST_SAVE_ENRICH_TIMEOUT_MS = env.POST_SAVE_ENRICH_TIMEOUT_MS;
 const POST_SAVE_ENRICH_SLEEP_MS = env.POST_SAVE_ENRICH_SLEEP_MS;
+const HATENA_BLOG_DEV_ENRICH_SLEEP_MS = env.HATENA_BLOG_DEV_ENRICH_SLEEP_MS;
+const HATENA_BLOG_DEV_SOURCE_ID = 'hatena_blog_dev';
+
+/**
+ * ソース別の enrichment 後 sleep 値を決定
+ * hatena_blog_dev は Hatena 独自ドメインでの 429 rate limit 回避のため長めに待つ
+ */
+function resolveEnrichSleepMs(sourceId: string): number {
+  if (sourceId === HATENA_BLOG_DEV_SOURCE_ID) {
+    return HATENA_BLOG_DEV_ENRICH_SLEEP_MS;
+  }
+  return POST_SAVE_ENRICH_SLEEP_MS;
+}
 
 interface ProcessSourceContext {
   source: Source;
@@ -144,15 +157,27 @@ interface ProcessSourceResult {
 }
 
 async function runWithTimeout<T>(
+  task: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<T>;
+async function runWithTimeout<T>(
   task: () => Promise<T>,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<T>;
+async function runWithTimeout<T>(
+  task: ((signal: AbortSignal) => Promise<T>) | (() => Promise<T>),
   timeoutMs: number,
   timeoutMessage: string
 ): Promise<T> {
   let timeoutId: NodeJS.Timeout | undefined;
+  const controller = new AbortController();
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
       console.error(`[TIMEOUT] ${timeoutMessage}`);
+      controller.abort(new Error(timeoutMessage));
       reject(new Error(timeoutMessage));
     }, timeoutMs);
   });
@@ -160,7 +185,9 @@ async function runWithTimeout<T>(
   try {
     // Call the task in a microtask so the timeout is armed even if the task body
     // does heavy synchronous work before its first await.
-    const taskPromise = Promise.resolve().then(task);
+    const taskPromise = Promise.resolve().then(() =>
+      (task as (signal: AbortSignal) => Promise<T>)(controller.signal)
+    );
     return await Promise.race([taskPromise, timeoutPromise]);
   } finally {
     if (timeoutId) {
@@ -361,7 +388,7 @@ async function processSource({
             try {
               debugLog(`   [INFO] エンリッチメント実行: ${article.title.substring(0, 40)}...`);
               const enrichedData = await runWithTimeout(
-                () => enricher.enrich(article.url),
+                (signal) => enricher.enrich(article.url, signal),
                 POST_SAVE_ENRICH_TIMEOUT_MS,
                 `Post-save enrichment timeout after ${POST_SAVE_ENRICH_TIMEOUT_MS}ms for ${sourceName}`
               );
@@ -430,8 +457,9 @@ async function processSource({
               console.error('   [WARN] エンリッチメントエラー:', enrichError instanceof Error ? enrichError.message : String(enrichError));
             }
 
-            if (POST_SAVE_ENRICH_SLEEP_MS > 0) {
-              await new Promise(resolve => setTimeout(resolve, POST_SAVE_ENRICH_SLEEP_MS));
+            const enrichSleepMs = resolveEnrichSleepMs(source.id);
+            if (enrichSleepMs > 0) {
+              await new Promise(resolve => setTimeout(resolve, enrichSleepMs));
             }
           }
         }


### PR DESCRIPTION
## 概要

- 企業技術ブログ（`sourceId='hatena_blog_dev'`）記事の 80-85% が `CONTENT_FETCH_FAILED` となる問題の緩和
- Hatena 独自ドメインで nginx が 429 を返し、enricher の長い retry (30s × 3) と `POST_SAVE_ENRICH_TIMEOUT_MS=10000` が複合的にミスマッチを起こしていた
- 合格閾値: デプロイ後の新規 hatena_blog_dev 記事で `CONTENT_FETCH_FAILED < 20%`

## 実装内容

### T1. `runWithTimeout()` の AbortController 連携
- `scripts/scheduled/collect-feeds.ts` の `runWithTimeout` に `AbortController` を統合
- timeout 発火時に signal 対応済みタスクを実際にキャンセル可能に（今回の適用先は主に enricher 側、fetcher.fetch() は signal 非対応のため従来通り Promise.race で reject）

### T2. Enricher 429 retry 短縮 + AbortSignal 連携
- `IContentEnricher.enrich(url, signal?)` 契約を拡張
- `BaseContentEnricher.fetchWithRetry` に `externalSignal` を追加し、`AbortSignal.any([external, AbortSignal.timeout(15000)])` で per-fetch timeout と合成
- 429 時 sleep: 30s → 1.5s（base.ts）、10s → 1.5s（generic.ts）
- `previousWas429` フラグで次ループ冒頭の exponential backoff を skip し、真に 1.5s リトライを保証（Codex 指摘対応）
- `delay(ms, signal?)` を abort 対応し、旧 `setTimeout` + `clearTimeout` catch パスの timer leak を回避
- `GenericContentEnricher` の maxRetries を 3 → 2 に短縮

### T3. Hatena 独自ドメイン allowlist
- `HATENA_CUSTOM_DOMAINS` 定数を `lib/enrichers/hatena.ts` に追加
- `canHandle()` が hatena.ne.jp / hatenablog.com / hatenablog.jp 系に加え、`tech.every.tv`, `caddi.tech`, `tech.gunosy.io`, `mackerel.io` 等 10 ドメインに完全一致でマッチ
- 専用 enricher 管轄 (`techblog.zozo.com`, `techblog.recruit.co.jp`, `tech.pepabo.com`, `developer.hatenastaff.com`) は除外

### T4. Source 別 sleep
- `scripts/scheduled/collect-feeds.ts` に `resolveEnrichSleepMs(sourceId)` を追加
- `source.id === 'hatena_blog_dev'` の場合、新 env `HATENA_BLOG_DEV_ENRICH_SLEEP_MS`（既定 2500ms）を適用
- 他ソースは従来通り `POST_SAVE_ENRICH_SLEEP_MS`（既定 0ms）

### T5. テスト追加
- `lib/enrichers/__tests__/index.test.ts`: enricher factory 優先順位テスト 14件追加（Hatena allowlist マッチ / 専用 enricher 優先 / 未知ドメインフォールバック）
- `lib/enrichers/__tests__/hatena.test.ts`: HatenaContentEnricher の `canHandle` テスト 18件（新規ファイル）

## テスト結果

VERIFY フェーズ通過:
- Lint: 0 errors, 0 warnings
- Type-check: PASS
- Security audit: 0 vulnerabilities
- Docker build: PASS
- Unit tests: 115件 (base 14 + hatena 18 + index 48 + hatena-blog-dev 16 + create-fetcher 19)

## cross-review 対応

| レビュアー | 指摘 | 対応 |
|-----------|------|------|
| typescript-reviewer | HIGH: `runWithTimeout` の `as` キャスト | 単一シグネチャに統一 |
| Codex | Warning: timer leak コメント過剰 | コメント訂正 |
| Codex | Warning: 429 retry 実質 2.5s+ | `previousWas429` フラグで修正 |

## チェックリスト

- [x] テスト通過
- [x] 破壊的変更なし（`IContentEnricher.enrich` は signal optional で後方互換）
- [x] 関連 env 追加 (`HATENA_BLOG_DEV_ENRICH_SLEEP_MS`)

## 検証計画（デプロイ後）

```sql
SELECT DATE("createdAt") AS d,
       COUNT(*) FILTER (WHERE "skipReason" = 'CONTENT_FETCH_FAILED') AS failed,
       COUNT(*) AS total,
       ROUND(100.0 * COUNT(*) FILTER (WHERE "skipReason" = 'CONTENT_FETCH_FAILED') / NULLIF(COUNT(*),0), 1) AS pct
FROM "Article"
WHERE "sourceId" = 'hatena_blog_dev' AND "createdAt" >= '{デプロイ日}'
GROUP BY d ORDER BY d;
```

合格: `pct < 20` で1サイクル経過

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Hatenaブログのカスタムドメイン対応を追加しました。
  * リクエストのキャンセレーション機能を実装し、より効率的なエンリッチメント処理が可能になりました。

* **Bug Fixes**
  * リトライ戦略を改善し、エラーハンドリングの精度を向上させました。
  * タイムアウト処理を強化しました。

* **Tests**
  * テストスイートを追加して、既存機能の信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->