### PR TITLE
fix(deps): Dependabotセキュリティアラート2件対応（postcss/uuid）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "sanitize-html": "^2.17.0",
         "tailwind-merge": "^3.3.1",
         "unist-util-visit": "^5.0.0",
-        "uuid": "^13.0.0",
+        "uuid": "^14.0.0",
         "web-vitals": "^5.1.0",
         "zod": "^3.23.8"
       },
@@ -20103,34 +20103,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-cron": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
@@ -21328,9 +21300,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -24982,9 +24954,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "sanitize-html": "^2.17.0",
     "tailwind-merge": "^3.3.1",
     "unist-util-visit": "^5.0.0",
-    "uuid": "^13.0.0",
+    "uuid": "^14.0.0",
     "web-vitals": "^5.1.0",
     "zod": "^3.23.8"
   },
@@ -283,6 +283,7 @@
     },
     "hono": "4.12.14",
     "@hono/node-server": "1.19.13",
-    "follow-redirects": "1.16.0"
+    "follow-redirects": "1.16.0",
+    "postcss": "8.5.10"
   }
 }


### PR DESCRIPTION
## 概要
- Dependabot Open アラート 2 件を解消（先行 PR #574/#570 と同じ overrides パターン）
- `postcss` を 8.5.10 へ override 昇格（next@16.2.3 が 8.4.31 を厳密 pin するため必須）
- `uuid` 直接依存を `^14.0.0` へ bump

## 対応アラート
| # | パッケージ | 重要度 | 詳細 |
|---|----------|--------|------|
| #80 | postcss <8.5.10 | Medium / CVSS 6.1 / CWE-79 | XSS via Unescaped `</style>` in CSS Stringify (GHSA-qx2v-qp2m-jg93 / CVE-2026-41305) |
| #79 | uuid <14.0.0 | Medium | Missing buffer bounds check in v3/v5/v6 when buf is provided (GHSA-w5hq-g745-h8pq) |

## 実装内容
`package.json` 2行のみ:
- `dependencies.uuid`: `^13.0.0` → `^14.0.0`
- `overrides.postcss = "8.5.10"` 追加（既存 `follow-redirects` 直後）

`package-lock.json` は `npm install` で再生成（net -27 行、dedupe 効果含む）。

### 互換性
- **postcss 8.5.10**: 8.5 系内のパッチ昇格。`@tailwindcss/postcss` (`^8.4.41`) / `next@16.2.3` (`8.4.31` pin) / `critters` / `sanitize-html` 全てを override で 8.5.10 統一。
- **uuid v14 BREAKING**: Node 20+ / `crypto` global 必須 / TypeScript 5.4.3+。本リポは `Dockerfile=node:20-alpine` / TS `^5.8.3` のため要件充足。
- **使用箇所**: `lib/ai/testing/regression-tester.ts:1,423` の `v4()` 1 箇所のみ。buf 引数なしで脆弱コードパス未到達のため API 互換問題なし。

### 残存事項（Won't Fix）
transitive `uuid@10.0.0` (svix → resend) / `uuid@8.3.2` (lhci/mswjs/data) は moderate 3 件残るが、脆弱パス未使用 + 一部は devDep のため対応見送り。Dependabot ダッシュボード上 #79 は manifest 直接依存バンプで close 見込み。

## テスト結果（verifyフェーズ）
- ✅ `npm run lint`: 0 errors / 0 warnings
- ✅ `npm run type-check`: PASSED
- ✅ `npm audit --production --audit-level=high`: EXIT=0（high+ 0 件）
- ✅ `npm run docker:build`: Next.js 全ページビルド成功
- ✅ `__tests__/lib/ai/testing/regression-tester.test.ts`: 5 passed (0.54s)
- ✅ `npm ls postcss`: 全エントリ 8.5.10 overridden
- ✅ `npm ls uuid`: 直接依存 14.0.0

## チェックリスト
- [x] テスト通過
- [x] ビルド通過
- [x] 破壊的変更なし（依存パッチ）
- [x] 関連 Issue リンク済み

Fixes #79, #80 (Dependabot alerts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の変更**
  * 依存関係のバージョンを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->