### PR TITLE
fix(deps): Dependabot Alert #79 transitive uuid を override で 14.0.0 強制

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3913,16 +3913,6 @@
         "lhci": "src/cli.js"
       }
     },
-    "node_modules/@lhci/cli/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@lhci/utils": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/@lhci/utils/-/utils-0.15.1.tgz",
@@ -3994,16 +3984,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
-      }
-    },
-    "node_modules/@mswjs/data/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -23940,19 +23920,6 @@
       "dependencies": {
         "standardwebhooks": "1.0.0",
         "uuid": "^10.0.0"
-      }
-    },
-    "node_modules/svix/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -284,6 +284,7 @@
     "hono": "4.12.14",
     "@hono/node-server": "1.19.13",
     "follow-redirects": "1.16.0",
-    "postcss": "8.5.10"
+    "postcss": "8.5.10",
+    "uuid": "^14.0.0"
   }
 }


### PR DESCRIPTION
## 概要
- Dependabot Alert #79 (GHSA-w5hq-g745-h8pq, uuid <14.0.0, medium) を transitive 経路まで含めて解消
- PR #615 で直接依存は 14.0.0 化済み。本 PR で `package.json` `overrides` に `uuid: ^14.0.0` を追加し、resend → svix → uuid@10.0.0 / @lhci/cli・@mswjs/data → uuid@8.3.2 を全層 14.0.0 に統一
- 実 exploitability はゼロ（自プロジェクトおよび transitive 消費者すべて `v4()` のみ使用、脆弱パス v3/v5/v6 + 外部 buf 未到達）

## 実装内容
- `package.json`: `overrides` 末尾に `"uuid": "^14.0.0"` を 1 行追加（PR #615 の overrides パターンを踏襲）
- `package-lock.json`: `npm install` で自動再生成（dedupe で net -32 行）

## 互換性
- **uuid v14 BREAKING**: Node 20+ 必須 / `crypto` global 必須。本リポは `Dockerfile=node:20-alpine` / CI `NODE_VERSION='20'` で要件充足
- **svix の uuid 利用**: `auto_${uuidv4()}` 1 箇所のみ（v4 シグネチャは v8/v10/v14 で互換）
- **@lhci/cli・@mswjs/data**: dev 限定。@lhci/cli は v4() のみ、@mswjs/data はビルド成果物に uuid 参照なし

## 残存事項
なし（直接・transitive すべて uuid@14.0.0）。Dependabot dashboard で Alert #79 が auto-close される見込み。

## テスト結果（verifyフェーズ）
- ✅ `npm run lint`: 0 errors / 0 warnings
- ✅ `npm run type-check`: PASSED
- ✅ `npm audit --omit=dev --audit-level=high`: found 0 vulnerabilities
- ✅ `npm run docker:build`: Next.js production build 成功
- ✅ `__tests__/lib/ai/testing/regression-tester.test.ts`: 5 passed (0.728s)
- ✅ `npm ls uuid`: 全エントリ `uuid@14.0.0 deduped`

## チェックリスト
- [x] テスト通過
- [x] ビルド通過
- [x] 破壊的変更なし（依存パッチ、Node 20 前提充足）
- [x] 関連 Issue リンク済み

Fixes #79 (Dependabot alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * パッケージ依存関係のバージョン固定を更新しました。これにより、アプリケーションの安定性と互換性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->