### PR TITLE
fix(deps): Dependabot 残存 2 件を解消（AI SDK v7 移行 + brace-expansion）

### DIFF
--- a/app/api/rag/agent-search/batch-handler.ts
+++ b/app/api/rag/agent-search/batch-handler.ts
@@ -244,9 +244,7 @@ export async function handleBatchRequest(
       ],
       abortSignal: agentAbortSignal,
     };
-    const result = await modeContext.agent.generate(
-      generateOptions as Parameters<typeof modeContext.agent.generate>[0]
-    );
+    const result = await modeContext.agent.generate(generateOptions);
 
     const allToolCalls =
       result.steps?.flatMap((step) => step.toolCalls ?? []) ?? [];

--- a/app/api/rag/agent-search/streaming-handler.ts
+++ b/app/api/rag/agent-search/streaming-handler.ts
@@ -257,9 +257,7 @@ async function createStreamingResponse(
           ],
           abortSignal: agentAbortSignal,
         };
-        const streamResult = await modeContext.agent.stream(
-          streamOptions as Parameters<typeof modeContext.agent.stream>[0]
-        );
+        const streamResult = await modeContext.agent.stream(streamOptions);
 
         if (qaContextPayload) {
           controller.enqueue(

--- a/jest.config.dom.js
+++ b/jest.config.dom.js
@@ -110,6 +110,11 @@ const esmAllowList = [
   'escape-string-regexp',
   'jsdom',
   'parse5',
+  // AI SDK v7 系は ESM のみ配信のため Jest の変換対象に含める
+  'ai',
+  '@ai-sdk',
+  // @ai-sdk/provider-utils が依存（ESM のみ）
+  '@workflow',
 ];
 const esmPattern = esmAllowList.join('|');
 

--- a/jest.config.integration.js
+++ b/jest.config.integration.js
@@ -44,6 +44,11 @@ const esmAllowList = [
   'jsdom',
   'parse5',
   'uuid',
+  // AI SDK v7 系は ESM のみ配信のため Jest の変換対象に含める
+  'ai',
+  '@ai-sdk',
+  // @ai-sdk/provider-utils が依存（ESM のみ）
+  '@workflow',
 ];
 const esmPattern = esmAllowList.join('|');
 

--- a/jest.config.node.js
+++ b/jest.config.node.js
@@ -80,6 +80,11 @@ const esmAllowList = [
   'jsdom',
   'parse5',
   'uuid',
+  // AI SDK v7 系は ESM のみ配信のため Jest の変換対象に含める
+  'ai',
+  '@ai-sdk',
+  // @ai-sdk/provider-utils が依存（ESM のみ）
+  '@workflow',
 ];
 const esmPattern = esmAllowList.join('|');
 

--- a/lib/rag/agents/article-qa-agent.ts
+++ b/lib/rag/agents/article-qa-agent.ts
@@ -148,7 +148,8 @@ export const articleQaAgent = new Agent({
   // Average path: 8-12 steps, max 40 for complex questions
   stopWhen: stepCountIs(40),
 
-  system: ARTICLE_QA_SYSTEM_PROMPT,
+  // AI SDK v7 で system は instructions に改名された
+  instructions: ARTICLE_QA_SYSTEM_PROMPT,
 
   tools: {
     'article-context': articleContextTool,

--- a/lib/rag/agents/article-search-agent.ts
+++ b/lib/rag/agents/article-search-agent.ts
@@ -32,7 +32,8 @@ export const articleSearchAgent = new Agent({
   // Max: Phase 1 (6 thresholds) + Phase 2 (3 temporal levels x 6 thresholds) + response steps
   stopWhen: stepCountIs(32),
 
-  system: `
+  // AI SDK v7 で system は instructions に改名された
+  instructions: `
 You are a technical article search assistant for TechTrend, a platform for discovering technical articles.
 
 CRITICAL INSTRUCTION: You MUST ALWAYS provide a text response to the user after calling tools. Never return only tool results without explaining them in natural language.

--- a/lib/rag/tools/semantic-search-tool.ts
+++ b/lib/rag/tools/semantic-search-tool.ts
@@ -43,7 +43,9 @@ function getSearchService(): VectorSearchService {
  * Handles cases where publishedAt might be Date (from Prisma) or string (from mocks/raw queries)
  */
 function toIsoDate(input: Date | string): string {
-  return input instanceof Date ? input.toISOString() : new Date(input).toISOString();
+  return input instanceof Date
+    ? input.toISOString()
+    : new Date(input).toISOString();
 }
 
 /**
@@ -68,12 +70,14 @@ const toolOutputSchema = z.object({
   originalQuery: z.string(),
   expandedQuery: z.string(),
   expansionMethod: z.enum(['none', 'dictionary', 'ai']),
-  fallbackMetadata: z.object({
-    phase: z.union([z.literal(1), z.null()]),
-    finalThreshold: z.number(),
-    attemptCount: z.number(),
-    usedFallback: z.boolean(),
-  }).optional(),
+  fallbackMetadata: z
+    .object({
+      phase: z.union([z.literal(1), z.null()]),
+      finalThreshold: z.number(),
+      attemptCount: z.number(),
+      usedFallback: z.boolean(),
+    })
+    .optional(),
 });
 
 /**
@@ -81,6 +85,76 @@ const toolOutputSchema = z.object({
  *
  * Enables agents to search for technical articles using semantic similarity.
  */
+const semanticSearchInputSchema = z.object({
+  query: z
+    .string()
+    .min(1, 'Query cannot be empty')
+    .max(200, 'Query too long for tool (max 200 characters)') // Stricter than API limit (500)
+    .describe('Search query text'),
+
+  topK: z
+    .number()
+    .int()
+    .min(1, 'topK must be at least 1')
+    .max(20, 'topK cannot exceed 20') // Agent limit: 20 (stricter than API limit: 100)
+    .default(10)
+    .describe('Number of results to return (1-20, default: 10)'),
+
+  similarityThreshold: z
+    .number()
+    .min(0, 'Similarity threshold must be between 0 and 1')
+    .max(1, 'Similarity threshold must be between 0 and 1')
+    .default(0.55)
+    .describe('Minimum similarity score (0-1, default: 0.55)'),
+
+  enableFallback: z
+    .boolean()
+    .default(true)
+    .describe('Enable automatic threshold fallback to improve recall'),
+
+  filters: z
+    .object({
+      sources: z
+        .array(z.string())
+        .max(10, 'Too many source filters (max 10 for agents)') // Clamped to 10 (API allows 50)
+        .optional(),
+      tags: z
+        .array(z.string())
+        .max(10, 'Too many tag filters (max 10 for agents)') // Clamped to 10 (API allows 20)
+        .optional(),
+      dateRange: z
+        .object({
+          from: z
+            .string()
+            .datetime()
+            .optional()
+            .describe('ISO 8601 start date (UTC)'),
+          to: z
+            .string()
+            .datetime()
+            .optional()
+            .describe('ISO 8601 end date (UTC)'),
+        })
+        .optional()
+        .describe(
+          'Date range filter for temporal queries (e.g., "latest", "last week")'
+        ),
+      recencyBoost: z
+        .number()
+        .min(0, 'recencyBoost must be between 0 and 1')
+        .max(1, 'recencyBoost must be between 0 and 1')
+        .default(0)
+        .describe(
+          'Recency weight (0=disabled, 0.3-0.4=balanced, 1=max recency)'
+        ),
+    })
+    .optional()
+    .describe('Optional filters for sources, tags, and date range'),
+});
+
+type SemanticSearchInput = z.infer<typeof semanticSearchInputSchema>;
+type SemanticSearchOutput = z.infer<typeof toolOutputSchema>;
+
 export const semanticSearchTool = tool({
   description: `
 Search for technical articles using semantic similarity with optional date filtering and recency boost.
@@ -120,64 +194,21 @@ DO NOT use this tool for:
 The tool returns articles ranked by semantic similarity (0-1 scale, higher is better), optionally boosted by recency.
   `.trim(),
 
-  inputSchema: z.object({
-    query: z
-      .string()
-      .min(1, 'Query cannot be empty')
-      .max(200, 'Query too long for tool (max 200 characters)') // Stricter than API limit (500)
-      .describe('Search query text'),
-
-    topK: z
-      .number()
-      .int()
-      .min(1, 'topK must be at least 1')
-      .max(20, 'topK cannot exceed 20') // Agent limit: 20 (stricter than API limit: 100)
-      .default(10)
-      .describe('Number of results to return (1-20, default: 10)'),
-
-    similarityThreshold: z
-      .number()
-      .min(0, 'Similarity threshold must be between 0 and 1')
-      .max(1, 'Similarity threshold must be between 0 and 1')
-      .default(0.55)
-      .describe('Minimum similarity score (0-1, default: 0.55)'),
-
-    enableFallback: z
-      .boolean()
-      .default(true)
-      .describe('Enable automatic threshold fallback to improve recall'),
-
-    filters: z
-      .object({
-        sources: z
-          .array(z.string())
-          .max(10, 'Too many source filters (max 10 for agents)') // Clamped to 10 (API allows 50)
-          .optional(),
-        tags: z
-          .array(z.string())
-          .max(10, 'Too many tag filters (max 10 for agents)') // Clamped to 10 (API allows 20)
-          .optional(),
-        dateRange: z
-          .object({
-            from: z.string().datetime().optional().describe('ISO 8601 start date (UTC)'),
-            to: z.string().datetime().optional().describe('ISO 8601 end date (UTC)'),
-          })
-          .optional()
-          .describe('Date range filter for temporal queries (e.g., "latest", "last week")'),
-        recencyBoost: z
-          .number()
-          .min(0, 'recencyBoost must be between 0 and 1')
-          .max(1, 'recencyBoost must be between 0 and 1')
-          .default(0)
-          .describe('Recency weight (0=disabled, 0.3-0.4=balanced, 1=max recency)'),
-      })
-      .optional()
-      .describe('Optional filters for sources, tags, and date range'),
-  }),
+  // AI SDK v7 の tool() は INPUT を execute の引数形状から推論する。
+  // filters が optional なため、型注釈なしの分割代入だと「filters 必須」の
+  // 候補が作られ strictFunctionTypes 下で代入不可になる（推論が never に落ちる）。
+  // スキーマを切り出して z.infer で注釈することで INPUT を確定させる。
+  inputSchema: semanticSearchInputSchema,
 
   outputSchema: toolOutputSchema,
 
-  execute: async ({ query, topK, similarityThreshold, enableFallback, filters }) => {
+  execute: async ({
+    query,
+    topK,
+    similarityThreshold,
+    enableFallback,
+    filters,
+  }: SemanticSearchInput): Promise<SemanticSearchOutput> => {
     const startTime = Date.now();
     try {
       logger.debug(
@@ -187,7 +218,10 @@ The tool returns articles ranked by semantic similarity (0-1 scale, higher is be
           similarityThreshold,
           enableFallback,
           hasFilters: !!filters,
-          hasDateFilter: !!(filters?.dateRange && (filters.dateRange.from || filters.dateRange.to)),
+          hasDateFilter: !!(
+            filters?.dateRange &&
+            (filters.dateRange.from || filters.dateRange.to)
+          ),
           dateRangeFrom: filters?.dateRange?.from,
           dateRangeTo: filters?.dateRange?.to,
           recencyBoost: filters?.recencyBoost ?? 0,
@@ -197,24 +231,33 @@ The tool returns articles ranked by semantic similarity (0-1 scale, higher is be
 
       const searchService = getSearchService();
 
-      const { results, metadata } = await searchService.searchWithFallback(query, {
-        topK,
-        similarityThreshold,
-        enableFallback,
-        sourceIds: filters?.sources,
-        tags: filters?.tags,
-        dateRange: filters?.dateRange,
-        recencyBoost: filters?.recencyBoost,
-        embeddingKey: 'summary',
-      });
+      const { results, metadata } = await searchService.searchWithFallback(
+        query,
+        {
+          topK,
+          similarityThreshold,
+          enableFallback,
+          sourceIds: filters?.sources,
+          tags: filters?.tags,
+          dateRange: filters?.dateRange,
+          recencyBoost: filters?.recencyBoost,
+          embeddingKey: 'summary',
+        }
+      );
 
-      const expansion = { method: 'none' as const, expandedQuery: query, latencyMs: 0 };
+      const expansion = {
+        method: 'none' as const,
+        expandedQuery: query,
+        latencyMs: 0,
+      };
       const originalQuery = query;
 
       const elapsedMs = Date.now() - startTime;
       const avgSimilarity =
         results.length > 0
-          ? (results.reduce((sum, r) => sum + r.similarity, 0) / results.length).toFixed(4)
+          ? (
+              results.reduce((sum, r) => sum + r.similarity, 0) / results.length
+            ).toFixed(4)
           : 0;
 
       logger.info(
@@ -222,14 +265,22 @@ The tool returns articles ranked by semantic similarity (0-1 scale, higher is be
           query: query.substring(0, 50),
           resultCount: results.length,
           threshold: similarityThreshold,
-          hasDateFilter: !!(filters?.dateRange && (filters.dateRange.from || filters.dateRange.to)),
+          hasDateFilter: !!(
+            filters?.dateRange &&
+            (filters.dateRange.from || filters.dateRange.to)
+          ),
           dateRangeFrom: filters?.dateRange?.from,
           dateRangeTo: filters?.dateRange?.to,
           recencyBoost: filters?.recencyBoost ?? 0,
           avgSimilarity,
           elapsedMs,
           isLowRecall: results.length < 3,
-          likelyConstraint: results.length < 3 && filters?.dateRange ? 'temporal' : results.length < 3 ? 'threshold' : 'none',
+          likelyConstraint:
+            results.length < 3 && filters?.dateRange
+              ? 'temporal'
+              : results.length < 3
+                ? 'threshold'
+                : 'none',
         },
         'Tool: semantic-article-search completed'
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1615,9 +1615,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1696,9 +1696,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1904,9 +1904,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.5.tgz",
-      "integrity": "sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.10.tgz",
+      "integrity": "sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -8726,16 +8726,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -11262,9 +11262,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11353,9 +11353,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11437,9 +11437,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11508,9 +11508,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22092,9 +22092,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@ai-sdk/openai": "^2.0.52",
+        "@ai-sdk/openai": "^4.0.27",
         "@better-auth/prisma-adapter": "^1.6.11",
         "@dqbd/tiktoken": "^1.0.22",
         "@google/generative-ai": "^0.24.1",
@@ -44,7 +44,7 @@
         "@tanstack/react-query-devtools": "^5.87.4",
         "@vercel/otel": "^2.0.1",
         "@xyflow/react": "^12.10.0",
-        "ai": "^5.0.76",
+        "ai": "^7.0.48",
         "async-mutex": "^0.5.0",
         "axios": "^1.16.0",
         "bcryptjs": "^3.0.2",
@@ -157,62 +157,64 @@
       "license": "MIT"
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.103",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.103.tgz",
-      "integrity": "sha512-f3NmeCxHOmZTIk/VG3nVrF6LnuU+S/Ls4aUBSKOI1QF+xtkF6FnREsTkSvcbzoJSsO6Jr7OyQXXEWGFDAMobLQ==",
+      "version": "4.0.37",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.37.tgz",
+      "integrity": "sha512-YBCTsSlX0ETVsjo0ihfBOeJ3p3y1wXKXDzF9Ygp9dscUY06dzOGmyWJSGsKg+khKVArzBWUW4UCSAKms20ZDmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.27",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "2.0.108",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.108.tgz",
-      "integrity": "sha512-apM/hmw4ZinxPK/0vfuuiZ6MwoJmyoBjwTErgTqKVOyFhJxoYP9+SD4jV6yrFIzhuTv4X6Cx5jmv62baQefAlQ==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.27.tgz",
+      "integrity": "sha512-6MsWnbNG0ZjZgzYimNNjnTAlOFXn+jdLMFB47dDVUsRNjxdUoTSduCQPZZeTKoUl0ZNwCjsJ31of49l/t1r9MA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.27"
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
-      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.27",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.27.tgz",
-      "integrity": "sha512-JFhJK5ynprll2FR3e+sHagJJIwvIagsNA0FLbLPq2Os4yLUK2/eiaCU0jXsADik73/hhvcPPLmD+Uo8eu5kFaQ==",
+      "version": "5.0.18",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.18.tgz",
+      "integrity": "sha512-UBNCrkxS5llgN2/RXLBRkjCFTIuL6YB1Goq5c+yRecnznhtX4XPjTwLHz2hrsTltTVZ0rqVegtnwFXdPBkjDHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
+        "@ai-sdk/provider": "4.0.4",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -7496,9 +7498,9 @@
       ]
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
@@ -7521,6 +7523,12 @@
         "@opentelemetry/sdk-metrics": ">=2.0.0 <3.0.0",
         "@opentelemetry/sdk-trace-base": ">=2.0.0 <3.0.0"
       }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@xyflow/react": {
       "version": "12.11.0",
@@ -7679,30 +7687,20 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.204",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.204.tgz",
-      "integrity": "sha512-vr4bPUe9v5oJpv/fzcLCupSQODqSerP1oHXDq95oLJYw2vidZUtvRP4pLYD26WzQO/PlIxMHcuVKmjPC3dd6PA==",
+      "version": "7.0.48",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.48.tgz",
+      "integrity": "sha512-QmqshWFEDdkFFqSgdJ4cogaoDIYaedqbv73q/NXEYNkSIocJCzXnGFVyM9lrtAGTSBfm+5hq3/292ooXJ1jDSw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "2.0.103",
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.27",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "4.0.37",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/ai/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "worker:embedding:dry": "dotenv -e .env -- tsx scripts/dev/run-embedding-worker.ts --dry-run"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^2.0.52",
+    "@ai-sdk/openai": "^4.0.27",
     "@better-auth/prisma-adapter": "^1.6.11",
     "@dqbd/tiktoken": "^1.0.22",
     "@google/generative-ai": "^0.24.1",
@@ -163,7 +163,7 @@
     "@tanstack/react-query-devtools": "^5.87.4",
     "@vercel/otel": "^2.0.1",
     "@xyflow/react": "^12.10.0",
-    "ai": "^5.0.76",
+    "ai": "^7.0.48",
     "async-mutex": "^0.5.0",
     "axios": "^1.16.0",
     "bcryptjs": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -282,7 +282,7 @@
       "zod": "$zod"
     },
     "hono": "4.12.27",
-    "@hono/node-server": "2.0.5",
+    "@hono/node-server": "2.0.10",
     "follow-redirects": "1.16.0",
     "postcss": "8.5.18",
     "uuid": "^14.0.0",
@@ -294,7 +294,7 @@
     "fast-uri": "3.1.4",
     "ip-address": "10.1.1",
     "sharp": "0.35.0",
-    "brace-expansion@1": "1.1.16",
-    "brace-expansion@5": "5.0.7"
+    "brace-expansion@1": "1.1.17",
+    "brace-expansion@5": "5.0.8"
   }
 }


### PR DESCRIPTION
## 概要

- Dependabot の残存 open アラート **2 件を全て解消**します（#165 / #121）
- あわせて `brace-expansion` の新 advisory に追随し、`npm audit` の **high 33 件を 0 件**にします
- #121 の解消には AI SDK のメジャーアップグレード（ai 5→7 / @ai-sdk/openai 2→4）が必要でした

## 背景

前 PR #631 で 23 件を解消しましたが、2 件が残っていました。

- **#165 `@hono/node-server`**: PR #631 で 2.0.5 に更新しましたが、npm 側は 2.0.0〜2.0.9 を脆弱と判定しており、Dependabot も新アラートとして追随しました
- **#121 `@ai-sdk/provider-utils`**: 3.x 系に修正版が公開されておらず、親パッケージが `3.0.27` を**レンジではなく完全固定**で要求しているため overrides では回避できませんでした

## 実装内容

### 1. 依存更新

| パッケージ | 変更 | 種別 | アラート |
|-----------|------|------|---------|
| `@hono/node-server` | 2.0.5 → 2.0.10 | overrides | #165 (medium, dev) |
| `brace-expansion` | 1.1.16/5.0.7 → 1.1.17/5.0.8 | overrides | アラート外（下記参照） |
| `ai` | 5.0.204 → **7.0.48** | direct（2 major） | #121 経由 |
| `@ai-sdk/openai` | 2.0.108 → **4.0.27** | direct（2 major） | #121 経由 |
| `@ai-sdk/provider-utils` | 3.0.27 → **5.0.18** | 推移 | #121 (low, runtime) |

**`brace-expansion` について**: `@hono/node-server` を直した後、`npm audit` の総数が 10 件 → 41 件（high 33 件）に増加しました。調査したところ npm の新 advisory（`<1.1.17 || >=4.0.0 <5.0.8`）が単一の根本原因で、そこから minimatch 経由で eslint 系・jest 系へ連鎖していました。overrides 2 行の更新で **41 件 → 4 件**に収束します。

### 2. AI SDK v7 の破壊的変更への対応

| ファイル | 修正 |
|---------|------|
| `article-search-agent.ts` / `article-qa-agent.ts` | Agent 設定の `system:` → `instructions:`（v7 の改名） |
| `semantic-search-tool.ts` | `inputSchema` を変数に切り出し、`execute` に `z.infer` 型注釈を付与 |
| `batch-handler.ts` / `streaming-handler.ts` | `agent.generate/stream` への `as Parameters<...>` キャストを**削除** |

**`semantic-search-tool.ts` の型エラーの原因**（Codex の診断）:

v7 の `tool()` は `INPUT` を `execute` の引数形状から推論します。このツールは `filters` が optional なため、型注釈なしの分割代入だと「`filters` 必須」の関数候補が作られ、`strictFunctionTypes` 下で `ToolExecuteFunction` に代入できません。結果としてオーバーロード解決が最後の候補 `Tool<never, never, CONTEXT>` まで落ち、`inputSchema` / `outputSchema` / `execute` の全てが二次的にエラーになっていました。

同じ形の `article-context-tool.ts` がエラーにならないのは、そちらは `.default()` により**パース後の全プロパティが required** に解決されるためです。この非対称性が原因特定の決め手になりました。

**ハンドラのキャスト削除について**: `ModeContext.agent` は 2 つの Agent の union で、それぞれ ToolSet が異なります。`as Parameters<typeof agent.generate>[0]` は「どちらか一方の引数型」に広げるキャストで、union のメソッドを安全に呼ぶには「両方に渡せる引数」が必要なため逆効果でした。v7 では `abortSignal` が `AgentCallParameters` に正式に含まれるため、キャスト自体が不要です。

### 3. テスト基盤の対応

`jest.config.{node,integration,dom}.js` の `esmAllowList` に `ai` / `@ai-sdk` / `@workflow` を追加しました。

AI SDK v7 系は **ESM のみの配信**（`"type": "module"`）に変わったため、Jest の `transformIgnorePatterns` で node_modules を変換対象外にしたままだと、RAG 関連 5 スイートが `SyntaxError: Cannot use import statement outside a module` でロードできません。

`@workflow/serde` は `@ai-sdk/provider-utils` の依存ですが `npm ls` のツリーには現れず、実行時エラーで判明したため依存元を特定した上で追加しています。

## テスト結果

| 検証 | 結果 |
|------|------|
| `npm audit --production --audit-level=high` | **exit 0**（CI の Security Audit と同条件） |
| `npm audit` 全体 | 41 件 → **4 件**（low 1 / moderate 3、**high 0**） |
| TypeScript (`tsc --noEmit`) | エラー **0 件** |
| ESLint | 0 errors / 0 warnings |
| Docker 本番ビルド | 成功 |
| 全テスト | **4,948 件パス**（node 4,346 + DOM 602、失敗 0） |

RAG 関連 5 スイート（`article-context-tool` 11 / `semantic-search-tool` 6 / `parse-temporal-query` 21 / `direct-search-handler` 7 / `article-qa-agent` 5 = 50 件）は ESM 対応により復帰しています。

## レビュー時に留意いただきたい点

**RAG・エージェント検索の実動作は未検証です**

型チェック・ビルド・ユニットテストは全て通っていますが、v7 の Agent が実際に OpenAI API を呼んで応答を返すところは、API キーが必要なため確認できていません。ユニットテストは SDK をモックしているため、この経路はカバーされていません。

**マージ前に `/search/agent` で以下を確認いただくことを推奨します**:
- 記事検索モード（`article-search`）で検索結果が返るか
- 記事 Q&A モード（`article-qa`）で回答が返るか
- ストリーミング表示が正常に動作するか（`streaming-handler.ts` のキャスト削除の影響確認）

## チェックリスト

- [x] 全テスト通過（4,948 件）
- [x] ビルド通過
- [x] CI の Security Audit ゲート通過を事前確認
- [x] Dependabot の open アラート 0 件見込み
- [ ] RAG・エージェント検索の実動作確認（API キーが必要なため未実施）

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - AI機能の基盤を更新し、エージェントによる記事検索・質問応答の互換性と安定性を向上しました。
  - セマンティック検索の入出力処理を整理し、検索結果の処理やエラー伝播を従来どおり維持しました。

- **テスト**
  - AI関連機能を含むテスト環境を更新し、各種テストでの動作確認を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->