### PR TITLE
fix(enrichers): Issue #605 sourceId 伝播の横展開 + logEnrichmentError 拡張

### DIFF
--- a/lib/enrichers/__tests__/base.test.ts
+++ b/lib/enrichers/__tests__/base.test.ts
@@ -329,7 +329,7 @@ describe('BaseContentEnricher', () => {
           url: testUrl,
           enricher: 'TestContentEnricher',
           err: expect.any(Error),
-          status: 'failed',
+          errorCode: expect.any(String),
         }),
         '[Enrichment] failed'
       );
@@ -363,6 +363,86 @@ describe('BaseContentEnricher', () => {
 
       expect(loggerSpy).toHaveBeenCalledTimes(1);
       expect(loggerSpy.mock.calls[0][1]).toBe('[Enrichment] failed');
+
+      loggerSpy.mockRestore();
+    });
+
+    it('should classify error and emit errorCode + errorName + errorMessage', async () => {
+      const loggerSpy = jest
+        .spyOn(logger, 'error')
+        .mockImplementation(() => {});
+      enricher.setShouldFail(true);
+
+      await enricher.enrich(testUrl);
+
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+      const logged = loggerSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(logged.errorCode).toBe('EXCEPTION');
+      expect(typeof logged.errorName).toBe('string');
+      expect(typeof logged.errorMessage).toBe('string');
+
+      loggerSpy.mockRestore();
+    });
+
+    it('should omit sourceId/sourceName when options is not provided', async () => {
+      const loggerSpy = jest
+        .spyOn(logger, 'error')
+        .mockImplementation(() => {});
+      enricher.setShouldFail(true);
+
+      await enricher.enrich(testUrl);
+
+      const logged = loggerSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(logged).not.toHaveProperty('sourceId');
+      expect(logged).not.toHaveProperty('sourceName');
+
+      loggerSpy.mockRestore();
+    });
+
+    it('should include sourceId/sourceName when options is provided', () => {
+      const loggerSpy = jest
+        .spyOn(logger, 'error')
+        .mockImplementation(() => {});
+
+      // protected メソッドを直接テストするため subclass 経由でアクセス
+      class ExposedEnricher extends TestContentEnricher {
+        public callLog(
+          url: string,
+          error: unknown,
+          options?: { sourceId?: string; sourceName?: string }
+        ): void {
+          this.logEnrichmentError(url, error, options);
+        }
+      }
+      const exposed = new ExposedEnricher();
+      exposed.callLog(testUrl, new Error('boom'), {
+        sourceId: 'src-123',
+        sourceName: 'TestSource',
+      });
+
+      const logged = loggerSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(logged.sourceId).toBe('src-123');
+      expect(logged.sourceName).toBe('TestSource');
+
+      loggerSpy.mockRestore();
+    });
+
+    it('should classify HTTP error message as HTTP_<status>', () => {
+      const loggerSpy = jest
+        .spyOn(logger, 'error')
+        .mockImplementation(() => {});
+
+      class ExposedEnricher extends TestContentEnricher {
+        public callLog(url: string, error: unknown): void {
+          this.logEnrichmentError(url, error);
+        }
+      }
+      const exposed = new ExposedEnricher();
+      exposed.callLog(testUrl, new Error('HTTP 503: Service Unavailable'));
+
+      const logged = loggerSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(logged.errorCode).toBe('HTTP_503');
+      expect(logged.status).toBe(503);
 
       loggerSpy.mockRestore();
     });

--- a/lib/enrichers/__tests__/base.test.ts
+++ b/lib/enrichers/__tests__/base.test.ts
@@ -315,6 +315,19 @@ describe('BaseContentEnricher', () => {
   });
 
   describe('logEnrichmentError', () => {
+    // ExposedEnricher: protected logEnrichmentError を直接呼び出すための subclass
+    // setShouldFail(true) は Error('Network error') を throw するため
+    // classifier の fallback で 'EXCEPTION' に分類される
+    class ExposedEnricher extends TestContentEnricher {
+      public callLog(
+        url: string,
+        error: unknown,
+        options?: { sourceId?: string; sourceName?: string }
+      ): void {
+        this.logEnrichmentError(url, error, options);
+      }
+    }
+
     it('should log error when enrichment fails', async () => {
       const loggerSpy = jest
         .spyOn(logger, 'error')
@@ -329,7 +342,7 @@ describe('BaseContentEnricher', () => {
           url: testUrl,
           enricher: 'TestContentEnricher',
           err: expect.any(Error),
-          errorCode: expect.any(String),
+          errorCode: 'EXCEPTION',
         }),
         '[Enrichment] failed'
       );
@@ -404,16 +417,6 @@ describe('BaseContentEnricher', () => {
         .spyOn(logger, 'error')
         .mockImplementation(() => {});
 
-      // protected メソッドを直接テストするため subclass 経由でアクセス
-      class ExposedEnricher extends TestContentEnricher {
-        public callLog(
-          url: string,
-          error: unknown,
-          options?: { sourceId?: string; sourceName?: string }
-        ): void {
-          this.logEnrichmentError(url, error, options);
-        }
-      }
       const exposed = new ExposedEnricher();
       exposed.callLog(testUrl, new Error('boom'), {
         sourceId: 'src-123',
@@ -432,11 +435,6 @@ describe('BaseContentEnricher', () => {
         .spyOn(logger, 'error')
         .mockImplementation(() => {});
 
-      class ExposedEnricher extends TestContentEnricher {
-        public callLog(url: string, error: unknown): void {
-          this.logEnrichmentError(url, error);
-        }
-      }
       const exposed = new ExposedEnricher();
       exposed.callLog(testUrl, new Error('HTTP 503: Service Unavailable'));
 

--- a/lib/enrichers/__tests__/error-classifier.test.ts
+++ b/lib/enrichers/__tests__/error-classifier.test.ts
@@ -1,0 +1,95 @@
+import { classifyEnrichmentError } from '../error-classifier';
+
+describe('classifyEnrichmentError', () => {
+  describe('HTTP status 分類（最優先）', () => {
+    it('should classify HTTP 504 from message', () => {
+      const result = classifyEnrichmentError(
+        new Error('HTTP 504: Gateway Timeout')
+      );
+      expect(result.errorCode).toBe('HTTP_504');
+      expect(result.status).toBe(504);
+      expect(result.errorMessage).toBe('HTTP 504: Gateway Timeout');
+    });
+
+    it('should classify HTTP 404 from message', () => {
+      const result = classifyEnrichmentError(new Error('HTTP 404: Not Found'));
+      expect(result.errorCode).toBe('HTTP_404');
+      expect(result.status).toBe(404);
+    });
+
+    it('should prioritize HTTP over TIMEOUT keyword', () => {
+      // "HTTP 504: Gateway Timeout" は HTTP_504 として分類される
+      // （TIMEOUT に吸わせない）
+      const result = classifyEnrichmentError(
+        new Error('HTTP 504: Gateway Timeout')
+      );
+      expect(result.errorCode).toBe('HTTP_504');
+    });
+  });
+
+  describe('TIMEOUT 分類', () => {
+    it('should classify TimeoutError by name', () => {
+      const error = new Error('Operation timed out');
+      error.name = 'TimeoutError';
+      const result = classifyEnrichmentError(error);
+      expect(result.errorCode).toBe('TIMEOUT');
+      expect(result.status).toBeUndefined();
+      expect(result.errorName).toBe('TimeoutError');
+    });
+
+    it('should classify by timeout keyword in message', () => {
+      const result = classifyEnrichmentError(
+        new Error('connection timeout occurred')
+      );
+      expect(result.errorCode).toBe('TIMEOUT');
+    });
+  });
+
+  describe('ABORTED 分類', () => {
+    it('should classify AbortError by name', () => {
+      const error = new Error('Aborted');
+      error.name = 'AbortError';
+      const result = classifyEnrichmentError(error);
+      expect(result.errorCode).toBe('ABORTED');
+      expect(result.errorName).toBe('AbortError');
+    });
+  });
+
+  describe('EXCEPTION 分類（フォールバック）', () => {
+    it('should classify generic Error as EXCEPTION', () => {
+      const result = classifyEnrichmentError(new Error('Something went wrong'));
+      expect(result.errorCode).toBe('EXCEPTION');
+      expect(result.status).toBeUndefined();
+    });
+
+    it('should handle non-Error string value', () => {
+      const result = classifyEnrichmentError('plain string error');
+      expect(result.errorCode).toBe('EXCEPTION');
+      expect(result.errorName).toBe('');
+      expect(result.errorMessage).toBe('plain string error');
+    });
+
+    it('should handle undefined', () => {
+      const result = classifyEnrichmentError(undefined);
+      expect(result.errorCode).toBe('EXCEPTION');
+      expect(result.errorName).toBe('');
+      expect(result.errorMessage).toBe('undefined');
+    });
+
+    it('should handle null', () => {
+      const result = classifyEnrichmentError(null);
+      expect(result.errorCode).toBe('EXCEPTION');
+      expect(result.errorMessage).toBe('null');
+    });
+  });
+
+  describe('errorName / errorMessage の保持', () => {
+    it('should preserve original error name and message', () => {
+      const error = new TypeError('Invalid type');
+      const result = classifyEnrichmentError(error);
+      expect(result.errorName).toBe('TypeError');
+      expect(result.errorMessage).toBe('Invalid type');
+      expect(result.errorCode).toBe('EXCEPTION');
+    });
+  });
+});

--- a/lib/enrichers/__tests__/error-classifier.test.ts
+++ b/lib/enrichers/__tests__/error-classifier.test.ts
@@ -92,4 +92,41 @@ describe('classifyEnrichmentError', () => {
       expect(result.errorCode).toBe('EXCEPTION');
     });
   });
+
+  describe('機密情報のサニタイズ', () => {
+    it('should redact OpenAI API key in errorMessage', () => {
+      const result = classifyEnrichmentError(
+        new Error('API key sk-abcdefghij1234567890ABCDEFGHIJ is invalid')
+      );
+      expect(result.errorMessage).not.toContain('sk-abcdef');
+      expect(result.errorMessage).toContain('[REDACTED:API_KEY]');
+    });
+
+    it('should redact Gemini API key in errorMessage', () => {
+      const result = classifyEnrichmentError(
+        new Error('Auth failed for AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdef')
+      );
+      expect(result.errorMessage).not.toContain('AIzaSyA');
+      expect(result.errorMessage).toContain('[REDACTED:GEMINI_KEY]');
+    });
+
+    it('should redact Bearer token in errorMessage', () => {
+      const result = classifyEnrichmentError(
+        new Error('Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig')
+      );
+      expect(result.errorMessage).not.toContain('eyJhbGciOiJIUzI1NiJ9');
+      expect(result.errorMessage).toContain('Bearer [REDACTED]');
+    });
+
+    it('should preserve HTTP_<status> classification on sanitized message', () => {
+      const result = classifyEnrichmentError(
+        new Error(
+          'HTTP 401: Unauthorized for sk-abcdefghij1234567890ABCDEFGHIJ'
+        )
+      );
+      expect(result.errorCode).toBe('HTTP_401');
+      expect(result.status).toBe(401);
+      expect(result.errorMessage).toContain('[REDACTED:API_KEY]');
+    });
+  });
 });

--- a/lib/enrichers/__tests__/error-classifier.test.ts
+++ b/lib/enrichers/__tests__/error-classifier.test.ts
@@ -43,6 +43,36 @@ describe('classifyEnrichmentError', () => {
       );
       expect(result.errorCode).toBe('TIMEOUT');
     });
+
+    it('should classify undici HeadersTimeoutError as TIMEOUT', () => {
+      const error = new Error('Headers timeout');
+      error.name = 'HeadersTimeoutError';
+      const result = classifyEnrichmentError(error);
+      expect(result.errorCode).toBe('TIMEOUT');
+      expect(result.errorName).toBe('HeadersTimeoutError');
+    });
+
+    it('should classify undici BodyTimeoutError as TIMEOUT', () => {
+      const error = new Error('Body timeout');
+      error.name = 'BodyTimeoutError';
+      const result = classifyEnrichmentError(error);
+      expect(result.errorCode).toBe('TIMEOUT');
+    });
+
+    it('should classify undici ConnectTimeoutError as TIMEOUT', () => {
+      const error = new Error('Connect timeout');
+      error.name = 'ConnectTimeoutError';
+      const result = classifyEnrichmentError(error);
+      expect(result.errorCode).toBe('TIMEOUT');
+    });
+
+    it('should NOT classify substring "timeoutid" (no word boundary) as TIMEOUT', () => {
+      // \btimeout\b は word boundary を要求するため "timeoutid" は match しない
+      const result = classifyEnrichmentError(
+        new Error('set timeoutid was cleared')
+      );
+      expect(result.errorCode).toBe('EXCEPTION');
+    });
   });
 
   describe('ABORTED 分類', () => {
@@ -99,6 +129,22 @@ describe('classifyEnrichmentError', () => {
         new Error('API key sk-abcdefghij1234567890ABCDEFGHIJ is invalid')
       );
       expect(result.errorMessage).not.toContain('sk-abcdef');
+      expect(result.errorMessage).toContain('[REDACTED:API_KEY]');
+    });
+
+    it('should redact hyphenated OpenAI project key (sk-proj-)', () => {
+      const result = classifyEnrichmentError(
+        new Error('Auth failed for sk-proj-abcdefghij1234567890ABCDEFGHIJ')
+      );
+      expect(result.errorMessage).not.toContain('sk-proj-abc');
+      expect(result.errorMessage).toContain('[REDACTED:API_KEY]');
+    });
+
+    it('should redact hyphenated OpenAI service-account key (sk-svcacct-)', () => {
+      const result = classifyEnrichmentError(
+        new Error('Auth failed for sk-svcacct-abcdefghij1234567890ABCDEFGHIJ')
+      );
+      expect(result.errorMessage).not.toContain('sk-svcacct-abc');
       expect(result.errorMessage).toContain('[REDACTED:API_KEY]');
     });
 

--- a/lib/enrichers/base.ts
+++ b/lib/enrichers/base.ts
@@ -5,6 +5,7 @@
 
 import * as cheerio from 'cheerio';
 import logger from '@/lib/logger';
+import { classifyEnrichmentError } from './error-classifier';
 
 /**
  * エンリッチされたコンテンツのデータ構造
@@ -358,15 +359,34 @@ export abstract class BaseContentEnricher implements IContentEnricher {
   }
 
   /**
-   * Enrichment失敗時のエラーログ
+   * Enrichment失敗時のエラーログ（errorCode 分類付き構造化ログ）
+   *
+   * @param url 失敗対象のURL
+   * @param error スローされた例外
+   * @param options sourceId / sourceName を渡せば caller 側ログと同等の構造化情報になる。
+   *                BaseContentEnricher の既定実装は this.source.id を持たないため、
+   *                既定実装からの呼び出しでは省略され、5 個の継承勢（hatena-developer,
+   *                pepabo, recruit, sansan, zozo）からは sourceId なしでログが出力される。
    */
-  protected logEnrichmentError(url: string, error: unknown): void {
+  protected logEnrichmentError(
+    url: string,
+    error: unknown,
+    options?: { sourceId?: string; sourceName?: string }
+  ): void {
+    const classified = classifyEnrichmentError(error);
     logger.error(
       {
         url,
         enricher: this.constructor.name,
         err: error instanceof Error ? error : new Error(String(error)),
-        status: 'failed',
+        errorCode: classified.errorCode,
+        status: classified.status,
+        errorName: classified.errorName,
+        errorMessage: classified.errorMessage,
+        ...(options?.sourceId !== undefined && { sourceId: options.sourceId }),
+        ...(options?.sourceName !== undefined && {
+          sourceName: options.sourceName,
+        }),
       },
       '[Enrichment] failed'
     );

--- a/lib/enrichers/error-classifier.ts
+++ b/lib/enrichers/error-classifier.ts
@@ -20,6 +20,7 @@ export type EnrichmentErrorCode =
   | `HTTP_${number}`
   | 'TIMEOUT'
   | 'ABORTED'
+  | 'NO_DATA'
   | 'EXCEPTION';
 
 export interface ClassifiedEnrichmentError {
@@ -41,14 +42,16 @@ export function classifyEnrichmentError(
   const statusMatch = /HTTP\s+(\d{3})/i.exec(rawMessage);
   const status = statusMatch ? Number(statusMatch[1]) : undefined;
 
+  // undici 由来の HeadersTimeoutError / BodyTimeoutError / ConnectTimeoutError
+  // も TIMEOUT として分類する（fetchWithRetry が undici fetch を呼ぶため）
   const isTimeout =
-    errorName === 'TimeoutError' ||
+    /TimeoutError$/i.test(errorName) ||
     (!statusMatch && /\btimeout\b/i.test(errorMessage));
   const isAborted = errorName === 'AbortError';
 
   let errorCode: EnrichmentErrorCode;
-  if (statusMatch) {
-    errorCode = `HTTP_${statusMatch[1]}` as EnrichmentErrorCode;
+  if (status !== undefined) {
+    errorCode = `HTTP_${status}`;
   } else if (isTimeout) {
     errorCode = 'TIMEOUT';
   } else if (isAborted) {

--- a/lib/enrichers/error-classifier.ts
+++ b/lib/enrichers/error-classifier.ts
@@ -14,7 +14,7 @@
  * トークン除去を行う。
  */
 
-import { sanitizeErrorMessage } from '@/lib/logger';
+import { sanitizeErrorMessage } from '@/lib/utils/sanitize-error';
 
 export type EnrichmentErrorCode =
   | `HTTP_${number}`

--- a/lib/enrichers/error-classifier.ts
+++ b/lib/enrichers/error-classifier.ts
@@ -1,0 +1,57 @@
+/**
+ * Enrichment エラーの構造化分類ヘルパー
+ *
+ * 例外の name / message から errorCode を分類する。
+ * collect-feeds.ts の post-save enrichment outer catch と
+ * BaseContentEnricher.logEnrichmentError の両方から共通利用される。
+ *
+ * 分類優先順位: HTTP_<status> > TIMEOUT > ABORTED > EXCEPTION
+ * HTTP を最優先することで "HTTP 504: Gateway Timeout" 等の
+ * HTTP ステータス情報を TIMEOUT に吸わせない（観測性確保）。
+ */
+
+export type EnrichmentErrorCode =
+  | `HTTP_${number}`
+  | 'TIMEOUT'
+  | 'ABORTED'
+  | 'EXCEPTION';
+
+export interface ClassifiedEnrichmentError {
+  errorCode: EnrichmentErrorCode;
+  status?: number;
+  errorName: string;
+  errorMessage: string;
+}
+
+export function classifyEnrichmentError(
+  error: unknown
+): ClassifiedEnrichmentError {
+  const errorName = error instanceof Error ? error.name : '';
+  const errorMessage = error instanceof Error ? error.message : String(error);
+
+  const statusMatch = /HTTP\s+(\d{3})/i.exec(errorMessage);
+  const status = statusMatch ? Number(statusMatch[1]) : undefined;
+
+  const isTimeout =
+    errorName === 'TimeoutError' ||
+    (!statusMatch && /\btimeout\b/i.test(errorMessage));
+  const isAborted = errorName === 'AbortError';
+
+  let errorCode: EnrichmentErrorCode;
+  if (statusMatch) {
+    errorCode = `HTTP_${statusMatch[1]}` as EnrichmentErrorCode;
+  } else if (isTimeout) {
+    errorCode = 'TIMEOUT';
+  } else if (isAborted) {
+    errorCode = 'ABORTED';
+  } else {
+    errorCode = 'EXCEPTION';
+  }
+
+  return {
+    errorCode,
+    status,
+    errorName,
+    errorMessage,
+  };
+}

--- a/lib/enrichers/error-classifier.ts
+++ b/lib/enrichers/error-classifier.ts
@@ -8,7 +8,13 @@
  * 分類優先順位: HTTP_<status> > TIMEOUT > ABORTED > EXCEPTION
  * HTTP を最優先することで "HTTP 504: Gateway Timeout" 等の
  * HTTP ステータス情報を TIMEOUT に吸わせない（観測性確保）。
+ *
+ * セキュリティ: errorMessage は pino の `err` serializer (sanitizeError) を
+ * 経由しないため、API キー等を露出させないよう sanitizeErrorMessage で
+ * トークン除去を行う。
  */
+
+import { sanitizeErrorMessage } from '@/lib/logger';
 
 export type EnrichmentErrorCode =
   | `HTTP_${number}`
@@ -27,9 +33,12 @@ export function classifyEnrichmentError(
   error: unknown
 ): ClassifiedEnrichmentError {
   const errorName = error instanceof Error ? error.name : '';
-  const errorMessage = error instanceof Error ? error.message : String(error);
+  const rawMessage = error instanceof Error ? error.message : String(error);
+  const errorMessage = sanitizeErrorMessage(rawMessage);
 
-  const statusMatch = /HTTP\s+(\d{3})/i.exec(errorMessage);
+  // statusMatch は HTTP ステータス検出のため raw 値を使用
+  // (sanitizer は HTTP <status> パターンを置換しない)
+  const statusMatch = /HTTP\s+(\d{3})/i.exec(rawMessage);
   const status = statusMatch ? Number(statusMatch[1]) : undefined;
 
   const isTimeout =

--- a/lib/fetchers/cloudflare-blog.ts
+++ b/lib/fetchers/cloudflare-blog.ts
@@ -80,7 +80,10 @@ export class CloudflareBlogFetcher extends BaseFetcher {
 
           // コンテンツエンリッチメント（2000文字未満の場合のみ実行）
           if (content && content.length < 2000) {
-            const enricher = enricherFactory.getEnricher(item.link);
+            const enricher = enricherFactory.getEnricher(
+              item.link,
+              this.source.id
+            );
             if (enricher) {
               try {
                 const enrichedData = await enricher.enrich(item.link);

--- a/lib/fetchers/corporate-tech-blog.ts
+++ b/lib/fetchers/corporate-tech-blog.ts
@@ -172,7 +172,10 @@ export class CorporateTechBlogFetcher extends BaseFetcher {
             // コンテンツエンリッチメント（2000文字未満の場合は常に試みる）
             let thumbnail: string | undefined;
             if (content && content.length < 2000) {
-              const enricher = enricherFactory.getEnricher(item.link);
+              const enricher = enricherFactory.getEnricher(
+                item.link,
+                this.source.id
+              );
               if (enricher) {
                 try {
                   const enrichedData = await enricher.enrich(item.link);

--- a/lib/fetchers/github-blog.ts
+++ b/lib/fetchers/github-blog.ts
@@ -80,7 +80,10 @@ export class GitHubBlogFetcher extends BaseFetcher {
 
           // コンテンツエンリッチメント（2000文字未満の場合のみ実行）
           if (content && content.length < 2000) {
-            const enricher = enricherFactory.getEnricher(item.link);
+            const enricher = enricherFactory.getEnricher(
+              item.link,
+              this.source.id
+            );
             if (enricher) {
               try {
                 const enrichedData = await enricher.enrich(item.link);

--- a/lib/fetchers/google-dev-blog.ts
+++ b/lib/fetchers/google-dev-blog.ts
@@ -144,7 +144,7 @@ export class GoogleDevBlogFetcher extends BaseFetcher {
 
     // コンテンツエンリッチメント（2000文字未満の場合のみ実行）
     if (content && content.length < 2000) {
-      const enricher = enricherFactory.getEnricher(item.link);
+      const enricher = enricherFactory.getEnricher(item.link, this.source.id);
       if (enricher) {
         try {
           const enrichedData = await enricher.enrich(item.link);

--- a/lib/fetchers/medium-engineering.ts
+++ b/lib/fetchers/medium-engineering.ts
@@ -126,7 +126,10 @@ export class MediumEngineeringFetcher extends BaseFetcher {
 
             // Medium記事のコンテンツエンリッチメント
             if (content && content.length < 2000) {
-              const enricher = enricherFactory.getEnricher(cleanUrl);
+              const enricher = enricherFactory.getEnricher(
+                cleanUrl,
+                this.source.id
+              );
               if (enricher) {
                 try {
                   const enrichedData = await enricher.enrich(cleanUrl);

--- a/lib/fetchers/medium-engineering.ts
+++ b/lib/fetchers/medium-engineering.ts
@@ -5,6 +5,7 @@ import Parser from 'rss-parser';
 import { parseRSSDate } from '@/lib/utils/date';
 import { extractContent } from '@/lib/utils/content/content-extractor';
 import { ContentEnricherFactory } from '@/lib/enrichers';
+import { classifyEnrichmentError } from '@/lib/enrichers/error-classifier';
 import { normalizeTagInput } from '@/lib/utils/tag/tag-normalizer';
 import logger from '@/lib/logger';
 
@@ -145,8 +146,21 @@ export class MediumEngineeringFetcher extends BaseFetcher {
                     }
                   }
                 } catch (_error) {
+                  const classified = classifyEnrichmentError(_error);
                   logger.error(
-                    { err: _error },
+                    {
+                      err:
+                        _error instanceof Error
+                          ? _error
+                          : new Error(String(_error)),
+                      url: cleanUrl,
+                      sourceId: this.source.id,
+                      sourceName: this.source.name,
+                      errorCode: classified.errorCode,
+                      status: classified.status,
+                      errorName: classified.errorName,
+                      errorMessage: classified.errorMessage,
+                    },
                     `[Medium Engineering] Enrichment failed for ${cleanUrl}`
                   );
                 }

--- a/lib/fetchers/mozilla-hacks.ts
+++ b/lib/fetchers/mozilla-hacks.ts
@@ -80,7 +80,10 @@ export class MozillaHacksFetcher extends BaseFetcher {
 
           // コンテンツエンリッチメント（2000文字未満の場合のみ実行）
           if (content && content.length < 2000) {
-            const enricher = enricherFactory.getEnricher(item.link);
+            const enricher = enricherFactory.getEnricher(
+              item.link,
+              this.source.id
+            );
             if (enricher) {
               try {
                 const enrichedData = await enricher.enrich(item.link);

--- a/lib/fetchers/publickey.ts
+++ b/lib/fetchers/publickey.ts
@@ -5,6 +5,7 @@ import { FetchResult } from '@/types/fetchers';
 import { CreateArticleInput } from '@/types';
 import { parseRSSDate } from '@/lib/utils/date';
 import { ContentEnricherFactory } from '@/lib/enrichers';
+import { classifyEnrichmentError } from '@/lib/enrichers/error-classifier';
 import logger from '@/lib/logger';
 import { extractTagsFromCategories } from '@/lib/utils/tag/tag-extractor';
 
@@ -128,12 +129,18 @@ export class PublickeyFetcher extends BaseFetcher {
               }
               // else: RSS 100-199 chars, Enricher failed -> use RSS content (intentional)
             } catch (enrichError) {
+              const classified = classifyEnrichmentError(enrichError);
               logger.error(
                 {
                   err: enrichError,
                   url: item.link,
                   title: item.title,
                   rssContentLength,
+                  sourceId: this.source.id,
+                  errorCode: classified.errorCode,
+                  status: classified.status,
+                  errorName: classified.errorName,
+                  errorMessage: classified.errorMessage,
                 },
                 '[Publickey] Enrichment error'
               );

--- a/lib/fetchers/publickey.ts
+++ b/lib/fetchers/publickey.ts
@@ -88,7 +88,8 @@ export class PublickeyFetcher extends BaseFetcher {
 
               const enricherFactory = new ContentEnricherFactory();
               const enrichedData = await enricherFactory.trySequential(
-                item.link
+                item.link,
+                this.source.id
               );
 
               // サムネイルはコンテンツ条件に関わらず独立して取得

--- a/lib/fetchers/zenn-extended.ts
+++ b/lib/fetchers/zenn-extended.ts
@@ -119,7 +119,7 @@ export class ZennExtendedFetcher extends BaseFetcher {
 
     // エンリッチメント処理
     if (item.link && enricherFactory) {
-      const enricher = enricherFactory.getEnricher(item.link);
+      const enricher = enricherFactory.getEnricher(item.link, this.source.id);
       if (enricher) {
         try {
           const currentContent = article.content || '';

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -27,49 +27,32 @@ export function hashSensitiveValue(value: unknown): string {
 }
 
 /**
+ * Remove sensitive tokens (API keys, Bearer tokens) from a free-form string.
+ * Exposed so that構造化ログの error 派生フィールド (errorMessage 等) が
+ * pino の err シリアライザを経由しないケースでも sanitization を適用できる。
+ */
+export function sanitizeErrorMessage(message: string): string {
+  return (
+    message
+      // OpenAI API keys (pattern: sk-...)
+      .replace(/sk-[a-zA-Z0-9]{20,}/g, '[REDACTED:API_KEY]')
+      // Gemini API keys (pattern: AIza...)
+      .replace(/AIza[a-zA-Z0-9_\-]{35}/g, '[REDACTED:GEMINI_KEY]')
+      // Bearer tokens (including JWT with dots and padding)
+      .replace(/Bearer\s+[a-zA-Z0-9_.\-=]+/gi, 'Bearer [REDACTED]')
+  );
+}
+
+/**
  * Sanitize error objects to remove sensitive information
  * Handles API keys that may appear in error messages (not covered by redact)
  */
 export function sanitizeError(error: unknown): unknown {
   if (error instanceof Error) {
-    let sanitizedMessage = error.message;
-    let sanitizedStack = error.stack;
-
-    // Remove OpenAI API keys (pattern: sk-...)
-    sanitizedMessage = sanitizedMessage.replace(
-      /sk-[a-zA-Z0-9]{20,}/g,
-      '[REDACTED:API_KEY]'
-    );
-    if (sanitizedStack) {
-      sanitizedStack = sanitizedStack.replace(
-        /sk-[a-zA-Z0-9]{20,}/g,
-        '[REDACTED:API_KEY]'
-      );
-    }
-
-    // Remove Gemini API keys (pattern: AIza...)
-    sanitizedMessage = sanitizedMessage.replace(
-      /AIza[a-zA-Z0-9_\-]{35}/g,
-      '[REDACTED:GEMINI_KEY]'
-    );
-    if (sanitizedStack) {
-      sanitizedStack = sanitizedStack.replace(
-        /AIza[a-zA-Z0-9_\-]{35}/g,
-        '[REDACTED:GEMINI_KEY]'
-      );
-    }
-
-    // Remove Bearer tokens (including JWT with dots and padding)
-    sanitizedMessage = sanitizedMessage.replace(
-      /Bearer\s+[a-zA-Z0-9_.\-=]+/gi,
-      'Bearer [REDACTED]'
-    );
-    if (sanitizedStack) {
-      sanitizedStack = sanitizedStack.replace(
-        /Bearer\s+[a-zA-Z0-9_.\-=]+/gi,
-        'Bearer [REDACTED]'
-      );
-    }
+    const sanitizedMessage = sanitizeErrorMessage(error.message);
+    const sanitizedStack = error.stack
+      ? sanitizeErrorMessage(error.stack)
+      : undefined;
 
     return {
       name: error.name,

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,6 +1,14 @@
 import pino from 'pino';
 import crypto from 'crypto';
 import { trace, isSpanContextValid } from '@opentelemetry/api';
+import {
+  sanitizeError as sanitizeErrorImpl,
+  sanitizeErrorMessage as sanitizeErrorMessageImpl,
+} from '@/lib/utils/sanitize-error';
+
+// 後方互換のため既存 import path (`@/lib/logger`) からも公開する
+export { sanitizeErrorImpl as sanitizeError };
+export { sanitizeErrorMessageImpl as sanitizeErrorMessage };
 
 const isProduction = process.env.NODE_ENV === 'production';
 const isTest = process.env.NODE_ENV === 'test' || !!process.env.JEST_WORKER_ID;
@@ -24,48 +32,6 @@ export function hashSensitiveValue(value: unknown): string {
   // Hash for debuggability (same value = same hash prefix)
   const hash = crypto.createHash('sha256').update(str).digest('hex');
   return `[HASHED:${hash.slice(0, 8)}]`;
-}
-
-/**
- * Remove sensitive tokens (API keys, Bearer tokens) from a free-form string.
- * Exposed so that構造化ログの error 派生フィールド (errorMessage 等) が
- * pino の err シリアライザを経由しないケースでも sanitization を適用できる。
- */
-export function sanitizeErrorMessage(message: string): string {
-  return (
-    message
-      // OpenAI API keys (pattern: sk-...)
-      .replace(/sk-[a-zA-Z0-9]{20,}/g, '[REDACTED:API_KEY]')
-      // Gemini API keys (pattern: AIza...)
-      .replace(/AIza[a-zA-Z0-9_\-]{35}/g, '[REDACTED:GEMINI_KEY]')
-      // Bearer tokens (including JWT with dots and padding)
-      .replace(/Bearer\s+[a-zA-Z0-9_.\-=]+/gi, 'Bearer [REDACTED]')
-  );
-}
-
-/**
- * Sanitize error objects to remove sensitive information
- * Handles API keys that may appear in error messages (not covered by redact)
- */
-export function sanitizeError(error: unknown): unknown {
-  if (error instanceof Error) {
-    const sanitizedMessage = sanitizeErrorMessage(error.message);
-    const sanitizedStack = error.stack
-      ? sanitizeErrorMessage(error.stack)
-      : undefined;
-
-    return {
-      name: error.name,
-      message: sanitizedMessage,
-      // Include stack trace only in development
-      ...(process.env.NODE_ENV === 'development' &&
-        sanitizedStack && {
-          stack: sanitizedStack,
-        }),
-    };
-  }
-
-  return error;
 }
 
 /**
@@ -152,7 +118,7 @@ const logger = pino({
   serializers: {
     // Custom error serializer with sanitization (handles API keys in messages)
     err: (err) => {
-      return sanitizeError(err);
+      return sanitizeErrorImpl(err);
     },
     request: (req) => ({
       method: req.method,

--- a/lib/utils/sanitize-error.ts
+++ b/lib/utils/sanitize-error.ts
@@ -12,8 +12,12 @@
 export function sanitizeErrorMessage(message: string): string {
   return (
     message
-      // OpenAI API keys (pattern: sk-...)
-      .replace(/sk-[a-zA-Z0-9]{20,}/g, '[REDACTED:API_KEY]')
+      // OpenAI API keys: legacy (sk-XXXX) と hyphenated (sk-proj-, sk-svcacct- 等)
+      // 例: sk-proj-abcdefghij1234567890ABCDEFGHIJ
+      .replace(
+        /sk-(?:[a-zA-Z0-9]+-){0,3}[a-zA-Z0-9]{20,}/g,
+        '[REDACTED:API_KEY]'
+      )
       // Gemini API keys (pattern: AIza...)
       .replace(/AIza[a-zA-Z0-9_\-]{35}/g, '[REDACTED:GEMINI_KEY]')
       // Bearer tokens (including JWT with dots and padding)

--- a/lib/utils/sanitize-error.ts
+++ b/lib/utils/sanitize-error.ts
@@ -1,0 +1,47 @@
+/**
+ * Error / message サニタイズユーティリティ
+ *
+ * pino の `err` シリアライザを経由しない構造化ログフィールド
+ * (例: errorMessage) でも API キー・Bearer token を除去できるよう、
+ * logger 非依存のピュア関数として独立モジュール化する。
+ */
+
+/**
+ * Remove sensitive tokens (API keys, Bearer tokens) from a free-form string.
+ */
+export function sanitizeErrorMessage(message: string): string {
+  return (
+    message
+      // OpenAI API keys (pattern: sk-...)
+      .replace(/sk-[a-zA-Z0-9]{20,}/g, '[REDACTED:API_KEY]')
+      // Gemini API keys (pattern: AIza...)
+      .replace(/AIza[a-zA-Z0-9_\-]{35}/g, '[REDACTED:GEMINI_KEY]')
+      // Bearer tokens (including JWT with dots and padding)
+      .replace(/Bearer\s+[a-zA-Z0-9_.\-=]+/gi, 'Bearer [REDACTED]')
+  );
+}
+
+/**
+ * Sanitize error objects to remove sensitive information.
+ * Handles API keys that may appear in error messages (not covered by redact).
+ */
+export function sanitizeError(error: unknown): unknown {
+  if (error instanceof Error) {
+    const sanitizedMessage = sanitizeErrorMessage(error.message);
+    const sanitizedStack = error.stack
+      ? sanitizeErrorMessage(error.stack)
+      : undefined;
+
+    return {
+      name: error.name,
+      message: sanitizedMessage,
+      // Include stack trace only in development
+      ...(process.env.NODE_ENV === 'development' &&
+        sanitizedStack && {
+          stack: sanitizedStack,
+        }),
+    };
+  }
+
+  return error;
+}

--- a/scripts/diagnosis/check-content-enrichment.ts
+++ b/scripts/diagnosis/check-content-enrichment.ts
@@ -65,7 +65,7 @@ async function diagnoseContentEnrichment() {
       let enrichmentSuccess = false;
       let enrichmentError: string | undefined;
       
-      const enricher = enricherFactory.getEnricher(article.url);
+      const enricher = enricherFactory.getEnricher(article.url, article.sourceId);
       if (enricher) {
         try {
           console.error(`  Attempting enrichment...`);

--- a/scripts/maintenance/enrich-corporate-blog-content.ts
+++ b/scripts/maintenance/enrich-corporate-blog-content.ts
@@ -147,7 +147,9 @@ async function main() {
       console.error(`\nバッチ ${batchIndex + 1}/${batches.length} を処理中...`);
 
       for (const article of batch) {
-        const enricher = enricherFactory.getEnricher(article.url, article.sourceId);
+        // where で sourceId: corporateSource.id 絞り込み済みのため
+        // article.sourceId === corporateSource.id。意図を明示的に表すため直接渡す
+        const enricher = enricherFactory.getEnricher(article.url, corporateSource.id);
         
         if (!enricher) {
           console.error(`[SKIP] ${article.title} - エンリッチャー未対応`);

--- a/scripts/maintenance/enrich-corporate-blog-content.ts
+++ b/scripts/maintenance/enrich-corporate-blog-content.ts
@@ -147,7 +147,7 @@ async function main() {
       console.error(`\nバッチ ${batchIndex + 1}/${batches.length} を処理中...`);
 
       for (const article of batch) {
-        const enricher = enricherFactory.getEnricher(article.url);
+        const enricher = enricherFactory.getEnricher(article.url, article.sourceId);
         
         if (!enricher) {
           console.error(`[SKIP] ${article.title} - エンリッチャー未対応`);

--- a/scripts/maintenance/enrich-existing-hatena-articles.ts
+++ b/scripts/maintenance/enrich-existing-hatena-articles.ts
@@ -62,7 +62,8 @@ async function enrichExistingArticles(limit?: number, testMode: boolean = false)
         url: true,
         content: true,
         thumbnail: true,
-        createdAt: true
+        createdAt: true,
+        sourceId: true
       }
     });
 
@@ -96,7 +97,7 @@ async function enrichExistingArticles(limit?: number, testMode: boolean = false)
 
       try {
         // エンリッチャーを取得
-        const enricher = enricherFactory.getEnricher(article.url);
+        const enricher = enricherFactory.getEnricher(article.url, article.sourceId);
         
         if (!enricher) {
           console.error(`  ⚠️  エンリッチャーなし（スキップ）`);

--- a/scripts/maintenance/enrich-existing-hatena-articles.ts
+++ b/scripts/maintenance/enrich-existing-hatena-articles.ts
@@ -62,8 +62,7 @@ async function enrichExistingArticles(limit?: number, testMode: boolean = false)
         url: true,
         content: true,
         thumbnail: true,
-        createdAt: true,
-        sourceId: true
+        createdAt: true
       }
     });
 
@@ -96,8 +95,9 @@ async function enrichExistingArticles(limit?: number, testMode: boolean = false)
       result.processed++;
 
       try {
-        // エンリッチャーを取得
-        const enricher = enricherFactory.getEnricher(article.url, article.sourceId);
+        // エンリッチャーを取得（where で sourceId: source.id 絞り込み済みのため
+        // article.sourceId は select に含めず、ループ外の source.id を直接渡す）
+        const enricher = enricherFactory.getEnricher(article.url, source.id);
         
         if (!enricher) {
           console.error(`  ⚠️  エンリッチャーなし（スキップ）`);

--- a/scripts/maintenance/enrich-existing-zenn-articles.ts
+++ b/scripts/maintenance/enrich-existing-zenn-articles.ts
@@ -103,7 +103,7 @@ async function enrichExistingZennArticles(limit?: number, testMode: boolean = fa
       console.error(`  現在のコンテンツ長: ${article.content?.length || 0}文字`);
       
       // エンリッチャーを取得
-      const enricher = enricherFactory.getEnricher(article.url);
+      const enricher = enricherFactory.getEnricher(article.url, source.id);
       
       if (!enricher) {
         console.error('  ⚠️ エンリッチャーが見つかりません');

--- a/scripts/maintenance/re-enrich-content.ts
+++ b/scripts/maintenance/re-enrich-content.ts
@@ -122,7 +122,7 @@ async function reEnrichContent() {
 
     try {
       // エンリッチャーを取得
-      const enricher = factory.getEnricher(article.url);
+      const enricher = factory.getEnricher(article.url, article.sourceId);
       
       if (!enricher) {
         console.error('  ⚠️ エンリッチャーが見つかりません - スキップ');

--- a/scripts/maintenance/re-enrich-moneyforward-articles.ts
+++ b/scripts/maintenance/re-enrich-moneyforward-articles.ts
@@ -30,7 +30,7 @@ async function reEnrichArticles() {
     try {
       const article = await prisma.article.findUnique({
         where: { id: articleId },
-        select: { id: true, title: true, url: true, content: true }
+        select: { id: true, title: true, url: true, content: true, sourceId: true }
       });
 
       if (!article) {
@@ -42,7 +42,7 @@ async function reEnrichArticles() {
       console.log(`\n処理中: ${article.title}`);
       console.log(`  現在のコンテンツ長: ${article.content?.length || 0}文字`);
 
-      const enricher = enricherFactory.getEnricher(article.url);
+      const enricher = enricherFactory.getEnricher(article.url, article.sourceId);
       if (!enricher) {
         console.error(`  エンリッチャーが見つかりません`);
         failureCount++;

--- a/scripts/maintenance/re-enrich-publickey-nulls.ts
+++ b/scripts/maintenance/re-enrich-publickey-nulls.ts
@@ -116,11 +116,12 @@ function parseArgs(): Options {
 async function enrichWithRetry(
   factory: ContentEnricherFactory,
   url: string,
+  sourceId: string,
   maxRetries: number = 3
 ): Promise<{ content?: string; thumbnail?: string } | null> {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      const enriched = await factory.trySequential(url);
+      const enriched = await factory.trySequential(url, sourceId);
       return enriched;
     } catch (error) {
       const isNetworkError = error instanceof Error &&
@@ -227,7 +228,7 @@ async function main() {
 
     try {
       // Enrichmentをリトライ付きで実行
-      const enriched = await enrichWithRetry(factory, article.url);
+      const enriched = await enrichWithRetry(factory, article.url, publickeySource.id);
 
       if (enriched?.content && enriched.content.length >= RSS_SUFFICIENT_LENGTH) {
         // UPDATE成功

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -155,7 +155,7 @@ async function main() {
       console.error(`  URL: ${article.url}`);
 
       // エンリッチャーを取得
-      const enricher = enricherFactory.getEnricher(article.url);
+      const enricher = enricherFactory.getEnricher(article.url, article.source.id);
       
       if (!enricher) {
         console.error(`  ⏭️  スキップ: 対応するEnricherがありません`);

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -450,7 +450,7 @@ async function processSource({
                     sourceId: source.id,
                     sourceName,
                     enricher: enricher.constructor.name,
-                    errorCode: 'NO_DATA',
+                    errorCode: 'NO_DATA' as const,
                   },
                   '[Enrichment] failed: no data returned'
                 );

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -98,6 +98,7 @@ import { createFetcher } from '@/lib/fetchers';
 
 // エンリッチャーをインポート
 import { ContentEnricherFactory } from '@/lib/enrichers';
+import { classifyEnrichmentError } from '@/lib/enrichers/error-classifier';
 import { HATENA_BLOG_DEV_SOURCE_ID } from '@/lib/enrichers/hatena';
 import { logger } from '@/lib/logger';
 import { isHighQuality } from '@/lib/enrichers/strategies/quality';
@@ -457,37 +458,23 @@ async function processSource({
               }
             } catch (enrichError) {
               // エラー失敗: status/errorCode/errorMessage を構造化して記録
-              // 分類優先順位: HTTP_<status> > TIMEOUT > ABORTED > EXCEPTION
-              // HTTP を最優先にすることで "HTTP 504: Gateway Timeout" 等の
-              // HTTP ステータス情報を TIMEOUT に吸わせない（観測性確保）
-              const errorName = enrichError instanceof Error ? enrichError.name : '';
-              const errorMessage = enrichError instanceof Error ? enrichError.message : String(enrichError);
-              const statusMatch = /HTTP\s+(\d{3})/i.exec(errorMessage);
-              const isTimeout =
-                errorName === 'TimeoutError' ||
-                (!statusMatch && /\btimeout\b/i.test(errorMessage));
-              const isAborted = errorName === 'AbortError';
-              const errorCode = statusMatch
-                ? `HTTP_${statusMatch[1]}`
-                : isTimeout
-                  ? 'TIMEOUT'
-                  : isAborted
-                    ? 'ABORTED'
-                    : 'EXCEPTION';
+              // 分類ロジックは lib/enrichers/error-classifier.ts に集約
+              // （BaseContentEnricher.logEnrichmentError と共有）
+              const classified = classifyEnrichmentError(enrichError);
               logger.warn(
                 {
                   url: article.url,
                   sourceId: source.id,
                   sourceName,
                   enricher: enricher.constructor.name,
-                  errorCode,
-                  status: statusMatch ? Number(statusMatch[1]) : undefined,
-                  errorName,
-                  errorMessage,
+                  errorCode: classified.errorCode,
+                  status: classified.status,
+                  errorName: classified.errorName,
+                  errorMessage: classified.errorMessage,
                 },
                 '[Enrichment] failed: exception thrown'
               );
-              console.error('   [WARN] エンリッチメントエラー:', errorMessage);
+              console.error('   [WARN] エンリッチメントエラー:', classified.errorMessage);
             }
 
             const enrichSleepMs = resolveEnrichSleepMs(source.id);


### PR DESCRIPTION
## 概要

- PR #604 のレビュー指摘 (Issue #605) を 1 PR で解消
- **Thread 1**: `getEnricher` / `trySequential` の caller 16 箇所 (lib/fetchers 8 + scripts 8) に sourceId を伝播し API 契約を一貫化
- **Thread 2**: `lib/enrichers/error-classifier.ts` を新設し errorCode 分類ロジックを集約。`BaseContentEnricher.logEnrichmentError(url, error, options?)` を拡張して post-save enrichment outer catch で実質到達不能だった `HTTP_<status>` / `EXCEPTION` 観測性を継承勢経由でも確保
- **追加修正**: cross-review (Devil's Advocate) で発見された機密情報漏洩リスクに即時対応。`errorMessage` を `sanitizeErrorMessage` 経由でサニタイズ

## 背景・関連 PR

- 関連 Issue: #605
- 元 PR: #604 (hatena_blog_dev ソースで sourceId ベース enricher dispatch 導入)
- 調査レポート: `.workflow/docs/investigate/investigate_20260425_174755_017_issue605_enricher_sourceid_and_swallowing.md`
- 計画書: `.workflow/docs/plan/plan_20260425_184434_869_issue605_enricher_sourceid_and_logging.md`
- 実装レポート: `.workflow/docs/implement/implement_20260425_201538_869_issue605_enricher_sourceid_and_logging.md`

## 実装内容

### Thread 1: sourceId 伝播 (16 caller)

| 領域 | ファイル数 | sourceId 取得経路 |
|------|----------|-----------------|
| `lib/fetchers/` | 8 | `this.source.id` (BaseFetcher 継承) |
| `scripts/maintenance/` | 6 | `article.sourceId` または ループ外取得済み `source.id`。`enrich-existing-hatena-articles.ts` と `re-enrich-moneyforward-articles.ts` は select に `sourceId: true` 追加 |
| `scripts/manual/`, `scripts/diagnosis/` | 2 | `article.source.id` (include 経由) または `article.sourceId` |

`re-enrich-publickey-nulls.ts` は `enrichWithRetry(factory, url, sourceId, maxRetries?)` シグネチャ拡張済み。

**機能影響**: ゼロ。各 caller の対象ソースに `hatena_blog_dev` は含まれず、sourceId='hatena_blog_dev' 分岐が起動する余地はない。修正は API 契約一貫性のための形式的伝播で、将来 Hatena 系以外の enricher も sourceId ベース dispatch を採用した際の伝播漏れを予防。

**スコープ外** (計画書で明示):
- `lib/utils/article/article-manual-adder.ts:249` (記事登録前のため sourceId 不在)
- `ContentEnricherFactory.trySequential` 内 catch ログ強化 (lib/enrichers/index.ts:184-189)
- `hatena_blog_dev` 既存失敗 156 件の事後再 enrichment スクリプト新設

### Thread 2: error-classifier helper + logEnrichmentError 拡張

#### 新規 `lib/enrichers/error-classifier.ts`

\`\`\`ts
export type EnrichmentErrorCode =
  | \`HTTP_\${number}\` | 'TIMEOUT' | 'ABORTED' | 'EXCEPTION';

export interface ClassifiedEnrichmentError {
  errorCode: EnrichmentErrorCode;
  status?: number;
  errorName: string;
  errorMessage: string;
}

export function classifyEnrichmentError(error: unknown): ClassifiedEnrichmentError;
\`\`\`

- 分類優先順位: `HTTP_<status>` > `TIMEOUT` > `ABORTED` > `EXCEPTION`
- collect-feeds.ts:466-489 のインライン分類ロジックを移植して両 caller (collect-feeds + base.ts) で共有
- template literal 型で errorCode を絞り、将来の分類追加を型レベルで検出可能に

#### `BaseContentEnricher.logEnrichmentError` 拡張

\`\`\`ts
protected logEnrichmentError(
  url: string,
  error: unknown,
  options?: { sourceId?: string; sourceName?: string }
): void
\`\`\`

- ログフィールドに `errorCode`, `status`, `errorName`, `errorMessage` を構造化追加
- options 渡し時は `sourceId`, `sourceName` も付与
- 既存 `BaseContentEnricher.enrich` 既定実装の catch から呼ばれることで、5 個の継承勢 (hatena-developer, pepabo, recruit, sansan, zozo) も自動的に errorCode 分類ログを取得

#### collect-feeds.ts の DRY 化

post-save enrichment outer catch を `classifyEnrichmentError(enrichError)` 呼び出しに置換。ログフィールド・ロジックの重複を削除 (-15 / +5 行)。

### 追加修正: errorMessage のサニタイズ (cross-review 反映)

cross-review (Devil's Advocate) で発見された **HIGH novelty Warning**:
> `errorMessage` は pino の `err` シリアライザ (`sanitizeError`) を経由しないため、API キー (`sk-*`, `AIza*`) や Bearer token がサニタイズされず構造化ログに残る潜在リスクがある

対応:
- `lib/logger.ts` から `sanitizeErrorMessage(message: string): string` を新規 export
- `sanitizeError` 内のサニタイズロジックを共通化
- `classifyEnrichmentError` で `errorMessage` をサニタイズ経由で返却
- `HTTP_<status>` 検出は raw message に対して行い、サニタイズの影響を受けないよう分離

### 設計上の制約 (計画書で明示)

`BaseContentEnricher` は `this.source.id` を持たないため、5 個の継承勢からの enricher 内 catch ログには `sourceId` が含まれない。caller 側 (`collect-feeds.ts`) のログには `sourceId` が含まれるため、観測性の本質は損なわれない。

## テスト結果 (verify フェーズ通過)

| Step | 結果 |
|------|------|
| Lint (ESLint) | PASS - 0 errors / 0 warnings |
| Type-check (tsc) | PASS |
| Audit | PASS - 6 moderate (既存 svix/resend/uuid、本 PR 無関係) / 0 high・critical |
| Build (docker:build) | PASS - 既存の PrismaClient 警告のみ (PR #604 から継続) |
| Tests | PASS - 6 files / 133 tests |

### テスト内訳

- **新規** `lib/enrichers/__tests__/error-classifier.test.ts`: 15 テスト (HTTP / TIMEOUT / ABORTED / EXCEPTION + 機密情報サニタイズ 4 件)
- **追加** `lib/enrichers/__tests__/base.test.ts`: 既存 `status: 'failed'` を `errorCode: expect.any(String)` に更新 + 拡張テスト 4 件 (合計 18 PASS / 1 skipped)
- 既存 `lib/enrichers/__tests__/hatena.test.ts` (24)
- 既存 `lib/enrichers/__tests__/index.test.ts` (51)
- 既存 `__tests__/lib/utils/logger.test.ts` (18) - sanitizeError リファクタ後互換確認
- 既存 `__tests__/fetchers/google-dev-blog.test.ts` (7)

## cross-review 結果 (Codex 一時停止のため代替実施)

- typescript-reviewer (Specialist): **Approve**。MEDIUM 1 件 (`NO_DATA` の型統一) は次回 PR
- general-purpose (Devil's Advocate): HIGH novelty Warning 1 件 (errorMessage サニタイズ) を即時対応 (commit 7b0fb89c)。`status` フィールドのセマンティクス変更は caller 側 (PR #604) との整合修正のため対応不要

## 事後確認計画

マージ後 2-3 日で本番ログの `[Enrichment] failed` を集計し、5 個の継承勢経由でも `errorCode` 分類 (`HTTP_<status>` / `EXCEPTION`) が観測可能になっていることを確認。

## チェックリスト

- [x] verify フェーズ通過 (lint / type-check / audit / build / test / diff-review)
- [x] cross-review (typescript-reviewer + Devil's Advocate) 実施、HIGH/Warning 指摘を反映
- [x] 破壊的変更なし (logEnrichmentError は optional 引数追加で後方互換)
- [x] DB スキーマ変更なし
- [x] 環境変数追加なし
- [x] テストカバレッジ追加 (33 テスト新規・更新)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * コンテンツ記事の取得元(ソース)を考慮した改善されたエンリッチメント処理を実装しました。

* **Tests**
  * エラー分類ロジックの包括的なテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->