### PR TITLE
test(scroll-restoration): race condition の回帰ユニットテスト追加 (Closes #613)

### DIFF
--- a/__tests__/hooks/use-scroll-restoration.test.tsx
+++ b/__tests__/hooks/use-scroll-restoration.test.tsx
@@ -1,0 +1,149 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useScrollRestoration } from '@/app/hooks/use-scroll-restoration';
+
+// jsdom の location.pathname='/' から導出される sessionStorage キー
+// (buildScrollStorageKey() の出力と一致させる)
+const SCROLL_STORAGE_KEY = 'scroll_position_/';
+
+// lib/constants/index.ts で定義される値
+const SCROLL_RESTORE_RETRY_INTERVAL = 100;
+const SCROLL_RESTORE_MAX_ATTEMPTS = 12;
+const SCROLL_RESTORE_UI_DELAY = 700;
+// retry を全て使い切って restoreScroll が呼ばれるまでの所要時間
+const TIME_UNTIL_RESTORE = SCROLL_RESTORE_RETRY_INTERVAL * SCROLL_RESTORE_MAX_ATTEMPTS;
+
+const seedSessionStorage = (overrides: Record<string, unknown> = {}) => {
+  sessionStorage.setItem(
+    SCROLL_STORAGE_KEY,
+    JSON.stringify({
+      scrollY: 100,
+      timestamp: Date.now(),
+      // article-{id} 要素を DOM に置かないため、retry が maxAttempts まで続いてから
+      // フォールバックの restoreScroll が走る経路になる
+      articleId: 'a1',
+      articleIndex: 0,
+      ...overrides,
+    })
+  );
+};
+
+describe('useScrollRestoration', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  describe('race condition (regression for #612 / Issue #613)', () => {
+    // バグの正確なタイミング:
+    // 1. tryOnce が SCROLL_RESTORE_MAX_ATTEMPTS 回 retry → restoreScroll() 実行
+    // 2. restoreScroll() が SCROLL_RESTORE_UI_DELAY (700ms) 後に setIsRestoring(false) を予約
+    // 3. この 700ms の間に props 変化 → 修正前は effect cleanup で clearTimeout
+    //    → setIsRestoring(false) が永久に呼ばれず、オーバーレイが残る
+    //
+    // 修正後は deps から pagesLoaded/hasNextPage/fetchNextPage を外しているため、
+    // cleanup が走らず 700ms 後に isRestoring が false になる。
+    it('should set isRestoring back to false when props change AFTER restoreScroll has scheduled the UI delay timer', async () => {
+      seedSessionStorage();
+
+      const fetchNextPageA = jest.fn().mockResolvedValue(undefined);
+      const fetchNextPageB = jest.fn().mockResolvedValue(undefined);
+
+      const { result, rerender } = renderHook(
+        ({ pagesLoaded, hasNextPage, fetchFn }) =>
+          useScrollRestoration(
+            20,
+            pagesLoaded,
+            {},
+            fetchFn,
+            hasNextPage,
+            false,
+            undefined,
+            true
+          ),
+        {
+          initialProps: {
+            pagesLoaded: 1,
+            hasNextPage: true,
+            fetchFn: fetchNextPageA,
+          },
+        }
+      );
+
+      // restoreScroll() が実行され UI delay タイマーが予約されるまで進める
+      // (retry 12 * 100ms = 1200ms 経過後に restoreScroll が走り、700ms タイマー予約)
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(TIME_UNTIL_RESTORE + 50);
+      });
+
+      // 700ms タイマー実行前(まだ isRestoring=true)に props を変化させて
+      // cleanup race を誘発する
+      expect(result.current.isRestoring).toBe(true);
+
+      await act(async () => {
+        rerender({
+          pagesLoaded: 2,
+          hasNextPage: true,
+          fetchFn: fetchNextPageA,
+        });
+        rerender({
+          pagesLoaded: 2,
+          hasNextPage: false,
+          fetchFn: fetchNextPageB,
+        });
+      });
+
+      // 残りの UI delay 分(+α)を進める
+      // 修正前: clearTimeout で予約タイマー消滅 → isRestoring=true のまま
+      // 修正後: cleanup 走らず 700ms タイマー発火 → isRestoring=false
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(SCROLL_RESTORE_UI_DELAY + 100);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isRestoring).toBe(false);
+      });
+    });
+  });
+
+  describe('baseline restoration', () => {
+    it('should toggle isRestoring true -> false when restoring with seeded scroll data', async () => {
+      seedSessionStorage();
+
+      const fetchNextPage = jest.fn().mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        useScrollRestoration(
+          20,
+          1,
+          {},
+          fetchNextPage,
+          false,
+          false,
+          undefined,
+          true
+        )
+      );
+
+      await waitFor(() => {
+        expect(result.current.isRestoring).toBe(true);
+      });
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(
+          TIME_UNTIL_RESTORE + SCROLL_RESTORE_UI_DELAY + 100
+        );
+      });
+
+      await waitFor(() => {
+        expect(result.current.isRestoring).toBe(false);
+      });
+    });
+  });
+});

--- a/__tests__/hooks/use-scroll-restoration.test.tsx
+++ b/__tests__/hooks/use-scroll-restoration.test.tsx
@@ -1,16 +1,23 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { useScrollRestoration } from '@/app/hooks/use-scroll-restoration';
+import { TIMEOUTS } from '@/lib/constants/index';
+import { buildScrollStorageKey } from '@/lib/utils/scroll';
 
-// jsdom の location.pathname='/' から導出される sessionStorage キー
-// (buildScrollStorageKey() の出力と一致させる)
-const SCROLL_STORAGE_KEY = 'scroll_position_/';
+// jsdom の location から実際のキーを導出 (production 実装と必ず一致)
+const SCROLL_STORAGE_KEY = buildScrollStorageKey();
 
-// lib/constants/index.ts で定義される値
-const SCROLL_RESTORE_RETRY_INTERVAL = 100;
-const SCROLL_RESTORE_MAX_ATTEMPTS = 12;
-const SCROLL_RESTORE_UI_DELAY = 700;
-// retry を全て使い切って restoreScroll が呼ばれるまでの所要時間
-const TIME_UNTIL_RESTORE = SCROLL_RESTORE_RETRY_INTERVAL * SCROLL_RESTORE_MAX_ATTEMPTS;
+const {
+  SCROLL_RESTORE_RETRY_INTERVAL,
+  SCROLL_RESTORE_MAX_ATTEMPTS,
+  SCROLL_RESTORE_UI_DELAY,
+} = TIMEOUTS;
+
+// tryRestoreWithRetry は初回 setRestorationTimeout(tryOnce, interval) を実行した後、
+// tryOnce 内の `attempts < maxAttempts` 判定により最大 MAX_ATTEMPTS 回再スケジュールしてから
+// restoreScroll() を呼ぶ。
+// → 合計 (MAX_ATTEMPTS + 1) * RETRY_INTERVAL ms でフォールバック restoreScroll が実行される
+const TIME_UNTIL_RESTORE =
+  SCROLL_RESTORE_RETRY_INTERVAL * (SCROLL_RESTORE_MAX_ATTEMPTS + 1);
 
 const seedSessionStorage = (overrides: Record<string, unknown> = {}) => {
   sessionStorage.setItem(
@@ -33,27 +40,30 @@ describe('useScrollRestoration', () => {
     jest.useFakeTimers();
   });
 
-  afterEach(() => {
-    act(() => {
+  afterEach(async () => {
+    // pending タイマーを流したあとマイクロタスクをドレインしてからリアルタイマーへ戻す
+    // (fetchRequiredPagesAndRestore / restoreScroll 由来の Promise リーク防止)
+    await act(async () => {
       jest.runOnlyPendingTimers();
+      await Promise.resolve();
     });
     jest.useRealTimers();
+    sessionStorage.clear();
   });
 
   describe('race condition (regression for #612 / Issue #613)', () => {
     // バグの正確なタイミング:
     // 1. tryOnce が SCROLL_RESTORE_MAX_ATTEMPTS 回 retry → restoreScroll() 実行
     // 2. restoreScroll() が SCROLL_RESTORE_UI_DELAY (700ms) 後に setIsRestoring(false) を予約
-    // 3. この 700ms の間に props 変化 → 修正前は effect cleanup で clearTimeout
+    // 3. この 700ms の間に deps 該当 prop が変化 → 修正前は effect cleanup で clearTimeout
     //    → setIsRestoring(false) が永久に呼ばれず、オーバーレイが残る
     //
     // 修正後は deps から pagesLoaded/hasNextPage/fetchNextPage を外しているため、
     // cleanup が走らず 700ms 後に isRestoring が false になる。
-    it('should set isRestoring back to false when props change AFTER restoreScroll has scheduled the UI delay timer', async () => {
+    it('should set isRestoring back to false when pagesLoaded changes AFTER restoreScroll has scheduled the UI delay timer', async () => {
       seedSessionStorage();
 
-      const fetchNextPageA = jest.fn().mockResolvedValue(undefined);
-      const fetchNextPageB = jest.fn().mockResolvedValue(undefined);
+      const fetchNextPage = jest.fn().mockResolvedValue(undefined);
 
       const { result, rerender } = renderHook(
         ({ pagesLoaded, hasNextPage, fetchFn }) =>
@@ -71,39 +81,35 @@ describe('useScrollRestoration', () => {
           initialProps: {
             pagesLoaded: 1,
             hasNextPage: true,
-            fetchFn: fetchNextPageA,
+            fetchFn: fetchNextPage,
           },
         }
       );
 
-      // restoreScroll() が実行され UI delay タイマーが予約されるまで進める
-      // (retry 12 * 100ms = 1200ms 経過後に restoreScroll が走り、700ms タイマー予約)
+      // 初回 setRestorationTimeout + retry MAX_ATTEMPTS 回 = (MAX_ATTEMPTS + 1) * INTERVAL ms 経過直後
+      // この時点で restoreScroll() が走り終わり、UI delay タイマー(700ms)が予約済み・未発火
       await act(async () => {
-        await jest.advanceTimersByTimeAsync(TIME_UNTIL_RESTORE + 50);
+        await jest.advanceTimersByTimeAsync(TIME_UNTIL_RESTORE + 10);
       });
 
-      // 700ms タイマー実行前(まだ isRestoring=true)に props を変化させて
-      // cleanup race を誘発する
+      // UI delay タイマー実行前(まだ isRestoring=true)であることを確認
       expect(result.current.isRestoring).toBe(true);
 
+      // 修正前 deps に含まれていた prop を 1 つだけ変えれば回帰時の cleanup を誘発できる
+      // (回帰検出としては最小ケース。意図が伝わりやすく、どの prop の変化で再現するかも明確)
       await act(async () => {
         rerender({
           pagesLoaded: 2,
           hasNextPage: true,
-          fetchFn: fetchNextPageA,
-        });
-        rerender({
-          pagesLoaded: 2,
-          hasNextPage: false,
-          fetchFn: fetchNextPageB,
+          fetchFn: fetchNextPage,
         });
       });
 
-      // 残りの UI delay 分(+α)を進める
+      // UI delay 分(+α)を進める
       // 修正前: clearTimeout で予約タイマー消滅 → isRestoring=true のまま
       // 修正後: cleanup 走らず 700ms タイマー発火 → isRestoring=false
       await act(async () => {
-        await jest.advanceTimersByTimeAsync(SCROLL_RESTORE_UI_DELAY + 100);
+        await jest.advanceTimersByTimeAsync(SCROLL_RESTORE_UI_DELAY + 50);
       });
 
       await waitFor(() => {
@@ -137,7 +143,7 @@ describe('useScrollRestoration', () => {
 
       await act(async () => {
         await jest.advanceTimersByTimeAsync(
-          TIME_UNTIL_RESTORE + SCROLL_RESTORE_UI_DELAY + 100
+          TIME_UNTIL_RESTORE + SCROLL_RESTORE_UI_DELAY + 50
         );
       });
 


### PR DESCRIPTION
## 概要
- PR #612 の CodeRabbit 指摘 P3-2 (Issue #613) に対応する回帰ユニットテストを追加
- 復元中の `pagesLoaded`/`hasNextPage`/`fetchNextPage` 変化が cleanup race を引き起こす退行を機械的に検出
- プロダクションコード変更なし、テストファイル1本のみ追加

## 実装内容
新規ファイル: `__tests__/hooks/use-scroll-restoration.test.tsx` (149行、DOM env)

### テスト2本
1. **race condition regression** (Issue #613 / PR #612)
   - retry 完了後・`SCROLL_RESTORE_UI_DELAY` (700ms) タイマー予約直後の正確なタイミングで rerender を発火
   - 修正前 deps (`pagesLoaded`/`hasNextPage`/`fetchNextPage`) を再追加すると **このテストが失敗する** ことを退行検証で確認済み
2. **baseline restoration**
   - 通常復元時の `isRestoring` true→false 遷移を検証

### 設計判断
- 配置: `__tests__/hooks/` (CodeRabbit 提案の `app/hooks/__tests__/` ではなくプロジェクト慣習に合わせる)
- 拡張子: `.test.tsx` (DOM 環境必須、`jest.config.dom.js` testMatch 準拠)
- timer: `jest.useFakeTimers()` + `advanceTimersByTimeAsync` で flaky 化を防止
- race 再現条件: `articleId='a1'` を seed しつつ DOM に対応要素を置かないことで retry → fallback `restoreScroll()` 経路を強制

## テスト結果 (verify フェーズ)
- ✅ Lint: 0 errors / 0 warnings
- ✅ Type-check: PASSED
- ✅ Audit: 0 high/critical (3 moderate のみ、`--audit-level=high` 許容)
- ✅ Build (`docker:build`): PASSED
- ✅ Tests: 2 passed / 2 total (`__tests__/hooks/use-scroll-restoration.test.tsx`、0.85秒)
- ✅ Diff Review: 単一新規ファイル、デバッグコード/機密情報なし
- ⏭️ Visual: UI 変更なしのため SKIP

### 退行検出力の確認
1. 主 effect の deps に `pagesLoaded`/`hasNextPage`/`fetchNextPage` を一時追加 → race regression test が **期待通り失敗**
2. 元に戻す → 全 pass

## チェックリスト
- [x] テスト通過 (race regression + baseline、合計2本)
- [x] 退行検出力を退行検証 (deps 一時追加→失敗確認→revert) で担保
- [x] プロダクションコード変更なし (破壊的変更なし)
- [x] CodeRabbit 雛形をベースにプロジェクト書式に適合

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * スクロール復元機能の包括的なテストを追加。タイマー制御とストレージ動作の検証を含み、回帰テストと基準テストで`isRestoring`の状態遷移を確認。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->