### PR TITLE
chore(619): related-articles testid + React.memo + spec 整合 (PR-B)

### DIFF
--- a/__tests__/e2e/constants/selectors.ts
+++ b/__tests__/e2e/constants/selectors.ts
@@ -61,7 +61,6 @@ export const SELECTORS = {
   // ===== 関連記事 =====
   RELATED_SECTION: '[data-testid="related-articles"]',
   RELATED_ARTICLE_LINK: '[data-testid="related-articles"] [data-testid="related-article-link"]',
-  RELATED_ARTICLES: 'article, [class*="card"]',
   
   // ===== 分析ページ =====
   ANALYTICS_CONTENT: '[class*="analytics"], [class*="stats"], [data-testid="analytics"]',

--- a/__tests__/e2e/constants/selectors.ts
+++ b/__tests__/e2e/constants/selectors.ts
@@ -59,7 +59,8 @@ export const SELECTORS = {
   EXTERNAL_LINK: 'a[rel*="noopener"], a[rel*="external"]',
   
   // ===== 関連記事 =====
-  RELATED_SECTION: 'section:has-text("関連"), section:has-text("Related"), [data-testid="related-articles"]',
+  RELATED_SECTION: '[data-testid="related-articles"]',
+  RELATED_ARTICLE_LINK: '[data-testid="related-articles"] [data-testid="related-article-link"]',
   RELATED_ARTICLES: 'article, [class*="card"]',
   
   // ===== 分析ページ =====

--- a/__tests__/e2e/related-articles-navigation.spec.ts
+++ b/__tests__/e2e/related-articles-navigation.spec.ts
@@ -40,7 +40,7 @@ test.describe('関連記事のナビゲーション', () => {
     }
 
     // 関連記事のリンクを取得
-    const relatedLinks = relatedSection.locator('a[href^="/articles/"]');
+    const relatedLinks = page.locator(SELECTORS.RELATED_ARTICLE_LINK);
     const linkCount = await relatedLinks.count();
 
     if (linkCount === 0) {
@@ -77,7 +77,7 @@ test.describe('関連記事のナビゲーション', () => {
     }
 
     // 関連記事のリンクを取得
-    const relatedLinks = relatedSection.locator('a[href^="/articles/"]');
+    const relatedLinks = page.locator(SELECTORS.RELATED_ARTICLE_LINK);
     const linkCount = await relatedLinks.count();
 
     if (linkCount === 0) {
@@ -102,7 +102,7 @@ test.describe('関連記事のナビゲーション', () => {
     }
 
     // 関連記事のリンクを取得
-    const relatedLinks = relatedSection.locator('a[href^="/articles/"]');
+    const relatedLinks = page.locator(SELECTORS.RELATED_ARTICLE_LINK);
     const linkCount = await relatedLinks.count();
 
     if (linkCount === 0) {
@@ -135,7 +135,7 @@ test.describe('関連記事のナビゲーション', () => {
     }
 
     // 関連記事のリンクを取得
-    const relatedLinks = relatedSection.locator('a[href^="/articles/"]');
+    const relatedLinks = page.locator(SELECTORS.RELATED_ARTICLE_LINK);
     const linkCount = await relatedLinks.count();
 
     if (linkCount === 0) {
@@ -170,7 +170,7 @@ test.describe('関連記事のナビゲーション', () => {
     }
 
     // 関連記事のリンクを取得
-    const relatedLinks = relatedSection.locator('a[href^="/articles/"]');
+    const relatedLinks = page.locator(SELECTORS.RELATED_ARTICLE_LINK);
     const linkCount = await relatedLinks.count();
 
     if (linkCount === 0) {

--- a/app/components/article/related-articles.tsx
+++ b/app/components/article/related-articles.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { memo, useState, useEffect } from 'react';
 import Link from 'next/link';
 import {
   Card,
@@ -26,7 +26,11 @@ import {
 
 // Extracted component to use hooks for each article item
 // Avoids Date.now() during render (React Compiler purity rule)
-function RelatedArticleItem({ article }: { article: RelatedArticle }) {
+const RelatedArticleItem = memo(function RelatedArticleItem({
+  article,
+}: {
+  article: RelatedArticle;
+}) {
   const [timeInfo, setTimeInfo] = useState<{
     hoursAgo: number;
     isNew: boolean;
@@ -55,6 +59,7 @@ function RelatedArticleItem({ article }: { article: RelatedArticle }) {
   return (
     <Link
       href={`/articles/${article.id}`}
+      data-testid="related-article-link"
       className="group block cursor-pointer rounded-lg bg-[var(--tt-color-surface-muted)] p-3 transition-colors hover:bg-[var(--tt-color-surface-hover)]"
     >
       <div className="space-y-1">
@@ -117,7 +122,7 @@ function RelatedArticleItem({ article }: { article: RelatedArticle }) {
       </div>
     </Link>
   );
-}
+});
 
 interface RelatedArticlesProps {
   articleId: string;
@@ -187,7 +192,10 @@ export function RelatedArticles({
   }
 
   return (
-    <Card className="lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)]">
+    <Card
+      data-testid="related-articles"
+      className="lg:sticky lg:top-4 lg:max-h-[calc(100vh-2rem)]"
+    >
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="flex items-center gap-2 text-lg">


### PR DESCRIPTION
## 概要
- Issue #619 (E2E selector / a11y フォローアップ) の PR-B 対応
- `RelatedArticles` の default 分岐に `data-testid="related-articles"` を付与し、サイレントスキップ中だった 5 spec を実走可能化
- `RelatedArticleItem` を `React.memo` でラップ (CodeRabbit 指摘対応)

## 実装内容

### `app/components/article/related-articles.tsx`
- default 分岐の `<Card>` に `data-testid="related-articles"` 付与 (loading/empty には付与せず、skip 理由の暗黙変化を防ぐ)
- `RelatedArticleItem` を `React.memo` でラップ (`displayName` 維持)
- `RelatedArticleItem` の `<Link>` に `data-testid="related-article-link"` 付与 (header の "グラフで見る" リンクと区別するため)

### `__tests__/e2e/constants/selectors.ts`
- `RELATED_SECTION` を `[data-testid="related-articles"]` 単独に絞る (`section:has-text("関連")` 部分一致を撤廃)
- `RELATED_ARTICLE_LINK` セレクタを新設
- 未使用の `RELATED_ARTICLES` セレクタを削除 (レビュー指摘対応)

### `__tests__/e2e/related-articles-navigation.spec.ts`
- 5 箇所の `relatedSection.locator('a[href^="/articles/"]')` を `page.locator(SELECTORS.RELATED_ARTICLE_LINK)` に置換 (header の graph リンクとの区別)

## テスト結果

`__tests__/e2e/related-articles-navigation.spec.ts` 全 5 テストの実走結果 (chromium, `--rebuild`):

| # | テスト名 | 結果 |
|---|---------|------|
| 1 | 関連記事をクリックして詳細要約ページに遷移できる | **PASS** (flaky: 1 retry 後成功) |
| 2 | 関連記事のリンクが正しい href を持つ | **PASS** |
| 3 | 中クリックで関連記事を新しいタブで開ける | **PASS** |
| 4 | Ctrl/Cmd+クリックで関連記事を新しいタブで開ける | **PASS** (flaky: 1 retry 後成功) |
| 5 | Enter キーで関連記事に遷移できる | **PASS** |

**集計**: 5 PASS / 0 SKIP / 0 FAIL — PR #618 時点の skip サイレントから全 5 件が pass へ昇格。

flaky 2 件は環境的タイミング依存 (URL 反映遅延、新タブ navigation 完了遅延) で、本 PR の変更に起因しない既存リトライ機構でリカバリ可能。

## verify フェーズ結果
- Lint: PASS (0 errors / 0 warnings)
- Type-check: PASS
- npm audit: PASS (0 vulnerabilities)
- Build (docker:build): PASS
- Diff Review: PASS (3 files, +19/-11)
- Visual: SKIP (data-testid + memo のみで視覚変化なし、E2E で DOM 反映実証済)

## チェックリスト
- [x] テスト通過 (E2E 5/5 PASS)
- [x] code-reviewer agent レビュー対応済
- [x] 破壊的変更なし (testid 追加と非可視属性のみ)

## Issue
- Issue #619 タスク 6, 7 を消化
- PR-A (#621) merge 済み
- 残: PR-C, PR-D

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * E2Eテストの関連記事セレクタを改善し、テストの信頼性と保守性を向上させました。

* **Performance**
  * 関連記事コンポーネントのレンダリング性能を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->