### PR TITLE
refactor(admin/jobs): withAdminAuth + withRateLimit('admin:read') に統一 (Closes #589)

### DIFF
--- a/__tests__/api/admin/jobs/article-stats.test.ts
+++ b/__tests__/api/admin/jobs/article-stats.test.ts
@@ -3,12 +3,24 @@
  */
 
 import { NextRequest } from 'next/server';
-import { GET } from '@/app/api/admin/jobs/article-stats/route';
-import { getSession } from '@/lib/auth/get-session';
 import { prisma } from '@/lib/prisma';
 
-// Mock dependencies
-jest.mock('@/lib/auth/get-session');
+jest.mock('@/lib/logger', () => ({
+  __esModule: true,
+  default: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  logger: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
 jest.mock('@/lib/prisma', () => ({
   prisma: {
     article: {
@@ -17,7 +29,25 @@ jest.mock('@/lib/prisma', () => ({
   },
 }));
 
-const mockAuth = getSession as jest.MockedFunction<typeof getSession>;
+const mockWithRateLimit = jest.fn((_key: string, handler: any) => handler);
+jest.mock('@/lib/middleware/with-rate-limit', () => ({
+  withRateLimit: (...args: any[]) => (mockWithRateLimit as any)(...args),
+}));
+
+const mockWithAdminAuth = jest.fn((handler: any) => {
+  return (request: any, context: any) => {
+    return handler(request, {
+      ...context,
+      session: {
+        user: { id: 'admin-1', email: 'admin@test.com', role: 'admin' },
+      },
+    });
+  };
+});
+jest.mock('@/lib/middleware/with-admin-auth', () => ({
+  withAdminAuth: (handler: any) => (mockWithAdminAuth as any)(handler),
+}));
+
 const mockFindMany = prisma.article.findMany as jest.Mock;
 
 function createMockRequest(searchParams?: Record<string, string>): NextRequest {
@@ -31,45 +61,42 @@ function createMockRequest(searchParams?: Record<string, string>): NextRequest {
 }
 
 describe('GET /api/admin/jobs/article-stats', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+  let GET: any;
+  let withAdminAuthCalledOnLoad = false;
+  let withRateLimitCallOnLoad: any[] | null = null;
+
+  beforeAll(async () => {
+    const adminAuthCallsBefore = mockWithAdminAuth.mock.calls.length;
+    const rateLimitCallsBefore = mockWithRateLimit.mock.calls.length;
+    const mod = await import('@/app/api/admin/jobs/article-stats/route');
+    GET = mod.GET;
+    withAdminAuthCalledOnLoad =
+      mockWithAdminAuth.mock.calls.length > adminAuthCallsBefore;
+    if (mockWithRateLimit.mock.calls.length > rateLimitCallsBefore) {
+      withRateLimitCallOnLoad =
+        mockWithRateLimit.mock.calls[rateLimitCallsBefore];
+    }
   });
 
-  describe('Authentication', () => {
-    it('should return 401 if not authenticated', async () => {
-      mockAuth.mockResolvedValue(null);
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
 
-      const request = createMockRequest();
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(401);
-      expect(data.error).toBe('Unauthorized. Authentication required.');
+  describe('Middleware wiring', () => {
+    it('GET ハンドラが withAdminAuth でラップされて export されている', () => {
+      expect(GET).toBeDefined();
+      expect(typeof GET).toBe('function');
+      expect(withAdminAuthCalledOnLoad).toBe(true);
     });
 
-    it('should return 403 if user is not admin', async () => {
-      mockAuth.mockResolvedValue({
-        user: { id: '1', email: 'user@example.com', role: 'user' },
-        session: { id: 's1', userId: '1', token: 'tok', expiresAt: new Date('2099-01-01') },
-      });
-
-      const request = createMockRequest();
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(403);
-      expect(data.error).toBe('Forbidden. Admin access required.');
+    it('withRateLimit が "admin:read" キーで handler 関数を受けて呼ばれている', () => {
+      expect(withRateLimitCallOnLoad).not.toBeNull();
+      expect(withRateLimitCallOnLoad![0]).toBe('admin:read');
+      expect(typeof withRateLimitCallOnLoad![1]).toBe('function');
     });
   });
 
   describe('Authorized requests', () => {
-    beforeEach(() => {
-      mockAuth.mockResolvedValue({
-        user: { id: '1', email: 'admin@example.com', role: 'admin' },
-        session: { id: 's1', userId: '1', token: 'tok', expiresAt: new Date('2099-01-01') },
-      });
-    });
-
     it('should return article statistics by source', async () => {
       const mockArticles = [
         {

--- a/__tests__/api/admin/jobs/article-stats.test.ts
+++ b/__tests__/api/admin/jobs/article-stats.test.ts
@@ -104,9 +104,9 @@ describe('GET /api/admin/jobs/article-stats', () => {
     });
 
     it('合成順が withAdminAuth(withRateLimit(...)) であること（逆順の回帰検知）', () => {
-      expect(mockWithRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
-        mockWithAdminAuth.mock.invocationCallOrder[0]
-      );
+      // 正順では withRateLimit が先に評価され、その戻り値を withAdminAuth が受け取る。
+      // 逆順 withRateLimit(withAdminAuth(handler)) では withAdminAuth が原 handler を直接受け取るため、
+      // 下記の参照一致は成立しない。
       expect(mockWithAdminAuth.mock.calls[0][0]).toBe(
         mockWithRateLimit.mock.results[0].value
       );

--- a/__tests__/api/admin/jobs/article-stats.test.ts
+++ b/__tests__/api/admin/jobs/article-stats.test.ts
@@ -70,19 +70,21 @@ describe('GET /api/admin/jobs/article-stats', () => {
   let GET: any;
   let withAdminAuthCalledOnLoad = false;
   let withRateLimitCallOnLoad: any[] | null = null;
+  let withAdminAuthFirstArgOnLoad: any = null;
+  let withRateLimitResultOnLoad: any = null;
 
   beforeAll(async () => {
     mockWithAdminAuth.mockClear();
     mockWithRateLimit.mockClear();
-    const adminAuthCallsBefore = mockWithAdminAuth.mock.calls.length;
-    const rateLimitCallsBefore = mockWithRateLimit.mock.calls.length;
     const mod = await import('@/app/api/admin/jobs/article-stats/route');
     GET = mod.GET;
-    withAdminAuthCalledOnLoad =
-      mockWithAdminAuth.mock.calls.length > adminAuthCallsBefore;
-    if (mockWithRateLimit.mock.calls.length > rateLimitCallsBefore) {
-      withRateLimitCallOnLoad =
-        mockWithRateLimit.mock.calls[rateLimitCallsBefore];
+    if (mockWithAdminAuth.mock.calls.length > 0) {
+      withAdminAuthCalledOnLoad = true;
+      withAdminAuthFirstArgOnLoad = mockWithAdminAuth.mock.calls[0][0];
+    }
+    if (mockWithRateLimit.mock.calls.length > 0) {
+      withRateLimitCallOnLoad = mockWithRateLimit.mock.calls[0];
+      withRateLimitResultOnLoad = mockWithRateLimit.mock.results[0].value;
     }
   });
 
@@ -107,9 +109,8 @@ describe('GET /api/admin/jobs/article-stats', () => {
       // 正順では withRateLimit が先に評価され、その戻り値を withAdminAuth が受け取る。
       // 逆順 withRateLimit(withAdminAuth(handler)) では withAdminAuth が原 handler を直接受け取るため、
       // 下記の参照一致は成立しない。
-      expect(mockWithAdminAuth.mock.calls[0][0]).toBe(
-        mockWithRateLimit.mock.results[0].value
-      );
+      // (afterEach で jest.clearAllMocks されるため、module-load 時点で捕捉した値を参照)
+      expect(withAdminAuthFirstArgOnLoad).toBe(withRateLimitResultOnLoad);
     });
   });
 

--- a/__tests__/api/admin/jobs/article-stats.test.ts
+++ b/__tests__/api/admin/jobs/article-stats.test.ts
@@ -4,6 +4,8 @@
 
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { withRateLimit } from '@/lib/middleware/with-rate-limit';
+import { withAdminAuth } from '@/lib/middleware/with-admin-auth';
 
 jest.mock('@/lib/logger', () => ({
   __esModule: true,
@@ -29,25 +31,29 @@ jest.mock('@/lib/prisma', () => ({
   },
 }));
 
-const mockWithRateLimit = jest.fn((_key: string, handler: any) => handler);
 jest.mock('@/lib/middleware/with-rate-limit', () => ({
-  withRateLimit: (...args: any[]) => (mockWithRateLimit as any)(...args),
+  withRateLimit: jest.fn((_key: string, handler: any) => handler),
 }));
 
-const mockWithAdminAuth = jest.fn((handler: any) => {
-  return (request: any, context: any) => {
-    return handler(request, {
-      ...context,
-      session: {
-        user: { id: 'admin-1', email: 'admin@test.com', role: 'admin' },
-      },
-    });
-  };
-});
 jest.mock('@/lib/middleware/with-admin-auth', () => ({
-  withAdminAuth: (handler: any) => (mockWithAdminAuth as any)(handler),
+  withAdminAuth: jest.fn((handler: any) => {
+    return (request: any, context: any) => {
+      return handler(request, {
+        ...context,
+        session: {
+          user: { id: 'admin-1', email: 'admin@test.com', role: 'admin' },
+        },
+      });
+    };
+  }),
 }));
 
+const mockWithRateLimit = withRateLimit as jest.MockedFunction<
+  typeof withRateLimit
+>;
+const mockWithAdminAuth = withAdminAuth as jest.MockedFunction<
+  typeof withAdminAuth
+>;
 const mockFindMany = prisma.article.findMany as jest.Mock;
 
 function createMockRequest(searchParams?: Record<string, string>): NextRequest {
@@ -66,6 +72,8 @@ describe('GET /api/admin/jobs/article-stats', () => {
   let withRateLimitCallOnLoad: any[] | null = null;
 
   beforeAll(async () => {
+    mockWithAdminAuth.mockClear();
+    mockWithRateLimit.mockClear();
     const adminAuthCallsBefore = mockWithAdminAuth.mock.calls.length;
     const rateLimitCallsBefore = mockWithRateLimit.mock.calls.length;
     const mod = await import('@/app/api/admin/jobs/article-stats/route');

--- a/__tests__/api/admin/jobs/article-stats.test.ts
+++ b/__tests__/api/admin/jobs/article-stats.test.ts
@@ -32,7 +32,11 @@ jest.mock('@/lib/prisma', () => ({
 }));
 
 jest.mock('@/lib/middleware/with-rate-limit', () => ({
-  withRateLimit: jest.fn((_key: string, handler: any) => handler),
+  // production 実装と同様、handler を呼び出す distinct な wrapper 関数を返す。
+  // raw handler をそのまま返すと「rate-limit wrapper を合成しない」回帰を検知できないため。
+  withRateLimit: jest.fn((_key: string, handler: any) => {
+    return (request: any, context: any) => handler(request, context);
+  }),
 }));
 
 jest.mock('@/lib/middleware/with-admin-auth', () => ({
@@ -72,6 +76,7 @@ describe('GET /api/admin/jobs/article-stats', () => {
   let withRateLimitCallOnLoad: any[] | null = null;
   let withAdminAuthFirstArgOnLoad: any = null;
   let withRateLimitResultOnLoad: any = null;
+  let withAdminAuthResultOnLoad: any = null;
 
   beforeAll(async () => {
     mockWithAdminAuth.mockClear();
@@ -81,6 +86,7 @@ describe('GET /api/admin/jobs/article-stats', () => {
     if (mockWithAdminAuth.mock.calls.length > 0) {
       withAdminAuthCalledOnLoad = true;
       withAdminAuthFirstArgOnLoad = mockWithAdminAuth.mock.calls[0][0];
+      withAdminAuthResultOnLoad = mockWithAdminAuth.mock.results[0].value;
     }
     if (mockWithRateLimit.mock.calls.length > 0) {
       withRateLimitCallOnLoad = mockWithRateLimit.mock.calls[0];
@@ -111,6 +117,11 @@ describe('GET /api/admin/jobs/article-stats', () => {
       // 下記の参照一致は成立しない。
       // (afterEach で jest.clearAllMocks されるため、module-load 時点で捕捉した値を参照)
       expect(withAdminAuthFirstArgOnLoad).toBe(withRateLimitResultOnLoad);
+    });
+
+    it('export された GET は withAdminAuth の戻り値そのものである', () => {
+      // withAdminAuth のラップをスキップして handler を直接 export する回帰を検知
+      expect(GET).toBe(withAdminAuthResultOnLoad);
     });
   });
 

--- a/__tests__/api/admin/jobs/article-stats.test.ts
+++ b/__tests__/api/admin/jobs/article-stats.test.ts
@@ -102,6 +102,15 @@ describe('GET /api/admin/jobs/article-stats', () => {
       expect(withRateLimitCallOnLoad![0]).toBe('admin:read');
       expect(typeof withRateLimitCallOnLoad![1]).toBe('function');
     });
+
+    it('合成順が withAdminAuth(withRateLimit(...)) であること（逆順の回帰検知）', () => {
+      expect(mockWithRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
+        mockWithAdminAuth.mock.invocationCallOrder[0]
+      );
+      expect(mockWithAdminAuth.mock.calls[0][0]).toBe(
+        mockWithRateLimit.mock.results[0].value
+      );
+    });
   });
 
   describe('Authorized requests', () => {

--- a/__tests__/api/admin/jobs/embedding-summary.test.ts
+++ b/__tests__/api/admin/jobs/embedding-summary.test.ts
@@ -4,6 +4,8 @@
 
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { withRateLimit } from '@/lib/middleware/with-rate-limit';
+import { withAdminAuth } from '@/lib/middleware/with-admin-auth';
 
 jest.mock('@/lib/logger', () => ({
   __esModule: true,
@@ -30,25 +32,29 @@ jest.mock('@/lib/prisma', () => ({
   },
 }));
 
-const mockWithRateLimit = jest.fn((_key: string, handler: any) => handler);
 jest.mock('@/lib/middleware/with-rate-limit', () => ({
-  withRateLimit: (...args: any[]) => (mockWithRateLimit as any)(...args),
+  withRateLimit: jest.fn((_key: string, handler: any) => handler),
 }));
 
-const mockWithAdminAuth = jest.fn((handler: any) => {
-  return (request: any, context: any) => {
-    return handler(request, {
-      ...context,
-      session: {
-        user: { id: 'admin-1', email: 'admin@test.com', role: 'admin' },
-      },
-    });
-  };
-});
 jest.mock('@/lib/middleware/with-admin-auth', () => ({
-  withAdminAuth: (handler: any) => (mockWithAdminAuth as any)(handler),
+  withAdminAuth: jest.fn((handler: any) => {
+    return (request: any, context: any) => {
+      return handler(request, {
+        ...context,
+        session: {
+          user: { id: 'admin-1', email: 'admin@test.com', role: 'admin' },
+        },
+      });
+    };
+  }),
 }));
 
+const mockWithRateLimit = withRateLimit as jest.MockedFunction<
+  typeof withRateLimit
+>;
+const mockWithAdminAuth = withAdminAuth as jest.MockedFunction<
+  typeof withAdminAuth
+>;
 const mockGroupBy = prisma.embeddingJob.groupBy as jest.Mock;
 const mockFindMany = prisma.embeddingJob.findMany as jest.Mock;
 
@@ -68,6 +74,8 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
   let withRateLimitCallOnLoad: any[] | null = null;
 
   beforeAll(async () => {
+    mockWithAdminAuth.mockClear();
+    mockWithRateLimit.mockClear();
     const adminAuthCallsBefore = mockWithAdminAuth.mock.calls.length;
     const rateLimitCallsBefore = mockWithRateLimit.mock.calls.length;
     const mod = await import('@/app/api/admin/jobs/embedding-summary/route');

--- a/__tests__/api/admin/jobs/embedding-summary.test.ts
+++ b/__tests__/api/admin/jobs/embedding-summary.test.ts
@@ -33,7 +33,11 @@ jest.mock('@/lib/prisma', () => ({
 }));
 
 jest.mock('@/lib/middleware/with-rate-limit', () => ({
-  withRateLimit: jest.fn((_key: string, handler: any) => handler),
+  // production 実装と同様、handler を呼び出す distinct な wrapper 関数を返す。
+  // raw handler をそのまま返すと「rate-limit wrapper を合成しない」回帰を検知できないため。
+  withRateLimit: jest.fn((_key: string, handler: any) => {
+    return (request: any, context: any) => handler(request, context);
+  }),
 }));
 
 jest.mock('@/lib/middleware/with-admin-auth', () => ({
@@ -74,6 +78,7 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
   let withRateLimitCallOnLoad: any[] | null = null;
   let withAdminAuthFirstArgOnLoad: any = null;
   let withRateLimitResultOnLoad: any = null;
+  let withAdminAuthResultOnLoad: any = null;
 
   beforeAll(async () => {
     mockWithAdminAuth.mockClear();
@@ -83,6 +88,7 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
     if (mockWithAdminAuth.mock.calls.length > 0) {
       withAdminAuthCalledOnLoad = true;
       withAdminAuthFirstArgOnLoad = mockWithAdminAuth.mock.calls[0][0];
+      withAdminAuthResultOnLoad = mockWithAdminAuth.mock.results[0].value;
     }
     if (mockWithRateLimit.mock.calls.length > 0) {
       withRateLimitCallOnLoad = mockWithRateLimit.mock.calls[0];
@@ -114,6 +120,11 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
       // 下記の参照一致は成立しない。
       // (afterEach で jest.clearAllMocks されるため、module-load 時点で捕捉した値を参照)
       expect(withAdminAuthFirstArgOnLoad).toBe(withRateLimitResultOnLoad);
+    });
+
+    it('export された GET は withAdminAuth の戻り値そのものである', () => {
+      // withAdminAuth のラップをスキップして handler を直接 export する回帰を検知
+      expect(GET).toBe(withAdminAuthResultOnLoad);
     });
   });
 

--- a/__tests__/api/admin/jobs/embedding-summary.test.ts
+++ b/__tests__/api/admin/jobs/embedding-summary.test.ts
@@ -3,12 +3,24 @@
  */
 
 import { NextRequest } from 'next/server';
-import { GET } from '@/app/api/admin/jobs/embedding-summary/route';
-import { getSession } from '@/lib/auth/get-session';
 import { prisma } from '@/lib/prisma';
 
-// Mock dependencies
-jest.mock('@/lib/auth/get-session');
+jest.mock('@/lib/logger', () => ({
+  __esModule: true,
+  default: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  logger: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
 jest.mock('@/lib/prisma', () => ({
   prisma: {
     embeddingJob: {
@@ -18,7 +30,25 @@ jest.mock('@/lib/prisma', () => ({
   },
 }));
 
-const mockAuth = getSession as jest.MockedFunction<typeof getSession>;
+const mockWithRateLimit = jest.fn((_key: string, handler: any) => handler);
+jest.mock('@/lib/middleware/with-rate-limit', () => ({
+  withRateLimit: (...args: any[]) => (mockWithRateLimit as any)(...args),
+}));
+
+const mockWithAdminAuth = jest.fn((handler: any) => {
+  return (request: any, context: any) => {
+    return handler(request, {
+      ...context,
+      session: {
+        user: { id: 'admin-1', email: 'admin@test.com', role: 'admin' },
+      },
+    });
+  };
+});
+jest.mock('@/lib/middleware/with-admin-auth', () => ({
+  withAdminAuth: (handler: any) => (mockWithAdminAuth as any)(handler),
+}));
+
 const mockGroupBy = prisma.embeddingJob.groupBy as jest.Mock;
 const mockFindMany = prisma.embeddingJob.findMany as jest.Mock;
 
@@ -33,45 +63,43 @@ function createMockRequest(searchParams?: Record<string, string>): NextRequest {
 }
 
 describe('GET /api/admin/jobs/embedding-summary', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+  let GET: any;
+  let withAdminAuthCalledOnLoad = false;
+  let withRateLimitCallOnLoad: any[] | null = null;
+
+  beforeAll(async () => {
+    const adminAuthCallsBefore = mockWithAdminAuth.mock.calls.length;
+    const rateLimitCallsBefore = mockWithRateLimit.mock.calls.length;
+    const mod = await import('@/app/api/admin/jobs/embedding-summary/route');
+    GET = mod.GET;
+    withAdminAuthCalledOnLoad =
+      mockWithAdminAuth.mock.calls.length > adminAuthCallsBefore;
+    if (mockWithRateLimit.mock.calls.length > rateLimitCallsBefore) {
+      withRateLimitCallOnLoad =
+        mockWithRateLimit.mock.calls[rateLimitCallsBefore];
+    }
   });
 
-  describe('Authentication', () => {
-    it('should return 401 if not authenticated', async () => {
-      mockAuth.mockResolvedValue(null);
+  beforeEach(() => {
+    mockGroupBy.mockReset();
+    mockFindMany.mockReset();
+  });
 
-      const request = createMockRequest();
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(401);
-      expect(data.error).toBe('Unauthorized. Authentication required.');
+  describe('Middleware wiring', () => {
+    it('GET ハンドラが withAdminAuth でラップされて export されている', () => {
+      expect(GET).toBeDefined();
+      expect(typeof GET).toBe('function');
+      expect(withAdminAuthCalledOnLoad).toBe(true);
     });
 
-    it('should return 403 if user is not admin', async () => {
-      mockAuth.mockResolvedValue({
-        user: { id: '1', email: 'user@example.com', role: 'user' },
-        session: { id: 's1', userId: '1', token: 'tok', expiresAt: new Date('2099-01-01') },
-      });
-
-      const request = createMockRequest();
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(403);
-      expect(data.error).toBe('Forbidden. Admin access required.');
+    it('withRateLimit が "admin:read" キーで handler 関数を受けて呼ばれている', () => {
+      expect(withRateLimitCallOnLoad).not.toBeNull();
+      expect(withRateLimitCallOnLoad![0]).toBe('admin:read');
+      expect(typeof withRateLimitCallOnLoad![1]).toBe('function');
     });
   });
 
   describe('Authorized requests', () => {
-    beforeEach(() => {
-      mockAuth.mockResolvedValue({
-        user: { id: '1', email: 'admin@example.com', role: 'admin' },
-        session: { id: 's1', userId: '1', token: 'tok', expiresAt: new Date('2099-01-01') },
-      });
-    });
-
     it('should return embedding job statistics', async () => {
       mockGroupBy.mockResolvedValue([
         { status: 'PENDING', _count: { status: 10 } },
@@ -80,9 +108,7 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
         { status: 'FAILED', _count: { status: 5 } },
       ]);
 
-      // Stuck jobs query
       mockFindMany.mockResolvedValueOnce([]);
-      // High retry jobs query
       mockFindMany.mockResolvedValueOnce([]);
 
       const request = createMockRequest();
@@ -103,7 +129,7 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
         { status: 'PROCESSING', _count: { status: 2 } },
       ]);
 
-      const oldDate = new Date(Date.now() - 60 * 60 * 1000); // 1 hour ago
+      const oldDate = new Date(Date.now() - 60 * 60 * 1000);
       mockFindMany.mockResolvedValueOnce([
         {
           id: 'job-1',
@@ -125,7 +151,7 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
 
     it('should detect high retry jobs', async () => {
       mockGroupBy.mockResolvedValue([]);
-      mockFindMany.mockResolvedValueOnce([]); // Stuck jobs
+      mockFindMany.mockResolvedValueOnce([]);
       mockFindMany.mockResolvedValueOnce([
         {
           id: 'job-1',
@@ -167,13 +193,11 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
       const request = createMockRequest({ stuckThreshold: '60' });
       await GET(request);
 
-      // Verify the findMany was called with correct cutoff time (60 minutes ago)
       expect(mockFindMany).toHaveBeenCalled();
       const stuckJobsCall = mockFindMany.mock.calls[0][0];
       expect(stuckJobsCall.where.status).toBe('PROCESSING');
       expect(stuckJobsCall.where.queuedAt.lt).toBeDefined();
 
-      // Verify the cutoff is approximately 60 minutes ago (within 1 minute tolerance)
       const cutoffTime = stuckJobsCall.where.queuedAt.lt.getTime();
       const expectedCutoff = Date.now() - 60 * 60 * 1000;
       expect(Math.abs(cutoffTime - expectedCutoff)).toBeLessThan(60 * 1000);

--- a/__tests__/api/admin/jobs/embedding-summary.test.ts
+++ b/__tests__/api/admin/jobs/embedding-summary.test.ts
@@ -105,6 +105,15 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
       expect(withRateLimitCallOnLoad![0]).toBe('admin:read');
       expect(typeof withRateLimitCallOnLoad![1]).toBe('function');
     });
+
+    it('合成順が withAdminAuth(withRateLimit(...)) であること（逆順の回帰検知）', () => {
+      expect(mockWithRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
+        mockWithAdminAuth.mock.invocationCallOrder[0]
+      );
+      expect(mockWithAdminAuth.mock.calls[0][0]).toBe(
+        mockWithRateLimit.mock.results[0].value
+      );
+    });
   });
 
   describe('Authorized requests', () => {

--- a/__tests__/api/admin/jobs/embedding-summary.test.ts
+++ b/__tests__/api/admin/jobs/embedding-summary.test.ts
@@ -72,19 +72,21 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
   let GET: any;
   let withAdminAuthCalledOnLoad = false;
   let withRateLimitCallOnLoad: any[] | null = null;
+  let withAdminAuthFirstArgOnLoad: any = null;
+  let withRateLimitResultOnLoad: any = null;
 
   beforeAll(async () => {
     mockWithAdminAuth.mockClear();
     mockWithRateLimit.mockClear();
-    const adminAuthCallsBefore = mockWithAdminAuth.mock.calls.length;
-    const rateLimitCallsBefore = mockWithRateLimit.mock.calls.length;
     const mod = await import('@/app/api/admin/jobs/embedding-summary/route');
     GET = mod.GET;
-    withAdminAuthCalledOnLoad =
-      mockWithAdminAuth.mock.calls.length > adminAuthCallsBefore;
-    if (mockWithRateLimit.mock.calls.length > rateLimitCallsBefore) {
-      withRateLimitCallOnLoad =
-        mockWithRateLimit.mock.calls[rateLimitCallsBefore];
+    if (mockWithAdminAuth.mock.calls.length > 0) {
+      withAdminAuthCalledOnLoad = true;
+      withAdminAuthFirstArgOnLoad = mockWithAdminAuth.mock.calls[0][0];
+    }
+    if (mockWithRateLimit.mock.calls.length > 0) {
+      withRateLimitCallOnLoad = mockWithRateLimit.mock.calls[0];
+      withRateLimitResultOnLoad = mockWithRateLimit.mock.results[0].value;
     }
   });
 
@@ -110,9 +112,8 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
       // 正順では withRateLimit が先に評価され、その戻り値を withAdminAuth が受け取る。
       // 逆順 withRateLimit(withAdminAuth(handler)) では withAdminAuth が原 handler を直接受け取るため、
       // 下記の参照一致は成立しない。
-      expect(mockWithAdminAuth.mock.calls[0][0]).toBe(
-        mockWithRateLimit.mock.results[0].value
-      );
+      // (afterEach で jest.clearAllMocks されるため、module-load 時点で捕捉した値を参照)
+      expect(withAdminAuthFirstArgOnLoad).toBe(withRateLimitResultOnLoad);
     });
   });
 

--- a/__tests__/api/admin/jobs/embedding-summary.test.ts
+++ b/__tests__/api/admin/jobs/embedding-summary.test.ts
@@ -107,9 +107,9 @@ describe('GET /api/admin/jobs/embedding-summary', () => {
     });
 
     it('合成順が withAdminAuth(withRateLimit(...)) であること（逆順の回帰検知）', () => {
-      expect(mockWithRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
-        mockWithAdminAuth.mock.invocationCallOrder[0]
-      );
+      // 正順では withRateLimit が先に評価され、その戻り値を withAdminAuth が受け取る。
+      // 逆順 withRateLimit(withAdminAuth(handler)) では withAdminAuth が原 handler を直接受け取るため、
+      // 下記の参照一致は成立しない。
       expect(mockWithAdminAuth.mock.calls[0][0]).toBe(
         mockWithRateLimit.mock.results[0].value
       );

--- a/__tests__/api/admin/jobs/processing-logs.test.ts
+++ b/__tests__/api/admin/jobs/processing-logs.test.ts
@@ -4,6 +4,8 @@
 
 import { NextRequest } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { withRateLimit } from '@/lib/middleware/with-rate-limit';
+import { withAdminAuth } from '@/lib/middleware/with-admin-auth';
 
 jest.mock('@/lib/logger', () => ({
   __esModule: true,
@@ -29,25 +31,29 @@ jest.mock('@/lib/prisma', () => ({
   },
 }));
 
-const mockWithRateLimit = jest.fn((_key: string, handler: any) => handler);
 jest.mock('@/lib/middleware/with-rate-limit', () => ({
-  withRateLimit: (...args: any[]) => (mockWithRateLimit as any)(...args),
+  withRateLimit: jest.fn((_key: string, handler: any) => handler),
 }));
 
-const mockWithAdminAuth = jest.fn((handler: any) => {
-  return (request: any, context: any) => {
-    return handler(request, {
-      ...context,
-      session: {
-        user: { id: 'admin-1', email: 'admin@test.com', role: 'admin' },
-      },
-    });
-  };
-});
 jest.mock('@/lib/middleware/with-admin-auth', () => ({
-  withAdminAuth: (handler: any) => (mockWithAdminAuth as any)(handler),
+  withAdminAuth: jest.fn((handler: any) => {
+    return (request: any, context: any) => {
+      return handler(request, {
+        ...context,
+        session: {
+          user: { id: 'admin-1', email: 'admin@test.com', role: 'admin' },
+        },
+      });
+    };
+  }),
 }));
 
+const mockWithRateLimit = withRateLimit as jest.MockedFunction<
+  typeof withRateLimit
+>;
+const mockWithAdminAuth = withAdminAuth as jest.MockedFunction<
+  typeof withAdminAuth
+>;
 const mockFindMany = prisma.processingLog.findMany as jest.Mock;
 
 function createMockRequest(searchParams?: Record<string, string>): NextRequest {
@@ -66,6 +72,8 @@ describe('GET /api/admin/jobs/processing-logs', () => {
   let withRateLimitCallOnLoad: any[] | null = null;
 
   beforeAll(async () => {
+    mockWithAdminAuth.mockClear();
+    mockWithRateLimit.mockClear();
     const adminAuthCallsBefore = mockWithAdminAuth.mock.calls.length;
     const rateLimitCallsBefore = mockWithRateLimit.mock.calls.length;
     const mod = await import('@/app/api/admin/jobs/processing-logs/route');

--- a/__tests__/api/admin/jobs/processing-logs.test.ts
+++ b/__tests__/api/admin/jobs/processing-logs.test.ts
@@ -102,6 +102,16 @@ describe('GET /api/admin/jobs/processing-logs', () => {
       expect(withRateLimitCallOnLoad![0]).toBe('admin:read');
       expect(typeof withRateLimitCallOnLoad![1]).toBe('function');
     });
+
+    it('合成順が withAdminAuth(withRateLimit(...)) であること（逆順の回帰検知）', () => {
+      // 正順: withRateLimit が先に呼ばれ、その戻り値を withAdminAuth が受ける
+      expect(mockWithRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
+        mockWithAdminAuth.mock.invocationCallOrder[0]
+      );
+      expect(mockWithAdminAuth.mock.calls[0][0]).toBe(
+        mockWithRateLimit.mock.results[0].value
+      );
+    });
   });
 
   describe('Authorized requests', () => {

--- a/__tests__/api/admin/jobs/processing-logs.test.ts
+++ b/__tests__/api/admin/jobs/processing-logs.test.ts
@@ -70,19 +70,21 @@ describe('GET /api/admin/jobs/processing-logs', () => {
   let GET: any;
   let withAdminAuthCalledOnLoad = false;
   let withRateLimitCallOnLoad: any[] | null = null;
+  let withAdminAuthFirstArgOnLoad: any = null;
+  let withRateLimitResultOnLoad: any = null;
 
   beforeAll(async () => {
     mockWithAdminAuth.mockClear();
     mockWithRateLimit.mockClear();
-    const adminAuthCallsBefore = mockWithAdminAuth.mock.calls.length;
-    const rateLimitCallsBefore = mockWithRateLimit.mock.calls.length;
     const mod = await import('@/app/api/admin/jobs/processing-logs/route');
     GET = mod.GET;
-    withAdminAuthCalledOnLoad =
-      mockWithAdminAuth.mock.calls.length > adminAuthCallsBefore;
-    if (mockWithRateLimit.mock.calls.length > rateLimitCallsBefore) {
-      withRateLimitCallOnLoad =
-        mockWithRateLimit.mock.calls[rateLimitCallsBefore];
+    if (mockWithAdminAuth.mock.calls.length > 0) {
+      withAdminAuthCalledOnLoad = true;
+      withAdminAuthFirstArgOnLoad = mockWithAdminAuth.mock.calls[0][0];
+    }
+    if (mockWithRateLimit.mock.calls.length > 0) {
+      withRateLimitCallOnLoad = mockWithRateLimit.mock.calls[0];
+      withRateLimitResultOnLoad = mockWithRateLimit.mock.results[0].value;
     }
   });
 
@@ -107,9 +109,8 @@ describe('GET /api/admin/jobs/processing-logs', () => {
       // 正順では withRateLimit が先に評価され、その戻り値を withAdminAuth が受け取る。
       // 逆順 withRateLimit(withAdminAuth(handler)) では withAdminAuth が原 handler を直接受け取るため、
       // 下記の参照一致は成立しない。
-      expect(mockWithAdminAuth.mock.calls[0][0]).toBe(
-        mockWithRateLimit.mock.results[0].value
-      );
+      // (afterEach で jest.clearAllMocks されるため、module-load 時点で捕捉した値を参照)
+      expect(withAdminAuthFirstArgOnLoad).toBe(withRateLimitResultOnLoad);
     });
   });
 

--- a/__tests__/api/admin/jobs/processing-logs.test.ts
+++ b/__tests__/api/admin/jobs/processing-logs.test.ts
@@ -3,12 +3,24 @@
  */
 
 import { NextRequest } from 'next/server';
-import { GET } from '@/app/api/admin/jobs/processing-logs/route';
-import { getSession } from '@/lib/auth/get-session';
 import { prisma } from '@/lib/prisma';
 
-// Mock dependencies
-jest.mock('@/lib/auth/get-session');
+jest.mock('@/lib/logger', () => ({
+  __esModule: true,
+  default: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+  logger: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
 jest.mock('@/lib/prisma', () => ({
   prisma: {
     processingLog: {
@@ -17,7 +29,25 @@ jest.mock('@/lib/prisma', () => ({
   },
 }));
 
-const mockAuth = getSession as jest.MockedFunction<typeof getSession>;
+const mockWithRateLimit = jest.fn((_key: string, handler: any) => handler);
+jest.mock('@/lib/middleware/with-rate-limit', () => ({
+  withRateLimit: (...args: any[]) => (mockWithRateLimit as any)(...args),
+}));
+
+const mockWithAdminAuth = jest.fn((handler: any) => {
+  return (request: any, context: any) => {
+    return handler(request, {
+      ...context,
+      session: {
+        user: { id: 'admin-1', email: 'admin@test.com', role: 'admin' },
+      },
+    });
+  };
+});
+jest.mock('@/lib/middleware/with-admin-auth', () => ({
+  withAdminAuth: (handler: any) => (mockWithAdminAuth as any)(handler),
+}));
+
 const mockFindMany = prisma.processingLog.findMany as jest.Mock;
 
 function createMockRequest(searchParams?: Record<string, string>): NextRequest {
@@ -31,45 +61,42 @@ function createMockRequest(searchParams?: Record<string, string>): NextRequest {
 }
 
 describe('GET /api/admin/jobs/processing-logs', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+  let GET: any;
+  let withAdminAuthCalledOnLoad = false;
+  let withRateLimitCallOnLoad: any[] | null = null;
+
+  beforeAll(async () => {
+    const adminAuthCallsBefore = mockWithAdminAuth.mock.calls.length;
+    const rateLimitCallsBefore = mockWithRateLimit.mock.calls.length;
+    const mod = await import('@/app/api/admin/jobs/processing-logs/route');
+    GET = mod.GET;
+    withAdminAuthCalledOnLoad =
+      mockWithAdminAuth.mock.calls.length > adminAuthCallsBefore;
+    if (mockWithRateLimit.mock.calls.length > rateLimitCallsBefore) {
+      withRateLimitCallOnLoad =
+        mockWithRateLimit.mock.calls[rateLimitCallsBefore];
+    }
   });
 
-  describe('Authentication', () => {
-    it('should return 401 if not authenticated', async () => {
-      mockAuth.mockResolvedValue(null);
+  beforeEach(() => {
+    mockFindMany.mockReset();
+  });
 
-      const request = createMockRequest();
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(401);
-      expect(data.error).toBe('Unauthorized. Authentication required.');
+  describe('Middleware wiring', () => {
+    it('GET ハンドラが withAdminAuth でラップされて export されている', () => {
+      expect(GET).toBeDefined();
+      expect(typeof GET).toBe('function');
+      expect(withAdminAuthCalledOnLoad).toBe(true);
     });
 
-    it('should return 403 if user is not admin', async () => {
-      mockAuth.mockResolvedValue({
-        user: { id: '1', email: 'user@example.com', role: 'user' },
-        session: { id: 's1', userId: '1', token: 'tok', expiresAt: new Date('2099-01-01') },
-      });
-
-      const request = createMockRequest();
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(403);
-      expect(data.error).toBe('Forbidden. Admin access required.');
+    it('withRateLimit が "admin:read" キーで handler 関数を受けて呼ばれている', () => {
+      expect(withRateLimitCallOnLoad).not.toBeNull();
+      expect(withRateLimitCallOnLoad![0]).toBe('admin:read');
+      expect(typeof withRateLimitCallOnLoad![1]).toBe('function');
     });
   });
 
   describe('Authorized requests', () => {
-    beforeEach(() => {
-      mockAuth.mockResolvedValue({
-        user: { id: '1', email: 'admin@example.com', role: 'admin' },
-        session: { id: 's1', userId: '1', token: 'tok', expiresAt: new Date('2099-01-01') },
-      });
-    });
-
     it('should return processing logs with summary', async () => {
       const mockLogs = [
         {
@@ -169,12 +196,11 @@ describe('GET /api/admin/jobs/processing-logs', () => {
       const response = await GET(request);
       const data = await response.json();
 
-      // Top-level auth key should be removed
       expect(data.logs[0].metadata).not.toHaveProperty('auth');
-      // Nested API_KEY should be removed
       expect(data.logs[0].metadata.config).not.toHaveProperty('API_KEY');
-      // Non-sensitive fields should remain
-      expect(data.logs[0].metadata.config.endpoint).toBe('https://api.example.com');
+      expect(data.logs[0].metadata.config.endpoint).toBe(
+        'https://api.example.com'
+      );
       expect(data.logs[0].metadata.normalField).toBe('visible');
     });
 
@@ -200,7 +226,6 @@ describe('GET /api/admin/jobs/processing-logs', () => {
       const request = createMockRequest({ days: '-5', limit: '1000' });
       await GET(request);
 
-      // Invalid days (-5) should default to 7, limit (1000) should be capped at 500
       expect(mockFindMany).toHaveBeenCalledWith(
         expect.objectContaining({
           take: 500,

--- a/__tests__/api/admin/jobs/processing-logs.test.ts
+++ b/__tests__/api/admin/jobs/processing-logs.test.ts
@@ -104,10 +104,9 @@ describe('GET /api/admin/jobs/processing-logs', () => {
     });
 
     it('合成順が withAdminAuth(withRateLimit(...)) であること（逆順の回帰検知）', () => {
-      // 正順: withRateLimit が先に呼ばれ、その戻り値を withAdminAuth が受ける
-      expect(mockWithRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
-        mockWithAdminAuth.mock.invocationCallOrder[0]
-      );
+      // 正順では withRateLimit が先に評価され、その戻り値を withAdminAuth が受け取る。
+      // 逆順 withRateLimit(withAdminAuth(handler)) では withAdminAuth が原 handler を直接受け取るため、
+      // 下記の参照一致は成立しない。
       expect(mockWithAdminAuth.mock.calls[0][0]).toBe(
         mockWithRateLimit.mock.results[0].value
       );

--- a/__tests__/api/admin/jobs/processing-logs.test.ts
+++ b/__tests__/api/admin/jobs/processing-logs.test.ts
@@ -32,7 +32,11 @@ jest.mock('@/lib/prisma', () => ({
 }));
 
 jest.mock('@/lib/middleware/with-rate-limit', () => ({
-  withRateLimit: jest.fn((_key: string, handler: any) => handler),
+  // production 実装と同様、handler を呼び出す distinct な wrapper 関数を返す。
+  // raw handler をそのまま返すと「rate-limit wrapper を合成しない」回帰を検知できないため。
+  withRateLimit: jest.fn((_key: string, handler: any) => {
+    return (request: any, context: any) => handler(request, context);
+  }),
 }));
 
 jest.mock('@/lib/middleware/with-admin-auth', () => ({
@@ -72,6 +76,7 @@ describe('GET /api/admin/jobs/processing-logs', () => {
   let withRateLimitCallOnLoad: any[] | null = null;
   let withAdminAuthFirstArgOnLoad: any = null;
   let withRateLimitResultOnLoad: any = null;
+  let withAdminAuthResultOnLoad: any = null;
 
   beforeAll(async () => {
     mockWithAdminAuth.mockClear();
@@ -81,6 +86,7 @@ describe('GET /api/admin/jobs/processing-logs', () => {
     if (mockWithAdminAuth.mock.calls.length > 0) {
       withAdminAuthCalledOnLoad = true;
       withAdminAuthFirstArgOnLoad = mockWithAdminAuth.mock.calls[0][0];
+      withAdminAuthResultOnLoad = mockWithAdminAuth.mock.results[0].value;
     }
     if (mockWithRateLimit.mock.calls.length > 0) {
       withRateLimitCallOnLoad = mockWithRateLimit.mock.calls[0];
@@ -111,6 +117,11 @@ describe('GET /api/admin/jobs/processing-logs', () => {
       // 下記の参照一致は成立しない。
       // (afterEach で jest.clearAllMocks されるため、module-load 時点で捕捉した値を参照)
       expect(withAdminAuthFirstArgOnLoad).toBe(withRateLimitResultOnLoad);
+    });
+
+    it('export された GET は withAdminAuth の戻り値そのものである', () => {
+      // withAdminAuth のラップをスキップして handler を直接 export する回帰を検知
+      expect(GET).toBe(withAdminAuthResultOnLoad);
     });
   });
 

--- a/app/api/admin/jobs/article-stats/route.ts
+++ b/app/api/admin/jobs/article-stats/route.ts
@@ -5,11 +5,8 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { getSession } from '@/lib/auth/get-session';
-import {
-  validateUser,
-  createUserDeletedResponse,
-} from '@/lib/middleware/with-user-validation';
+import { withAdminAuth } from '@/lib/middleware/with-admin-auth';
+import { withRateLimit } from '@/lib/middleware/with-rate-limit';
 import { prisma } from '@/lib/prisma';
 import logger from '@/lib/logger';
 import type {
@@ -38,31 +35,8 @@ function hasValidSummary(summary: string | null | undefined): boolean {
   return typeof summary === 'string' && summary.trim().length > 0;
 }
 
-export async function GET(request: NextRequest) {
+async function handler(request: NextRequest) {
   try {
-    // Authentication check
-    const session = await getSession();
-    if (!session?.user) {
-      return NextResponse.json(
-        { error: 'Unauthorized. Authentication required.' },
-        { status: 401 }
-      );
-    }
-
-    // User existence check (prevent deleted user access)
-    const validatedUser = await validateUser(session);
-    if (!validatedUser) {
-      return createUserDeletedResponse();
-    }
-
-    // Authorization check (admin only)
-    if (session.user.role !== 'admin') {
-      return NextResponse.json(
-        { error: 'Forbidden. Admin access required.' },
-        { status: 403 }
-      );
-    }
-
     // Parse query parameters
     const searchParams = request.nextUrl.searchParams;
     const rawRange = searchParams.get('range');
@@ -198,3 +172,5 @@ export async function GET(request: NextRequest) {
     );
   }
 }
+
+export const GET = withAdminAuth(withRateLimit('admin:read', handler));

--- a/app/api/admin/jobs/embedding-summary/route.ts
+++ b/app/api/admin/jobs/embedding-summary/route.ts
@@ -5,11 +5,8 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import { getSession } from '@/lib/auth/get-session';
-import {
-  validateUser,
-  createUserDeletedResponse,
-} from '@/lib/middleware/with-user-validation';
+import { withAdminAuth } from '@/lib/middleware/with-admin-auth';
+import { withRateLimit } from '@/lib/middleware/with-rate-limit';
 import { prisma } from '@/lib/prisma';
 import logger from '@/lib/logger';
 import type {
@@ -30,31 +27,8 @@ const QuerySchema = z.object({
     .optional(),
 });
 
-export async function GET(request: NextRequest) {
+async function handler(request: NextRequest) {
   try {
-    // Authentication check
-    const session = await getSession();
-    if (!session?.user) {
-      return NextResponse.json(
-        { error: 'Unauthorized. Authentication required.' },
-        { status: 401 }
-      );
-    }
-
-    // User existence check (prevent deleted user access)
-    const validatedUser = await validateUser(session);
-    if (!validatedUser) {
-      return createUserDeletedResponse();
-    }
-
-    // Authorization check (admin only)
-    if (session.user.role !== 'admin') {
-      return NextResponse.json(
-        { error: 'Forbidden. Admin access required.' },
-        { status: 403 }
-      );
-    }
-
     // Parse and validate query parameters with Zod
     const searchParams = request.nextUrl.searchParams;
     const queryParseResult = QuerySchema.safeParse({
@@ -171,3 +145,5 @@ function truncateError(error: string, maxLength = 200): string {
   }
   return error.substring(0, maxLength) + '...';
 }
+
+export const GET = withAdminAuth(withRateLimit('admin:read', handler));

--- a/app/api/admin/jobs/processing-logs/route.ts
+++ b/app/api/admin/jobs/processing-logs/route.ts
@@ -4,11 +4,8 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { getSession } from '@/lib/auth/get-session';
-import {
-  validateUser,
-  createUserDeletedResponse,
-} from '@/lib/middleware/with-user-validation';
+import { withAdminAuth } from '@/lib/middleware/with-admin-auth';
+import { withRateLimit } from '@/lib/middleware/with-rate-limit';
 import { prisma } from '@/lib/prisma';
 import logger from '@/lib/logger';
 import type {
@@ -111,31 +108,8 @@ function sanitizeMetadata(metadata: unknown): Record<string, unknown> | null {
   return sanitizeObject(metadata as Record<string, unknown>);
 }
 
-export async function GET(request: NextRequest) {
+async function handler(request: NextRequest) {
   try {
-    // Authentication check
-    const session = await getSession();
-    if (!session?.user) {
-      return NextResponse.json(
-        { error: 'Unauthorized. Authentication required.' },
-        { status: 401 }
-      );
-    }
-
-    // User existence check (prevent deleted user access)
-    const validatedUser = await validateUser(session);
-    if (!validatedUser) {
-      return createUserDeletedResponse();
-    }
-
-    // Authorization check (admin only)
-    if (session.user.role !== 'admin') {
-      return NextResponse.json(
-        { error: 'Forbidden. Admin access required.' },
-        { status: 403 }
-      );
-    }
-
     // Parse and validate query parameters
     const searchParams = request.nextUrl.searchParams;
 
@@ -218,3 +192,5 @@ export async function GET(request: NextRequest) {
     );
   }
 }
+
+export const GET = withAdminAuth(withRateLimit('admin:read', handler));


### PR DESCRIPTION
## 概要

- `app/api/admin/jobs/` 配下 3 ルート（processing-logs / embedding-summary / article-stats）の手書き認証を `withAdminAuth(withRateLimit('admin:read', handler))` に統一
- DB-backed role 判定（Redis 120s TTL）・`deletedAt` ガード・rate-limit 保護を他 admin API と一貫化
- テスト戦略を `users.test.ts` の pass-through mock + `articles-actions.test.ts` の動的 import wiring 検証に刷新

Closes #589

## 実装内容

### Route（3 ファイル）
- `getSession` → `validateUser` → `role !== 'admin'` の手書き認証 22 行を削除
- `withAdminAuth(withRateLimit('admin:read', handler))` でラップして export
- ハンドラ本体（DB クエリ・集計・レスポンス整形）は無変更
- 合成順は `admin/users`, `admin/articles` (list) と統一。`admin/articles/[id]` の逆順合成は別 Issue 候補として記録

### Test（3 ファイル）
pass-through mock + 動的 import パターンに差し替え。以下 3 つの wiring 検証を追加:
1. `GET` が `withAdminAuth` でラップされて export されている
2. `withRateLimit` が `'admin:read'` キーで handler 関数を受けて呼ばれている
3. **合成順が `withAdminAuth(withRateLimit(...))` であること（逆順の回帰検知）** — `withAdminAuth` の第1引数が `withRateLimit` の戻り値と参照一致することで検証

`jest.setup.node.js` の `afterEach(() => jest.clearAllMocks())` に対応し、`beforeAll` 内で wiring 参照を変数にキャプチャする方式を採用。

## 挙動変更（重要）

### ✅ 改善
- JWT の stale role 問題が解消（Redis 120s TTL で role 降格が反映される）
- rate-limit 保護を追加（従来なし）

### ⚠️ 非機能変更（新規障害モード）
1. **エラーレスポンス JSON 構造変化**
   - 旧: `{ error: 'Unauthorized. Authentication required.' }`
   - 新: `{ error: 'Unauthorized', message: 'Authentication required.' }`
   - フロント影響: `app/dashboard/jobs/hooks/useJobsPolling.ts` は HTTP ステータスのみ参照するため影響なし
2. **成功時レスポンスに `X-RateLimit-*` ヘッダ追加**（`X-RateLimit-Limit/Remaining/Reset`）
3. **429 応答の新規発生**（`admin:read` は user 単位の共有バケット 60 req/min。既存の `admin:read` 利用エンドポイント、例: `/api/admin/users`, `/api/admin/articles`, `/api/sources`, `/api/sources/[id]` と利用枠を共有）
4. **Redis 障害時の 500 化**（`withRateLimit` は graceful degradation を持たない。`withAdminAuth` 側は DB フォールバック可）

### 📝 Issue DoD の補足
Issue #589 本文の DoD 「削除ユーザー（deletedAt 設定）が **403** 返却」は実装と不一致のため、本 PR では **401 (`code: 'USER_DELETED'`, `requiresLogout: true`)** で統一しています。`withAdminAuth` および既存の `createUserDeletedResponse` いずれも 401 を返す実装のため、これが source of truth として正となります。Issue 本文の当該記述は別途修正コメントを追加します。

## テスト結果

verify フェーズ全パス:

| Step | 結果 |
|------|------|
| Lint + Type Check | PASS (0 errors / 0 warnings) |
| Security Audit | PASS (0 vulnerabilities) |
| Docker Build | PASS |
| Unit Tests | PASS (processing-logs 10 / embedding-summary 8 / article-stats 9 = 27 tests) |
| Diff Review | PASS |
| Visual | SKIP (UI 変更なし) |

## 非対象（別 Issue 候補）

- `app/api/admin/social-posts/**` の統一化 → Issue #590 で対応
- admin API の逆順合成 `withRateLimit(withAdminAuth(handler))` の是正:
  - `app/api/admin/articles/[id]/route.ts`
  - `app/api/admin/users/[id]/route.ts`
  - `app/api/admin/articles/[id]/regenerate-summary/route.ts`
- `useJobsPolling` の 429 ハンドリング改善（現状は generic error としてポーリング継続）
- `withRateLimit` の Redis 障害時 graceful degradation

## チェックリスト

- [x] テスト通過（27/27 passed）
- [x] Build 通過
- [x] Lint/Type Check 通過
- [x] cross-review Full Tier (Codex + DA) 実施・反映済み
- [x] security-engineer レビュー実施・反映済み
- [x] 破壊的変更なし（正常系レスポンス・DB スキーマ無変更）

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 管理者向けAPI エンドポイントの認証・認可フロー を改善し、セキュリティ・メンテナンス性を向上させました。

* **Tests**
  * ミドルウェアベースの検証テストを導入し、エンドポイントの動作を包括的に検証するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->