### PR TITLE
fix(enrichers): hatena_blog_dev ソースで sourceId ベース enricher dispatch 導入

### DIFF
--- a/lib/enrichers/__tests__/hatena.test.ts
+++ b/lib/enrichers/__tests__/hatena.test.ts
@@ -59,10 +59,11 @@ describe('HatenaContentEnricher', () => {
       ).toBe(true);
     });
 
-    it('should match invalid URL when sourceId is hatena_blog_dev (sourceId優先)', () => {
-      // sourceId ベース判定は URL パースに依存しない
+    it('should NOT match invalid URL even when sourceId is hatena_blog_dev (fetcher契約違反時の最小防御)', () => {
+      // URL パース不可の場合は fetcher 側の異常として false を返し、
+      // Generic へのフォールスルーを維持する
       expect(enricher.canHandle('not-a-url', HATENA_BLOG_DEV_SOURCE_ID)).toBe(
-        true
+        false
       );
     });
 

--- a/lib/enrichers/__tests__/hatena.test.ts
+++ b/lib/enrichers/__tests__/hatena.test.ts
@@ -1,4 +1,8 @@
-import { HatenaContentEnricher, HATENA_CUSTOM_DOMAINS } from '../hatena';
+import {
+  HatenaContentEnricher,
+  HATENA_CUSTOM_DOMAINS,
+  HATENA_BLOG_DEV_SOURCE_ID,
+} from '../hatena';
 
 describe('HatenaContentEnricher', () => {
   const enricher = new HatenaContentEnricher();
@@ -33,6 +37,59 @@ describe('HatenaContentEnricher', () => {
 
     it('should return false for invalid URL', () => {
       expect(enricher.canHandle('not-a-url')).toBe(false);
+    });
+  });
+
+  describe('canHandle - sourceId-based dispatch', () => {
+    it('should match any URL when sourceId is hatena_blog_dev (allowlist未登録の独自ドメイン)', () => {
+      expect(
+        enricher.canHandle(
+          'https://blog.g-gen.co.jp/entry/next-26-keynote-day-1',
+          HATENA_BLOG_DEV_SOURCE_ID
+        )
+      ).toBe(true);
+    });
+
+    it('should match any URL when sourceId is hatena_blog_dev (techblog系)', () => {
+      expect(
+        enricher.canHandle(
+          'https://techblog.ap-com.co.jp/entry/kiro-cli-2.0-release',
+          HATENA_BLOG_DEV_SOURCE_ID
+        )
+      ).toBe(true);
+    });
+
+    it('should match invalid URL when sourceId is hatena_blog_dev (sourceId優先)', () => {
+      // sourceId ベース判定は URL パースに依存しない
+      expect(enricher.canHandle('not-a-url', HATENA_BLOG_DEV_SOURCE_ID)).toBe(
+        true
+      );
+    });
+
+    it('should fall back to URL-based check when sourceId is different', () => {
+      expect(
+        enricher.canHandle(
+          'https://blog.g-gen.co.jp/entry/test',
+          'some_other_source_id'
+        )
+      ).toBe(false);
+    });
+
+    it('should fall back to URL-based check when sourceId is undefined', () => {
+      // 既存呼び出し（sourceId未指定）との後方互換
+      expect(
+        enricher.canHandle('https://example.hatenablog.com/entry/123')
+      ).toBe(true);
+      expect(enricher.canHandle('https://blog.g-gen.co.jp/entry/test')).toBe(
+        false
+      );
+    });
+  });
+
+  describe('HATENA_BLOG_DEV_SOURCE_ID', () => {
+    it('should be the expected constant value', () => {
+      // collect-feeds.ts から渡される source.id と一致する必要がある
+      expect(HATENA_BLOG_DEV_SOURCE_ID).toBe('hatena_blog_dev');
     });
   });
 

--- a/lib/enrichers/__tests__/index.test.ts
+++ b/lib/enrichers/__tests__/index.test.ts
@@ -261,6 +261,34 @@ describe('ContentEnricherFactory', () => {
     });
   });
 
+  describe('getEnricher - sourceId-based dispatch', () => {
+    it('should return HatenaContentEnricher for allowlist-未登録独自ドメイン when sourceId=hatena_blog_dev', () => {
+      const enricher = factory.getEnricher(
+        'https://blog.g-gen.co.jp/entry/next-26-keynote-day-1',
+        'hatena_blog_dev'
+      );
+      expect(enricher?.constructor.name).toBe('HatenaContentEnricher');
+    });
+
+    it('should return GenericContentEnricher for allowlist-未登録独自ドメイン when sourceId is absent', () => {
+      // sourceId なしでは allowlist 未登録ドメインは Generic にフォールスルー（従来挙動）
+      const enricher = factory.getEnricher(
+        'https://blog.g-gen.co.jp/entry/next-26-keynote-day-1'
+      );
+      expect(enricher?.constructor.name).toBe('GenericContentEnricher');
+    });
+
+    it('should prefer dedicated enricher over Hatena even when sourceId=hatena_blog_dev', () => {
+      // sourceId='hatena_blog_dev' でも ZOZO 等の専用 enricher が先に評価される
+      // （実運用で hatena_blog_dev が ZOZO ドメインを収集することはないが、順序不変性の確認）
+      const enricher = factory.getEnricher(
+        'https://techblog.zozo.com/entry/test',
+        'hatena_blog_dev'
+      );
+      expect(enricher?.constructor.name).toBe('ZOZOContentEnricher');
+    });
+  });
+
   describe('AnthropicNewsEnricher boundary', () => {
     it('should NOT match /newsroom path', () => {
       const enricher = factory.getEnricher(

--- a/lib/enrichers/base.ts
+++ b/lib/enrichers/base.ts
@@ -30,8 +30,9 @@ export interface IContentEnricher {
   /**
    * このエンリッチャーが処理可能なURLかを判定
    * @param url チェック対象のURL
+   * @param sourceId 記事のsourceId (optional)。collect-feeds経由でsourceIdベースdispatchするenricherが利用する
    */
-  canHandle(url: string): boolean;
+  canHandle(url: string, sourceId?: string): boolean;
 }
 
 /**
@@ -92,7 +93,7 @@ export abstract class BaseContentEnricher implements IContentEnricher {
     }
   }
 
-  abstract canHandle(url: string): boolean;
+  abstract canHandle(url: string, sourceId?: string): boolean;
 
   // 既定の抽出セレクタと最小長
   protected getContentSelectors(): string[] {

--- a/lib/enrichers/hatena.ts
+++ b/lib/enrichers/hatena.ts
@@ -47,9 +47,16 @@ export class HatenaContentEnricher extends BaseContentEnricher {
    * 収集した記事のため、独自ドメイン allowlist に関わらず常に処理対象とする。
    */
   canHandle(url: string, sourceId?: string): boolean {
-    // sourceId ベース dispatch: hatena_blog_dev は全ドメインで Hatena enricher を使う
+    // sourceId ベース dispatch: hatena_blog_dev は URL パース可能な限り全ドメインで
+    // Hatena enricher を使う。URL パース不可の場合は fetcher 側の異常として false を返し、
+    // Generic へのフォールスルーを維持する（GraphQL API の契約が破れた際の最小防御）
     if (sourceId === HATENA_BLOG_DEV_SOURCE_ID) {
-      return true;
+      try {
+        new URL(url);
+        return true;
+      } catch {
+        return false;
+      }
     }
     try {
       const hostname = new URL(url).hostname;

--- a/lib/enrichers/hatena.ts
+++ b/lib/enrichers/hatena.ts
@@ -31,12 +31,26 @@ export const HATENA_CUSTOM_DOMAINS: readonly string[] = [
   'developer.so-tech.co.jp',
 ];
 
+/**
+ * hatena.blog/dev/entries 経由で収集される Source.id。
+ * この sourceId の記事は Hatena Blog ホストが保証されるため、
+ * URL の allowlist に関わらず HatenaContentEnricher で処理する。
+ */
+export const HATENA_BLOG_DEV_SOURCE_ID = 'hatena_blog_dev';
+
 export class HatenaContentEnricher extends BaseContentEnricher {
   /**
    * はてなブックマーク記事のURLかチェック
    * 注意: これは実際のコンテンツURLをチェック（はてなのURL自体ではない）
+   *
+   * sourceId='hatena_blog_dev' の場合は、ソースが Hatena Blog GraphQL API 経由で
+   * 収集した記事のため、独自ドメイン allowlist に関わらず常に処理対象とする。
    */
-  canHandle(url: string): boolean {
+  canHandle(url: string, sourceId?: string): boolean {
+    // sourceId ベース dispatch: hatena_blog_dev は全ドメインで Hatena enricher を使う
+    if (sourceId === HATENA_BLOG_DEV_SOURCE_ID) {
+      return true;
+    }
     try {
       const hostname = new URL(url).hostname;
       // Hatenaドメインのみを対象（完全一致またはサブドメイン）

--- a/lib/enrichers/index.ts
+++ b/lib/enrichers/index.ts
@@ -115,6 +115,12 @@ export class ContentEnricherFactory {
       // YouTube サムネイル生成（HTTPリクエスト不要、HackerNewsEnricherより後に配置）
       // HNソース以外のYouTube URLはここでキャッチ
       new YouTubeEnricher(),
+      // 注意: HatenaContentEnricher は sourceId='hatena_blog_dev' 時に無条件 true を
+      // 返すため、Hatena 系の専用 enricher（HatenaDeveloperContentEnricher 等）は
+      // 必ずこれより前に登録すること。順序を崩すと sourceId='hatena_blog_dev' で
+      // 先行するはずの専用 enricher が Hatena に吸われて到達不能になる。
+      // 回帰テスト: lib/enrichers/__tests__/index.test.ts の
+      //   "should prefer dedicated enricher over Hatena even when sourceId=hatena_blog_dev"
       new HatenaContentEnricher(), // 汎用HTMLパーサー
       new GenericContentEnricher(), // 最後のフォールバック（すべてのURLに対応）
       // 将来的に他の企業のエンリッチャーを追加

--- a/lib/enrichers/index.ts
+++ b/lib/enrichers/index.ts
@@ -126,10 +126,11 @@ export class ContentEnricherFactory {
   /**
    * URLに対応するエンリッチャーを取得
    * @param url 処理対象のURL
+   * @param sourceId 記事のsourceId (optional)。sourceIdベースdispatchするenricher（HatenaContentEnricher等）で利用
    * @returns 対応するエンリッチャー、またはnull
    */
-  getEnricher(url: string): IContentEnricher | null {
-    return this.enrichers.find((e) => e.canHandle(url)) || null;
+  getEnricher(url: string, sourceId?: string): IContentEnricher | null {
+    return this.enrichers.find((e) => e.canHandle(url, sourceId)) || null;
   }
 
   /**
@@ -157,15 +158,17 @@ export class ContentEnricherFactory {
   /**
    * 各エンリッチャーを順番に試して最初の成功結果を返す
    * @param url 処理対象のURL
+   * @param sourceId 記事のsourceId (optional)
    * @returns エンリッチメント結果、またはnull
    */
   async trySequential(
-    url: string
+    url: string,
+    sourceId?: string
   ): Promise<import('./base').EnrichmentResult | null> {
     // すべてのエンリッチャーを順番に試す
     for (const enricher of this.enrichers) {
       try {
-        if (enricher.canHandle(url)) {
+        if (enricher.canHandle(url, sourceId)) {
           const result = await enricher.enrich(url);
           if (result && (result.content || result.thumbnail)) {
             // 有効な結果が得られたら即座に返す

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -98,6 +98,7 @@ import { createFetcher } from '@/lib/fetchers';
 
 // エンリッチャーをインポート
 import { ContentEnricherFactory } from '@/lib/enrichers';
+import { HATENA_BLOG_DEV_SOURCE_ID } from '@/lib/enrichers/hatena';
 import { logger } from '@/lib/logger';
 import { isHighQuality } from '@/lib/enrichers/strategies/quality';
 
@@ -129,7 +130,6 @@ const debugLog = (message: string) => {
 const POST_SAVE_ENRICH_TIMEOUT_MS = env.POST_SAVE_ENRICH_TIMEOUT_MS;
 const POST_SAVE_ENRICH_SLEEP_MS = env.POST_SAVE_ENRICH_SLEEP_MS;
 const HATENA_BLOG_DEV_ENRICH_SLEEP_MS = env.HATENA_BLOG_DEV_ENRICH_SLEEP_MS;
-const HATENA_BLOG_DEV_SOURCE_ID = 'hatena_blog_dev';
 
 /**
  * ソース別の enrichment 後 sleep 値を決定
@@ -457,20 +457,22 @@ async function processSource({
               }
             } catch (enrichError) {
               // エラー失敗: status/errorCode/errorMessage を構造化して記録
-              // errorCode は TIMEOUT / ABORTED / HTTP_<status> / EXCEPTION の順で分類
+              // 分類優先順位: HTTP_<status> > TIMEOUT > ABORTED > EXCEPTION
+              // HTTP を最優先にすることで "HTTP 504: Gateway Timeout" 等の
+              // HTTP ステータス情報を TIMEOUT に吸わせない（観測性確保）
               const errorName = enrichError instanceof Error ? enrichError.name : '';
               const errorMessage = enrichError instanceof Error ? enrichError.message : String(enrichError);
+              const statusMatch = /HTTP\s+(\d{3})/i.exec(errorMessage);
               const isTimeout =
                 errorName === 'TimeoutError' ||
-                /timeout/i.test(errorMessage);
+                (!statusMatch && /\btimeout\b/i.test(errorMessage));
               const isAborted = errorName === 'AbortError';
-              const statusMatch = /HTTP\s+(\d{3})/i.exec(errorMessage);
-              const errorCode = isTimeout
-                ? 'TIMEOUT'
-                : isAborted
-                  ? 'ABORTED'
-                  : statusMatch
-                    ? `HTTP_${statusMatch[1]}`
+              const errorCode = statusMatch
+                ? `HTTP_${statusMatch[1]}`
+                : isTimeout
+                  ? 'TIMEOUT'
+                  : isAborted
+                    ? 'ABORTED'
                     : 'EXCEPTION';
               logger.warn(
                 {

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -98,6 +98,7 @@ import { createFetcher } from '@/lib/fetchers';
 
 // エンリッチャーをインポート
 import { ContentEnricherFactory } from '@/lib/enrichers';
+import { logger } from '@/lib/logger';
 import { isHighQuality } from '@/lib/enrichers/strategies/quality';
 
 /**
@@ -373,10 +374,10 @@ async function processSource({
         });
 
         if (env.SKIP_POST_SAVE_ENRICHMENT !== '1') {
-          const enricher = enricherFactory.getEnricher(article.url);
+          const enricher = enricherFactory.getEnricher(article.url, source.id);
           if (enricher) {
             try {
-              debugLog(`   [INFO] エンリッチメント実行: ${article.title.substring(0, 40)}...`);
+              debugLog(`   [INFO] エンリッチメント実行: ${article.title.substring(0, 40)}... (enricher=${enricher.constructor.name})`);
               const enrichedData = await runWithTimeout(
                 (signal) => enricher.enrich(article.url, signal),
                 POST_SAVE_ENRICH_TIMEOUT_MS,
@@ -441,10 +442,36 @@ async function processSource({
                   console.error('   [WARN] エンリッチメント失敗: コンテンツもサムネイルもなし');
                 }
               } else {
+                // データなし失敗: 観測性のためログを構造化
+                logger.warn(
+                  {
+                    url: article.url,
+                    sourceId: source.id,
+                    sourceName,
+                    enricher: enricher.constructor.name,
+                    errorCode: 'NO_DATA',
+                  },
+                  '[Enrichment] failed: no data returned'
+                );
                 console.error('   [WARN] エンリッチメント失敗: データなし');
               }
             } catch (enrichError) {
-              console.error('   [WARN] エンリッチメントエラー:', enrichError instanceof Error ? enrichError.message : String(enrichError));
+              // エラー失敗: status/errorCode/errorMessage を構造化して記録
+              const errorMessage = enrichError instanceof Error ? enrichError.message : String(enrichError);
+              const statusMatch = /HTTP\s+(\d{3})/i.exec(errorMessage);
+              logger.warn(
+                {
+                  url: article.url,
+                  sourceId: source.id,
+                  sourceName,
+                  enricher: enricher.constructor.name,
+                  errorCode: statusMatch ? `HTTP_${statusMatch[1]}` : 'EXCEPTION',
+                  status: statusMatch ? Number(statusMatch[1]) : undefined,
+                  errorMessage,
+                },
+                '[Enrichment] failed: exception thrown'
+              );
+              console.error('   [WARN] エンリッチメントエラー:', errorMessage);
             }
 
             const enrichSleepMs = resolveEnrichSleepMs(source.id);

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -457,16 +457,30 @@ async function processSource({
               }
             } catch (enrichError) {
               // エラー失敗: status/errorCode/errorMessage を構造化して記録
+              // errorCode は TIMEOUT / ABORTED / HTTP_<status> / EXCEPTION の順で分類
+              const errorName = enrichError instanceof Error ? enrichError.name : '';
               const errorMessage = enrichError instanceof Error ? enrichError.message : String(enrichError);
+              const isTimeout =
+                errorName === 'TimeoutError' ||
+                /timeout/i.test(errorMessage);
+              const isAborted = errorName === 'AbortError';
               const statusMatch = /HTTP\s+(\d{3})/i.exec(errorMessage);
+              const errorCode = isTimeout
+                ? 'TIMEOUT'
+                : isAborted
+                  ? 'ABORTED'
+                  : statusMatch
+                    ? `HTTP_${statusMatch[1]}`
+                    : 'EXCEPTION';
               logger.warn(
                 {
                   url: article.url,
                   sourceId: source.id,
                   sourceName,
                   enricher: enricher.constructor.name,
-                  errorCode: statusMatch ? `HTTP_${statusMatch[1]}` : 'EXCEPTION',
+                  errorCode,
                   status: statusMatch ? Number(statusMatch[1]) : undefined,
+                  errorName,
                   errorMessage,
                 },
                 '[Enrichment] failed: exception thrown'


### PR DESCRIPTION
## 概要

- `hatena_blog_dev` ソースが収集する Hatena Blog 独自ドメイン（40+）のうち `HATENA_CUSTOM_DOMAINS` allowlist 未登録ドメインが `GenericContentEnricher` にフォールスルーして失敗していた（直近7日で110件 CONTENT_FETCH_FAILED）
- `IContentEnricher.canHandle(url, sourceId?)` に sourceId をオプショナル引数として追加し、`HatenaContentEnricher` が `sourceId='hatena_blog_dev'` 時に無条件 true を返すことで、独自ドメイン全てを Hatena 専用経路で処理するよう構造的に修正
- Hacker News 副因（外部URL失敗）の本格対応はスコープ外とし、本PRでは enrichment 失敗ログの構造化のみ実施（後日の切り分け用）

## 背景・関連PR

- 調査レポート: `.workflow/docs/investigate/investigate_20260424_211839_802_content_fetch_failed_recurrence.md`
- 計画書: `.workflow/docs/plan/plan_20260424_213714_057_content_fetch_failed_fix.md`
- 実装レポート: `.workflow/docs/implement/implement_20260424_213714_057_content_fetch_failed_fix.md`
- 関連: PR #598（hatena_blog_dev CONTENT_FETCH_FAILED 率低下対策、allowlist 10ドメイン追加）の後続対応

## 実装内容

### 構造変更

- `IContentEnricher.canHandle` と `BaseContentEnricher` abstract に `sourceId?: string` オプショナル引数を追加
- TypeScript 関数サブタイピングにより、32 concrete enricher 実装（`canHandle(url)` 形式）は変更不要で型適合（`tsc --noEmit` で確認）
- `HatenaContentEnricher.canHandle` で `sourceId === 'hatena_blog_dev'` 時に無条件 true。ただし URL パース不可の場合は false を返し、fetcher 契約違反時に Generic フォールスルーで最小防御
- `HATENA_BLOG_DEV_SOURCE_ID` 定数を `lib/enrichers/hatena.ts` から export し、テストから参照
- `ContentEnricherFactory.getEnricher` / `trySequential` に sourceId を伝播
- `scripts/scheduled/collect-feeds.ts:376` の呼び出しを `getEnricher(article.url, source.id)` に更新

### ログ拡充（HN副因の観測性向上）

- post-save enrichment 失敗ログを `logger.warn` で構造化し、`errorCode` を `TIMEOUT` / `ABORTED` / `HTTP_<status>` / `EXCEPTION` / `NO_DATA` に分類
- `url` / `sourceId` / `sourceName` / `enricher`（選択された enricher クラス名）/ `status` / `errorName` / `errorMessage` を同時記録

### 配置順制約の明示

- `HatenaContentEnricher` は Factory 内で後方に配置されているため、Hatena 系の専用 enricher（HatenaDeveloperContentEnricher 等）が先行する必要がある旨をコメントで明示し、回帰テストへの参照を付与

## スコープ外（別Issue候補）

- 再エンリッチ系・手動追加系（`re-enrich-content.ts`, `enrich-existing-hatena-articles.ts`, `article-manual-adder.ts` 等15+箇所）への sourceId 伝播
- 既存失敗記事156件の再 enrichment（ユーザー合意済み）
- Hacker News 外部URL失敗の本格対応（早期スキップの factory 改造、`EXTERNAL_UNFETCHABLE` enum 追加など）
- `HATENA_CUSTOM_DOMAINS` allowlist の削減（RSS経路との後方互換のため残存）

## テスト結果（verify通過）

- **Lint**: 0 errors, 0 warnings
- **Type-check**: PASS
- **Build**: Compiled with warnings（既存の PrismaClient インポート警告のみ、本PRと無関係）
- **Audit**: 3 moderate vulnerabilities（svix/resend/uuid、既存）
- **Tests**:
  - `lib/enrichers/__tests__/hatena.test.ts`: **24 passed**（新規 sourceId 分岐テスト5件追加）
  - `lib/enrichers/__tests__/index.test.ts`: **51 passed**（新規 factory sourceId 分岐テスト3件追加）

## 実機検証（手元実測）

PR前にローカル環境で allowlist 未登録ドメイン3件を対象に、`sourceId='hatena_blog_dev'` 指定時の enricher dispatch と本文取得を手元実測で確認（参考値）:

| URL | 修正前 (sourceId未指定) | 修正後 (sourceId='hatena_blog_dev') |
|---|---|---|
| `blog.g-gen.co.jp/entry/next-26-keynote-day-1` | GenericContentEnricher / NULL (3049ms) | HatenaContentEnricher / **14,343文字 + サムネイル** (912ms) |
| `techblog.ap-com.co.jp/entry/kiro-cli-2.0-release` | (従来失敗) | HatenaContentEnricher / **3,326文字 + サムネイル** (1683ms) |
| `www.m3tech.blog/entry/2026/04/23/110322` | (従来失敗) | HatenaContentEnricher / **4,610文字 + サムネイル** (1769ms) |

※ 数値は手元実測で再現性ありだが、外部サイトの応答状況により時間は変動する。

## 事後確認計画

マージ後 2-3日で DB 確認し、企業技術ブログの日次 CONTENT_FETCH_FAILED 件数が5件以下に低下することを目標。達成できない場合は allowlist 手動拡張（選択肢C）を追加検討。

## チェックリスト

- [x] verify フェーズ通過（lint/type-check/audit/build/test/diff-review）
- [x] cross-review（Codex + Devil's Advocate）実施、HIGH/Warning指摘を反映
- [x] typescript-reviewer 設計レビュー反映
- [x] 実機検証で allowlist 未登録ドメインでの取得成功を確認（手元実測）
- [x] 破壊的変更なし（オプショナル引数で後方互換）
- [x] DB スキーマ変更なし
- [x] 環境変数追加なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * コンテンツエンリッチャーのフィード配信元別処理に関するテストカバレッジを追加。

* **改善**
  * フィード配信元に応じた適切なエンリッチャー選択機能を強化。
  * フィード収集時のエラーログを強化し、詳細なコンテキスト情報（配信元ID、エンリッチャー名等）を記録。
  * エラー分類（タイムアウト、中止、HTTPステータス等）の精度を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->