### PR TITLE
fix(rate-limits): admin social-post 未定義キーを追加 (#588)

### DIFF
--- a/__tests__/lib/config/rate-limits.test.ts
+++ b/__tests__/lib/config/rate-limits.test.ts
@@ -40,6 +40,21 @@ describe('Rate Limit Configuration', () => {
       expect(RATE_LIMIT_POLICIES['public:health']).toBeDefined();
     });
 
+    it('should have admin social-post policies including generate-article and candidates', () => {
+      const genArticle =
+        RATE_LIMIT_POLICIES['admin:social-post-generate-article'];
+      expect(genArticle).toBeDefined();
+      expect(genArticle.points).toBe(5);
+      expect(genArticle.duration).toBe(60);
+      expect(genArticle.keyStrategy).toBe('user');
+
+      const candidates = RATE_LIMIT_POLICIES['admin:social-post-candidates'];
+      expect(candidates).toBeDefined();
+      expect(candidates.points).toBe(30);
+      expect(candidates.duration).toBe(60);
+      expect(candidates.keyStrategy).toBe('user');
+    });
+
     it('should have default policy', () => {
       expect(RATE_LIMIT_POLICIES['default']).toBeDefined();
       expect(RATE_LIMIT_POLICIES['default'].points).toBe(100);

--- a/lib/config/rate-limits.ts
+++ b/lib/config/rate-limits.ts
@@ -324,6 +324,23 @@ export const RATE_LIMIT_POLICIES: Record<string, RateLimitConfig> = {
     notes: 'Social post create/update/delete (20 per minute)',
     telemetryEvent: 'ratelimit.admin.social-post-write',
   },
+  'admin:social-post-generate-article': {
+    points: 5,
+    duration: 60,
+    blockDuration: 0,
+    keyStrategy: 'user',
+    notes:
+      'AI generation from specific article (5 per minute, AI cost control)',
+    telemetryEvent: 'ratelimit.admin.social-post-generate-article',
+  },
+  'admin:social-post-candidates': {
+    points: 30,
+    duration: 60,
+    blockDuration: 0,
+    keyStrategy: 'user',
+    notes: 'Candidate article search for social posts (30 per minute)',
+    telemetryEvent: 'ratelimit.admin.social-post-candidates',
+  },
 
   'admin:ai-generate': {
     points: 5,


### PR DESCRIPTION
## 概要
- Issue #588 対応: `lib/config/rate-limits.ts` に未定義だった 2 つの admin 向けキーを追加
- 未定義時の `default` フォールバック（100/60s, IP 集計）から、admin ユーザー別集計（`keyStrategy: 'user'`）に正常化
- route 側ファイルは変更不要（キー文字列は元から一致しているため追加だけで解決）

## 実装内容
`lib/config/rate-limits.ts` の "Admin Operations (Social Post Management)" セクションに 2 キーを追加:

| Key | points/duration | keyStrategy | 根拠 |
|-----|----------------|-------------|------|
| `admin:social-post-generate-article` | 5 / 60s | user | AI 生成（コスト観点）。`admin:ai-generate` と同水準 |
| `admin:social-post-candidates` | 30 / 60s | user | 候補記事検索（読み取り系）。route コメント記載の期待値 |

両キーとも `blockDuration: 0`（既存 admin 系の慣例に従う）、`telemetryEvent` は命名規約 `ratelimit.admin.<key>` を踏襲。

方針はハイブリッド案を採用（生成は Issue #588 準拠で厳しめ、検索は UX を優先してやや緩め）。

## テスト結果
- 新規アサーション: `admin:social-post-{generate-article,candidates}` の points/duration/keyStrategy を検証
- `__tests__/lib/config/rate-limits.test.ts`: **25 passed / 25 total**
- `validateRateLimitConfigs()` が新規 2 キーも含め全ポリシー検証パス
- VERIFY: lint 0 errors / type-check pass / `npm audit` 0 vulnerabilities / `docker:build` success

## DoD (Issue #588)
- [x] rate-limits.ts に 2 キー定義追加
- [ ] 対象 endpoint を叩いて `X-RateLimit-Limit` が期待値を返す（動作確認はマージ後の staging で実施）
- [ ] admin user key 集計確認（同上）

## チェックリスト
- [x] テスト通過（25/25）
- [x] 破壊的変更なし（既定義キー未改変、route は変更なし）
- [x] lint/type-check/build/audit すべてパス

Closes #588

Generated with Claude Code