### PR TITLE
fix(enrichers): 9 enricher を IContentEnricher.enrich(url, signal?) 契約準拠 + AbortSignal 伝播 (Closes #608)

### DIFF
--- a/lib/enrichers/__tests__/hacker-news.test.ts
+++ b/lib/enrichers/__tests__/hacker-news.test.ts
@@ -46,7 +46,7 @@ describe('HackerNewsEnricher - body drain on non-OK fetch (Issue #599)', () => {
 
     expect(cancelMock).toHaveBeenCalledTimes(1);
     expect(genericEnrichSpy).toHaveBeenCalledTimes(1);
-    expect(genericEnrichSpy).toHaveBeenCalledWith(targetUrl);
+    expect(genericEnrichSpy).toHaveBeenCalledWith(targetUrl, undefined);
     expect(callOrder).toEqual(['cancel', 'generic.enrich']);
     expect(result).toEqual({ content: 'fallback content', thumbnail: null });
   });
@@ -71,7 +71,7 @@ describe('HackerNewsEnricher - body drain on non-OK fetch (Issue #599)', () => {
 
     expect(cancelMock).toHaveBeenCalledTimes(1);
     expect(genericEnrichSpy).toHaveBeenCalledTimes(1);
-    expect(genericEnrichSpy).toHaveBeenCalledWith(targetUrl);
+    expect(genericEnrichSpy).toHaveBeenCalledWith(targetUrl, undefined);
     expect(result).toEqual({ content: 'fallback content', thumbnail: null });
   });
 
@@ -94,6 +94,106 @@ describe('HackerNewsEnricher - body drain on non-OK fetch (Issue #599)', () => {
     // (将来 body && body.cancel() への書き換え等のリグレッションを検出)
     expect(cancelSpy).not.toHaveBeenCalled();
     expect(genericEnrichSpy).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+  });
+
+  it('should propagate externalSignal to fetch and to GenericEnricher fallback (Issue #608)', async () => {
+    const controller = new AbortController();
+    const signalsSeen: (AbortSignal | undefined)[] = [];
+
+    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
+      signalsSeen.push(init?.signal ?? undefined);
+      return {
+        ok: false,
+        status: 500,
+        body: { cancel: async () => {} },
+      };
+    }) as unknown as typeof global.fetch;
+
+    const genericEnrichSpy = jest
+      .spyOn(GenericContentEnricher.prototype, 'enrich')
+      .mockResolvedValue({ content: 'fallback', thumbnail: null });
+
+    const enricher = new HackerNewsEnricher();
+    await enricher.enrich(targetUrl, controller.signal);
+
+    // fetch には composed signal が渡されること（externalSignal が AbortSignal.any で合成される）
+    expect(signalsSeen.length).toBe(1);
+    expect(signalsSeen[0]).toBeInstanceOf(AbortSignal);
+    // generic フォールバックには externalSignal がそのまま渡されること
+    expect(genericEnrichSpy).toHaveBeenCalledWith(targetUrl, controller.signal);
+  });
+
+  it('should propagate externalSignal to repo OGP fallback fetch (Issue #608)', async () => {
+    const blobUrl = 'https://github.com/foo/bar/blob/main/README.md';
+    const blobHtml = `
+      <html>
+        <body>
+          <article itemprop="text" class="markdown-body">
+            ${'<p>Long enough README body content to bypass the short-content fallback path that triggers GenericEnricher again.</p>'.repeat(5)}
+          </article>
+        </body>
+      </html>
+    `;
+    const controller = new AbortController();
+    const fetchCallSignals: (AbortSignal | undefined)[] = [];
+
+    global.fetch = jest
+      .fn()
+      .mockImplementationOnce(async (_url, init?: RequestInit) => {
+        fetchCallSignals.push(init?.signal ?? undefined);
+        return {
+          ok: true,
+          status: 200,
+          text: async () => blobHtml,
+        };
+      })
+      .mockImplementationOnce(async (_url, init?: RequestInit) => {
+        fetchCallSignals.push(init?.signal ?? undefined);
+        return {
+          ok: false,
+          status: 500,
+          body: { cancel: async () => {} },
+        };
+      }) as unknown as typeof global.fetch;
+
+    const enricher = new HackerNewsEnricher();
+    await enricher.enrich(blobUrl, controller.signal);
+
+    // 主経路 fetch + repo OGP fallback fetch 両方に signal が合成されて渡されること
+    expect(fetchCallSignals.length).toBe(2);
+    expect(fetchCallSignals[0]).toBeInstanceOf(AbortSignal);
+    expect(fetchCallSignals[1]).toBeInstanceOf(AbortSignal);
+  });
+
+  it('should abort fetch immediately when externalSignal is already aborted (Issue #608)', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    let fetchCalled = false;
+    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
+      fetchCalled = true;
+      // composed signal は既に aborted 状態であるべき
+      expect(init?.signal?.aborted).toBe(true);
+      throw new DOMException('aborted', 'AbortError');
+    }) as unknown as typeof global.fetch;
+
+    const genericEnrichSpy = jest
+      .spyOn(GenericContentEnricher.prototype, 'enrich')
+      .mockResolvedValue(null);
+
+    const enricher = new HackerNewsEnricher();
+    const result = await enricher.enrich(
+      'https://github.com/foo/bar',
+      controller.signal
+    );
+
+    expect(fetchCalled).toBe(true);
+    // catch 経路で fallback が呼ばれるが abort 済 signal が伝わる
+    expect(genericEnrichSpy).toHaveBeenCalledWith(
+      'https://github.com/foo/bar',
+      controller.signal
+    );
     expect(result).toBeNull();
   });
 

--- a/lib/enrichers/__tests__/speakerdeck.test.ts
+++ b/lib/enrichers/__tests__/speakerdeck.test.ts
@@ -13,6 +13,21 @@ describe('SpeakerDeckEnricher - signal propagation (Issue #608)', () => {
   const targetUrl = 'https://speakerdeck.com/example/talk';
   let originalFetch: typeof global.fetch;
 
+  const buildOEmbedPayload = () => ({
+    type: 'rich',
+    version: '1.0',
+    title: 'Test Talk',
+    author_name: 'Speaker',
+    author_url: 'https://speakerdeck.com/example',
+    provider_name: 'Speaker Deck',
+    provider_url: 'https://speakerdeck.com',
+    html: '<iframe></iframe>',
+    width: 800,
+    height: 600,
+    ratio: 1.33,
+    thumbnail_url: 'https://speakerd.s3.amazonaws.com/test.jpg',
+  });
+
   beforeEach(() => {
     originalFetch = global.fetch;
   });
@@ -31,20 +46,7 @@ describe('SpeakerDeckEnricher - signal propagation (Issue #608)', () => {
       return {
         ok: true,
         status: 200,
-        json: async () => ({
-          type: 'rich',
-          version: '1.0',
-          title: 'Test Talk',
-          author_name: 'Speaker',
-          author_url: 'https://speakerdeck.com/example',
-          provider_name: 'Speaker Deck',
-          provider_url: 'https://speakerdeck.com',
-          html: '<iframe></iframe>',
-          width: 800,
-          height: 600,
-          ratio: 1.33,
-          thumbnail_url: 'https://speakerd.s3.amazonaws.com/test.jpg',
-        }),
+        json: async () => buildOEmbedPayload(),
       };
     }) as unknown as typeof global.fetch;
 
@@ -84,20 +86,7 @@ describe('SpeakerDeckEnricher - signal propagation (Issue #608)', () => {
       return {
         ok: true,
         status: 200,
-        json: async () => ({
-          type: 'rich',
-          version: '1.0',
-          title: 'Test Talk',
-          author_name: 'Speaker',
-          author_url: 'https://speakerdeck.com/example',
-          provider_name: 'Speaker Deck',
-          provider_url: 'https://speakerdeck.com',
-          html: '<iframe></iframe>',
-          width: 800,
-          height: 600,
-          ratio: 1.33,
-          thumbnail_url: 'https://speakerd.s3.amazonaws.com/test.jpg',
-        }),
+        json: async () => buildOEmbedPayload(),
       };
     }) as unknown as typeof global.fetch;
 

--- a/lib/enrichers/__tests__/speakerdeck.test.ts
+++ b/lib/enrichers/__tests__/speakerdeck.test.ts
@@ -68,6 +68,10 @@ describe('SpeakerDeckEnricher - signal propagation (Issue #608)', () => {
     const enricher = new SpeakerDeckEnricher();
     const result = await enricher.enrich(targetUrl, controller.signal);
 
+    // oEmbed fetch + fetchWithRetry (HTML fallback) の両方が試行されることを確認
+    // (fetchWithRetry は base.ts で maxRetries=3 だが、abort 済 signal の場合は
+    //  externalSignal?.aborted ガードで即時 throw されるため 1 回で終了する)
+    expect(global.fetch).toHaveBeenCalledTimes(2);
     // oEmbed が失敗 → HTML scraping fallback も abort 済 signal で失敗 → null
     expect(result).toBeNull();
   });

--- a/lib/enrichers/__tests__/speakerdeck.test.ts
+++ b/lib/enrichers/__tests__/speakerdeck.test.ts
@@ -1,0 +1,110 @@
+/**
+ * SpeakerDeckEnricher tests
+ *
+ * Issue #608 (signal 伝播) のリグレッション防止:
+ * externalSignal が enrich → fetchOEmbed (private) と
+ * fetchWithRetry (HTML scraping fallback / thumbnail サブ経路) の
+ * 両方の経路に伝播することを検証する。
+ */
+
+import { SpeakerDeckEnricher } from '../speakerdeck';
+
+describe('SpeakerDeckEnricher - signal propagation (Issue #608)', () => {
+  const targetUrl = 'https://speakerdeck.com/example/talk';
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('should pass composed signal to fetchOEmbed fetch when externalSignal is provided', async () => {
+    const controller = new AbortController();
+    const signalsSeen: (AbortSignal | undefined)[] = [];
+
+    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
+      signalsSeen.push(init?.signal ?? undefined);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          type: 'rich',
+          version: '1.0',
+          title: 'Test Talk',
+          author_name: 'Speaker',
+          author_url: 'https://speakerdeck.com/example',
+          provider_name: 'Speaker Deck',
+          provider_url: 'https://speakerdeck.com',
+          html: '<iframe></iframe>',
+          width: 800,
+          height: 600,
+          ratio: 1.33,
+          thumbnail_url: 'https://speakerd.s3.amazonaws.com/test.jpg',
+        }),
+      };
+    }) as unknown as typeof global.fetch;
+
+    const enricher = new SpeakerDeckEnricher();
+    await enricher.enrich(targetUrl, controller.signal);
+
+    expect(signalsSeen.length).toBe(1);
+    // composeSignal は AbortSignal.any() で external + timeout を合成したものを返す
+    expect(signalsSeen[0]).toBeInstanceOf(AbortSignal);
+  });
+
+  it('should abort fetchOEmbed when externalSignal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
+      expect(init?.signal?.aborted).toBe(true);
+      throw new DOMException('aborted', 'AbortError');
+    }) as unknown as typeof global.fetch;
+
+    const enricher = new SpeakerDeckEnricher();
+    const result = await enricher.enrich(targetUrl, controller.signal);
+
+    // oEmbed が失敗 → HTML scraping fallback も abort 済 signal で失敗 → null
+    expect(result).toBeNull();
+  });
+
+  it('should work without externalSignal (backward compatibility)', async () => {
+    const signalsSeen: (AbortSignal | undefined)[] = [];
+
+    global.fetch = jest.fn(async (_url, init?: RequestInit) => {
+      signalsSeen.push(init?.signal ?? undefined);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          type: 'rich',
+          version: '1.0',
+          title: 'Test Talk',
+          author_name: 'Speaker',
+          author_url: 'https://speakerdeck.com/example',
+          provider_name: 'Speaker Deck',
+          provider_url: 'https://speakerdeck.com',
+          html: '<iframe></iframe>',
+          width: 800,
+          height: 600,
+          ratio: 1.33,
+          thumbnail_url: 'https://speakerd.s3.amazonaws.com/test.jpg',
+        }),
+      };
+    }) as unknown as typeof global.fetch;
+
+    const enricher = new SpeakerDeckEnricher();
+    const result = await enricher.enrich(targetUrl);
+
+    // signal 引数なしでも timeout signal は付与される
+    expect(signalsSeen[0]).toBeInstanceOf(AbortSignal);
+    expect(result).not.toBeNull();
+    expect(result?.thumbnail).toBe(
+      'https://speakerd.s3.amazonaws.com/test.jpg'
+    );
+  });
+});

--- a/lib/enrichers/anthropic-blog.ts
+++ b/lib/enrichers/anthropic-blog.ts
@@ -15,7 +15,8 @@ export class ClaudeBlogEnricher extends BaseContentEnricher {
    * Claude Blogの記事を詳細に取得してエンリッチ
    */
   async enrich(
-    url: string
+    url: string,
+    externalSignal?: AbortSignal
   ): Promise<{ content: string | null; thumbnail?: string | null } | null> {
     try {
       const response = await fetch(url, {
@@ -25,6 +26,7 @@ export class ClaudeBlogEnricher extends BaseContentEnricher {
           Accept: 'text/html,application/xhtml+xml',
           'Accept-Language': 'en-US,en;q=0.9',
         },
+        signal: this.composeSignal(externalSignal, 30000),
       });
 
       if (!response.ok) {

--- a/lib/enrichers/anthropic-news.ts
+++ b/lib/enrichers/anthropic-news.ts
@@ -4,8 +4,6 @@ import { anthropicNewsConfig } from '@/lib/config/anthropic-news';
 import * as cheerio from 'cheerio';
 import logger from '@/lib/logger';
 
-const ENRICHER_TIMEOUT = 15000; // 15 seconds
-
 export class AnthropicNewsEnricher extends BaseContentEnricher {
   /**
    * Anthropic News (anthropic.com/news) の記事URLかどうかを判定
@@ -27,14 +25,12 @@ export class AnthropicNewsEnricher extends BaseContentEnricher {
    * Anthropic Newsの記事を詳細に取得してエンリッチ
    */
   async enrich(
-    url: string
+    url: string,
+    externalSignal?: AbortSignal
   ): Promise<{ content: string | null; thumbnail?: string | null } | null> {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), ENRICHER_TIMEOUT);
-
     try {
       const response = await fetch(url, {
-        signal: controller.signal,
+        signal: this.composeSignal(externalSignal, 30000),
         headers: {
           'User-Agent':
             'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
@@ -160,8 +156,6 @@ export class AnthropicNewsEnricher extends BaseContentEnricher {
         '[Anthropic News Enricher] Error enriching URL'
       );
       return null;
-    } finally {
-      clearTimeout(timeoutId);
     }
   }
 

--- a/lib/enrichers/aws.ts
+++ b/lib/enrichers/aws.ts
@@ -139,7 +139,7 @@ export class AWSEnricher extends BaseContentEnricher {
       };
     } catch (error) {
       if (error instanceof Error) {
-        if (error.name === 'TimeoutError' || error.name === 'AbortError') {
+        if (/TimeoutError$/i.test(error.name) || error.name === 'AbortError') {
           logger.error({ url }, '[AWS Enricher] Request timeout');
         } else {
           logger.error(

--- a/lib/enrichers/aws.ts
+++ b/lib/enrichers/aws.ts
@@ -139,8 +139,13 @@ export class AWSEnricher extends BaseContentEnricher {
       };
     } catch (error) {
       if (error instanceof Error) {
-        if (/TimeoutError$/i.test(error.name) || error.name === 'AbortError') {
+        if (/TimeoutError$/i.test(error.name)) {
           logger.error({ url }, '[AWS Enricher] Request timeout');
+        } else if (error.name === 'AbortError') {
+          // 呼び出し元 (collect-feeds.ts の runWithTimeout 等) からのキャンセル
+          // 操作は実エラーではないため warn で記録し、運用ログでタイムアウトと
+          // 区別できるようにする
+          logger.warn({ url }, '[AWS Enricher] Request aborted');
         } else {
           logger.error(
             { err: error, url },

--- a/lib/enrichers/aws.ts
+++ b/lib/enrichers/aws.ts
@@ -27,7 +27,8 @@ export class AWSEnricher extends BaseContentEnricher {
    * AWSブログの記事を詳細に取得してエンリッチ
    */
   async enrich(
-    url: string
+    url: string,
+    externalSignal?: AbortSignal
   ): Promise<{ content: string | null; thumbnail?: string | null } | null> {
     try {
       const response = await fetch(url, {
@@ -36,7 +37,7 @@ export class AWSEnricher extends BaseContentEnricher {
           Accept: 'text/html,application/xhtml+xml',
           'Accept-Language': 'en-US,en;q=0.9,ja;q=0.8',
         },
-        signal: AbortSignal.timeout(15000),
+        signal: this.composeSignal(externalSignal, 30000),
       });
 
       if (!response.ok) {
@@ -139,10 +140,7 @@ export class AWSEnricher extends BaseContentEnricher {
     } catch (error) {
       if (error instanceof Error) {
         if (error.name === 'TimeoutError' || error.name === 'AbortError') {
-          logger.error(
-            { url },
-            '[AWS Enricher] Request timeout after 15 seconds'
-          );
+          logger.error({ url }, '[AWS Enricher] Request timeout');
         } else {
           logger.error(
             { err: error, url },

--- a/lib/enrichers/cloudflare-blog.ts
+++ b/lib/enrichers/cloudflare-blog.ts
@@ -18,7 +18,8 @@ export class CloudflareBlogEnricher extends BaseContentEnricher {
    * Cloudflare Blogの記事を詳細に取得してエンリッチ
    */
   async enrich(
-    url: string
+    url: string,
+    externalSignal?: AbortSignal
   ): Promise<{ content: string | null; thumbnail?: string | null } | null> {
     try {
       const response = await fetch(url, {
@@ -27,6 +28,7 @@ export class CloudflareBlogEnricher extends BaseContentEnricher {
           Accept: 'text/html,application/xhtml+xml',
           'Accept-Language': 'en-US,en;q=0.9',
         },
+        signal: this.composeSignal(externalSignal, 30000),
       });
 
       if (!response.ok) {

--- a/lib/enrichers/github-blog.ts
+++ b/lib/enrichers/github-blog.ts
@@ -18,7 +18,8 @@ export class GitHubBlogEnricher extends BaseContentEnricher {
    * GitHub Blogの記事を詳細に取得してエンリッチ
    */
   async enrich(
-    url: string
+    url: string,
+    externalSignal?: AbortSignal
   ): Promise<{ content: string | null; thumbnail?: string | null } | null> {
     try {
       const response = await fetch(url, {
@@ -27,6 +28,7 @@ export class GitHubBlogEnricher extends BaseContentEnricher {
           Accept: 'text/html,application/xhtml+xml',
           'Accept-Language': 'en-US,en;q=0.9',
         },
+        signal: this.composeSignal(externalSignal, 30000),
       });
 
       if (!response.ok) {

--- a/lib/enrichers/hacker-news.ts
+++ b/lib/enrichers/hacker-news.ts
@@ -50,12 +50,14 @@ export class HackerNewsEnricher extends BaseContentEnricher {
     }
   }
 
-  async enrich(url: string): Promise<EnrichmentResult | null> {
+  async enrich(
+    url: string,
+    externalSignal?: AbortSignal
+  ): Promise<EnrichmentResult | null> {
     try {
-      // 30秒タイムアウトを設定
       const response = await fetch(url, {
         headers: HackerNewsEnricher.DEFAULT_HEADERS,
-        signal: AbortSignal.timeout(30000), // 30秒タイムアウト
+        signal: this.composeSignal(externalSignal, 30000),
       });
 
       // ステータスコードが200以外の場合はGenericEnricherにフォールバック
@@ -70,7 +72,7 @@ export class HackerNewsEnricher extends BaseContentEnricher {
           { status: response.status, url },
           '[HackerNewsEnricher] HTTP error, falling back to GenericEnricher'
         );
-        return await this.genericEnricher.enrich(url);
+        return await this.genericEnricher.enrich(url, externalSignal);
       }
 
       const html = await response.text();
@@ -125,7 +127,7 @@ export class HackerNewsEnricher extends BaseContentEnricher {
             try {
               const repoResponse = await fetch(repoRootUrl, {
                 headers: HackerNewsEnricher.DEFAULT_HEADERS,
-                signal: AbortSignal.timeout(5000), // 5秒タイムアウト
+                signal: this.composeSignal(externalSignal, 5000),
               });
               if (repoResponse.ok) {
                 const repoHtml = await repoResponse.text();
@@ -225,7 +227,10 @@ export class HackerNewsEnricher extends BaseContentEnricher {
           '[HackerNewsEnricher] Content too short, falling back to GenericEnricher'
         );
         try {
-          const genericResult = await this.genericEnricher.enrich(url);
+          const genericResult = await this.genericEnricher.enrich(
+            url,
+            externalSignal
+          );
           if (genericResult) return genericResult;
         } catch (fallbackError) {
           logger.debug(
@@ -249,7 +254,10 @@ export class HackerNewsEnricher extends BaseContentEnricher {
 
       // フォールバック: GenericEnricherを試す
       try {
-        const genericResult = await this.genericEnricher.enrich(url);
+        const genericResult = await this.genericEnricher.enrich(
+          url,
+          externalSignal
+        );
         if (genericResult) {
           return genericResult;
         }

--- a/lib/enrichers/index.ts
+++ b/lib/enrichers/index.ts
@@ -165,17 +165,19 @@ export class ContentEnricherFactory {
    * 各エンリッチャーを順番に試して最初の成功結果を返す
    * @param url 処理対象のURL
    * @param sourceId 記事のsourceId (optional)
+   * @param externalSignal 外部abort signal (optional、呼び出し側でtimeout連携時に使用)
    * @returns エンリッチメント結果、またはnull
    */
   async trySequential(
     url: string,
-    sourceId?: string
+    sourceId?: string,
+    externalSignal?: AbortSignal
   ): Promise<import('./base').EnrichmentResult | null> {
     // すべてのエンリッチャーを順番に試す
     for (const enricher of this.enrichers) {
       try {
         if (enricher.canHandle(url, sourceId)) {
-          const result = await enricher.enrich(url);
+          const result = await enricher.enrich(url, externalSignal);
           if (result && (result.content || result.thumbnail)) {
             // 有効な結果が得られたら即座に返す
             return result;

--- a/lib/enrichers/medium-engineering.ts
+++ b/lib/enrichers/medium-engineering.ts
@@ -15,10 +15,13 @@ export class MediumEngineeringEnricher extends BaseContentEnricher {
     );
   }
 
-  async enrich(url: string): Promise<EnrichmentResult | null> {
+  async enrich(
+    url: string,
+    externalSignal?: AbortSignal
+  ): Promise<EnrichmentResult | null> {
     try {
       const response = await fetch(url, {
-        signal: AbortSignal.timeout(30000),
+        signal: this.composeSignal(externalSignal, 30000),
         headers: {
           'User-Agent':
             'Mozilla/5.0 (compatible; TechTrendBot/1.0; +https://techtrend.example.com/bot)',

--- a/lib/enrichers/mozilla-hacks.ts
+++ b/lib/enrichers/mozilla-hacks.ts
@@ -15,7 +15,8 @@ export class MozillaHacksEnricher extends BaseContentEnricher {
    * Mozilla Hacksの記事を詳細に取得してエンリッチ
    */
   async enrich(
-    url: string
+    url: string,
+    externalSignal?: AbortSignal
   ): Promise<{ content: string | null; thumbnail?: string | null } | null> {
     try {
       const response = await fetch(url, {
@@ -24,6 +25,7 @@ export class MozillaHacksEnricher extends BaseContentEnricher {
           Accept: 'text/html,application/xhtml+xml',
           'Accept-Language': 'en-US,en;q=0.9',
         },
+        signal: this.composeSignal(externalSignal, 30000),
       });
 
       if (!response.ok) {

--- a/lib/enrichers/speakerdeck.ts
+++ b/lib/enrichers/speakerdeck.ts
@@ -32,10 +32,13 @@ export class SpeakerDeckEnricher extends BaseContentEnricher {
     return isUrlFromDomain(url, 'speakerdeck.com');
   }
 
-  async enrich(url: string): Promise<EnrichedContent | null> {
+  async enrich(
+    url: string,
+    externalSignal?: AbortSignal
+  ): Promise<EnrichedContent | null> {
     try {
       // Strategy 1: Try oEmbed API first (most reliable for content)
-      const oEmbedData = await this.fetchOEmbed(url);
+      const oEmbedData = await this.fetchOEmbed(url, externalSignal);
 
       if (oEmbedData) {
         const content = this.buildContentFromOEmbed(oEmbedData, url);
@@ -48,7 +51,7 @@ export class SpeakerDeckEnricher extends BaseContentEnricher {
               { url },
               '[SpeakerDeckEnricher] oEmbed has no thumbnail, fetching from HTML'
             );
-            const html = await this.fetchWithRetry(url);
+            const html = await this.fetchWithRetry(url, externalSignal);
             thumbnail = this.extractThumbnail(html);
           } catch (htmlError) {
             logger.debug(
@@ -78,7 +81,7 @@ export class SpeakerDeckEnricher extends BaseContentEnricher {
         { url },
         '[SpeakerDeckEnricher] Falling back to HTML scraping'
       );
-      const html = await this.fetchWithRetry(url);
+      const html = await this.fetchWithRetry(url, externalSignal);
       return this.extractFromHtml(html, url);
     } catch (error) {
       logger.error(
@@ -89,7 +92,10 @@ export class SpeakerDeckEnricher extends BaseContentEnricher {
     }
   }
 
-  private async fetchOEmbed(url: string): Promise<OEmbedResponse | null> {
+  private async fetchOEmbed(
+    url: string,
+    externalSignal?: AbortSignal
+  ): Promise<OEmbedResponse | null> {
     try {
       const oEmbedUrl = `${this.oEmbedEndpoint}?url=${encodeURIComponent(url)}`;
 
@@ -98,7 +104,7 @@ export class SpeakerDeckEnricher extends BaseContentEnricher {
           Accept: 'application/json',
           'User-Agent': 'TechTrend/1.0 ContentEnricher',
         },
-        signal: AbortSignal.timeout(10000),
+        signal: this.composeSignal(externalSignal, 30000),
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## 概要

- PR #598 で導入した `IContentEnricher.enrich(url, signal?)` 契約に未準拠な 9 enricher を契約準拠させ、外部 `AbortSignal` を fetch・fallback に正しく伝播させる
- `scripts/scheduled/collect-feeds.ts` の `runWithTimeout` 発火時に fetch が即時キャンセルされ、socket pressure が改善する
- `ContentEnricherFactory.trySequential()` も signal 透過化し、契約準拠を factory 層まで完成

Closes #608

## 実装内容

### 9 enricher (DoD 1-5)

| ファイル | 変更 |
|---------|------|
| `anthropic-blog.ts` / `cloudflare-blog.ts` / `github-blog.ts` / `mozilla-hacks.ts` | timeout 不在だったため `composeSignal(externalSignal, 30000)` を新規付与 + シグネチャ拡張 |
| `aws.ts` | `AbortSignal.timeout(15000)` → `composeSignal(externalSignal, 30000)` (注意点参照) |
| `medium-engineering.ts` | `AbortSignal.timeout(30000)` → `composeSignal(externalSignal, 30000)` (値維持) |
| `anthropic-news.ts` | `ENRICHER_TIMEOUT=15000` 定数 + `AbortController` + `setTimeout` + `clearTimeout` 削除、`composeSignal(externalSignal, 30000)` 統一 (注意点参照) |
| `hacker-news.ts` | 主経路 fetch + repo OGP fallback (5000ms 維持) を `composeSignal` 化、3 箇所の `genericEnricher.enrich(url)` を `(url, externalSignal)` に |
| `speakerdeck.ts` | `enrich` シグネチャ拡張、private `fetchOEmbed` も `(url, signal?)` に拡張 (10s→30s)、`fetchWithRetry` 呼び出し 2 箇所に signal 透過 |

### Factory 層

| ファイル | 変更 |
|---------|------|
| `index.ts` | `ContentEnricherFactory.trySequential()` に `externalSignal?` 引数追加、`enricher.enrich(url, externalSignal)` で透過 |

### テスト

- `__tests__/hacker-news.test.ts`: signal 伝播テスト 3 件追加 (主経路 + generic fallback / repo OGP fallback / abort 済 signal の即時 abort 検証)。既存 spy 引数を `(targetUrl, undefined)` に更新
- `__tests__/speakerdeck.test.ts` (新規): `fetchOEmbed` への composed signal 伝播 / abort 済 signal での失敗 / 後方互換性 (signal なし) 検証 3 件

## 注意点

### timeout 値変更

| ファイル | 旧 | 新 | 理由 |
|---------|---|---|------|
| `aws.ts` | 15000ms | 30000ms | 全 9 ファイル 30000ms 統一方針 |
| `anthropic-news.ts` | 15000ms | 30000ms | 同上 |
| `speakerdeck.ts` (`fetchOEmbed`) | 10000ms | 30000ms | 同上 |

外部 `POST_SAVE_ENRICH_TIMEOUT_MS = 10000ms` (`collect-feeds.ts:131`) が先に発火するため、本番収集バッチでは 10s で abort される。新 timeout は env 変更時の調整不要を保証する「保険」位置付け。

### hacker-news フォールバック挙動変化

`runWithTimeout` の 10s 経過後、`generic.ts:42` の `if (externalSignal?.aborted) return null;` で即 null が返る。「外部 timeout 経過後はベストエフォートで諦める」意図と一致する仕様変更。

### テスト spy 引数更新

既存 `genericEnrichSpy.toHaveBeenCalledWith(targetUrl)` を `(targetUrl, undefined)` に更新。signal なし呼び出し時の伝播挙動を反映 (signal は optional のため `undefined` が伝わる)。

## フォロー issue

`fetchWithRetry` 経由で同型の契約未準拠が残る 16 ファイル (`google-ai`, `freee`, `gmo`, `huggingface`, `google-dev`, `moneyforward`, `qiita-ai`, `publickey`, `huggingface-papers`, `stackoverflow`, `youtube`, `thinkit`, `zenn`, `zenn-ai`, `zenn-api`, `infoq`) は本 PR スコープ外。マージ後に別 issue として起票する。

## テスト結果 (verify フェーズ)

- Lint: 0 errors, 0 warnings
- Type-check: PASS
- Security audit: 0 vulnerabilities
- Build: Docker production build 成功
- Tests: 6 suites, 124 passed, 1 skipped (`lib/enrichers/__tests__/`)
- Diff Review: 12 files, +267/-38 lines, 意図しない変更なし

## チェックリスト

- [x] テスト通過 (新規 6 件 + 既存維持)
- [x] 実装計画書 / 調査レポート / 実装記録あり
- [x] 破壊的変更なし (`signal?` は optional)
- [x] cross-review 反映済 (typescript-reviewer + DA、HIGH 指摘対応または計画方針通り SKIP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 複数のコンテンツエンリッチャーで外部中止シグナルを受け付けるようになり、外部キャンセルと内部タイムアウトを連携できるようになりました。

* **Tests**
  * 中止シグナルの合成・伝播や、既に中止された信号の扱いを検証するテストを追加し、フォールバック経路やタイムアウト挙動の網羅性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->