### PR TITLE
chore(619): assertLocatorFound 適用棚卸し + 形式置換 1 件 (PR-D)

### DIFF
--- a/e2e/regression-test.spec.ts
+++ b/e2e/regression-test.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { SELECTORS } from './constants/selectors';
 import { MOBILE_VIEWPORT } from './constants/viewports';
+import { assertLocatorFound } from './utils/test-helpers';
 
 test.describe('回帰テスト - 既存機能の動作確認', () => {
   // このテストスイートは多数の機能を網羅的にテストするため、タイムアウトを3倍に延長
@@ -22,9 +23,9 @@ test.describe('回帰テスト - 既存機能の動作確認', () => {
       const firstCard = page.locator('[data-testid="article-card"]').first();
       
       // タイトルまたはサムネイルが存在（サムネイル時はタイトル非表示）
-      const hasTitle = await firstCard.locator('h3').count() > 0;
-      const hasThumbnail = await firstCard.locator('img').count() > 0;
-      expect(hasTitle || hasThumbnail).toBeTruthy();
+      // Issue #619 PR-D: count()>0 OR 検証を assertLocatorFound に意味同値置換
+      // (Playwright の `,` セパレータは OR 解釈で、両セレクタの和集合を返す)
+      await assertLocatorFound(firstCard.locator('h3, img'), 'firstCard heading or thumbnail');
       
       // ソース名が存在する場合チェック（showSource prop次第でオプショナル）
       const sourceCount = await firstCard.locator('[data-testid="article-source"]').count();


### PR DESCRIPTION
## 概要

- Issue #619 タスク 2 (PR-D): `assertLocatorFound` ヘルパーの spec 適用棚卸し
- `e2e/regression-test.spec.ts:25-27` の OR 検証を `assertLocatorFound` に意味同値置換 (1 件)
- 他 23 箇所はすべて意図的フォールバック / skip / OR / 機能未実装許容で、no-op が既に防がれているため維持判定

## 棚卸サマリ

PR-A/B/C 完了後の現状を 4 spec × 24 箇所で棚卸した結果。

| spec / file | 行 | 判定 |
|-------------|----|-----|
| `regression-test.spec.ts` | 25-27 | **必須昇格 (1 件、本 PR)** |
| `regression-test.spec.ts` | 68 | フォールバック維持 (シード変動許容) |
| `regression-test.spec.ts` | 93 | フォールバック維持 (機能未実装許容) |
| `regression-test.spec.ts` | 116 | フォールバック維持 (同上) |
| `regression-test.spec.ts` | 137 | フォールバック維持 (sort testid 整備中) |
| `regression-test.spec.ts` | 158 | フォールバック維持 (同上) |
| `regression-test.spec.ts` | 178 | フォールバック維持 (人気リンク仕様変動) |
| `regression-test.spec.ts` | 356 | フォールバック維持 (複数 selector 探索) |
| `infinite-scroll.spec.ts` | 18, 63, 105, 173, 329 | フォールバック維持 (`testInfo.skip` で no-op 防止済み) |
| `infinite-scroll.spec.ts` | 81 | フォールバック維持 (2 回目スクロール再確認) |
| `infinite-scroll.spec.ts` | 137, 386 | フォールバック維持 (複数 selector 探索) |
| `infinite-scroll.spec.ts` | 226 | フォールバック維持 (`test.skip` 内、影響なし) |
| `infinite-scroll.spec.ts` | 439 | フォールバック維持 (環境変数依存機能) |
| `multiple-source-filter.spec.ts` | 34 | フォールバック維持 (`hasCheckboxes \|\| hasButtons` OR) |
| `multiple-source-filter.spec.ts` | 111 | フォールバック維持 (前段 select 後の派生) |
| `multiple-source-filter.spec.ts` | 195 | フォールバック維持 (機能未実装許容) |
| `tag-filter.spec.ts` | 37, 68 | フォールバック維持 (シード変動許容) |

**集計**: 必須昇格 1 件 / フォールバック維持 23 件。`grep -rn 'assertLocatorFound' e2e/*.spec.ts`: 0 → 1 件。

## 実装内容

- `e2e/regression-test.spec.ts` に `import { assertLocatorFound } from './utils/test-helpers'` を追加
- line 25-27 の `count() > 0` OR 検証 + `expect(...).toBeTruthy()` を `assertLocatorFound(firstCard.locator('h3, img'), 'firstCard heading or thumbnail')` に置換
- Playwright の CSS `,` セパレータは OR 解釈で和集合カウントを返すため、現行の「h3 または img のいずれかが最低 1 件」検証と完全同値

## テスト結果

- `/test e2e/regression-test.spec.ts`: **13 passed / 1 skipped** (既存の意図的 skip、本変更と無関係)
- 該当テスト「記事カードが正しく表示される」: pass (1.9s)
- VERIFY フェーズ: lint 0/0、type-check OK、audit 0 vulnerabilities、build OK、e2e 13 passed/1 skipped

## チェックリスト

- [x] テスト通過 (chromium)
- [x] 破壊的変更なし
- [x] 意味同値置換 (commit message に Playwright `,` セパレータ仕様記載)

Refs: #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 記事カードの表示確認テストの堅牢性を向上。より明確なエラーメッセージを提供し、テストの信頼性を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->