### PR TITLE
feat(sources): 海外アグリゲータ Lobsters / Techmeme を追加 (Issue #628 Batch 2)

### DIFF
--- a/.github/workflows/scheduler-rss-hourly.yml
+++ b/.github/workflows/scheduler-rss-hourly.yml
@@ -103,7 +103,9 @@ jobs:
             "JSer.info" \
             "CodeZine" \
             "gihyo.jp" \
-            "Findy Engineer Lab"
+            "Findy Engineer Lab" \
+            "Lobsters" \
+            "Techmeme"
           # 要約生成はcollect-feeds.ts内で実行済み
           # 品質スコアと難易度計算は1日1回に移動 (scheduler-daily-quality.yml)
       - name: Notify failure to Slack

--- a/__tests__/fetchers/batch2-sources.test.ts
+++ b/__tests__/fetchers/batch2-sources.test.ts
@@ -129,7 +129,8 @@ describe('GenericForeignRssFetcher: Techmeme設定 (useNormalizedUrl)', () => {
 
     expect(result.errors).toHaveLength(0);
     expect(result.articles).toHaveLength(1);
-    expect(result.articles[0].url).toBe('https://www.techmeme.com/260802/p6');
+    // normalizeUrl はフラグメント除去に加えて www. も除去する
+    expect(result.articles[0].url).toBe('https://techmeme.com/260802/p6');
   });
 
   it('アイテムごとに正規化URLが一意になる（別アンカー付きlinkは別URLとして保存される）', async () => {
@@ -166,8 +167,8 @@ describe('GenericForeignRssFetcher: Techmeme設定 (useNormalizedUrl)', () => {
     const urls = result.articles.map((a) => a.url);
     expect(new Set(urls).size).toBe(2);
     expect(urls).toEqual([
-      'https://www.techmeme.com/260802/p6',
-      'https://www.techmeme.com/260802/p7',
+      'https://techmeme.com/260802/p6',
+      'https://techmeme.com/260802/p7',
     ]);
   });
 });

--- a/__tests__/fetchers/batch2-sources.test.ts
+++ b/__tests__/fetchers/batch2-sources.test.ts
@@ -1,0 +1,173 @@
+/**
+ * GenericForeignRssFetcher の Lobsters / Techmeme 設定リグレッションテスト
+ * （Issue #628 Batch 2）
+ *
+ * FOREIGN_SOURCE_CONFIGS['Lobsters'] / ['Techmeme'] を実設定のまま使用し、
+ * feed-fixtures.test.ts で固定した rss-parser のパース結果（description の
+ * content/contentSnippet 変換、アンカー付きlink）相当の parseURL 結果を
+ * モックして fetch() を実行する。
+ *
+ * - Lobsters (ignoreFeedContent: true): content が空文字になり、
+ *   url は正規化されない生URL（www・末尾スラッシュ保持）のまま保存される
+ * - Techmeme (useNormalizedUrl: true): url がフラグメント・www除去済みの
+ *   正規化URLで保存され、アイテムごとに一意になる
+ */
+
+import {
+  GenericForeignRssFetcher,
+  FOREIGN_SOURCE_CONFIGS,
+} from '@/lib/fetchers/generic-foreign-rss';
+import { Source } from '@/lib/prisma-exports';
+import Parser from 'rss-parser';
+
+jest.mock('rss-parser', () => {
+  return jest.fn().mockImplementation(() => ({
+    parseURL: jest.fn(),
+  }));
+});
+const MockedParser = jest.mocked(Parser);
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/utils/duplicate-detection', () => ({
+  isDuplicate: jest.fn().mockReturnValue(false),
+}));
+
+const createMockSource = (overrides?: Partial<Source>): Source => ({
+  id: 'lobsters',
+  name: 'Lobsters',
+  url: 'https://lobste.rs',
+  type: 'RSS',
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+describe('GenericForeignRssFetcher: Lobsters設定 (ignoreFeedContent)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const mockParseURL = jest.fn().mockResolvedValue({
+      items: [
+        {
+          title: 'Some article title',
+          // Lobsters の link は外部記事の生URL（www・末尾スラッシュ付き）
+          link: 'https://www.example.com/blog/Some-Article/',
+          isoDate: '2026-08-02T10:00:00.000Z',
+          // rss-parser の description -> content/contentSnippet 変換結果
+          // （feed-fixtures.test.ts で固定した事実と同じ形状）
+          content:
+            '<p><a href="https://lobste.rs/s/abc123/some_article_title">Comments</a></p>',
+          contentSnippet: 'Comments',
+        },
+      ],
+    });
+    MockedParser.mockImplementation(
+      () => ({ parseURL: mockParseURL }) as unknown as Parser
+    );
+  });
+
+  it('contentが空文字になり、urlは生URLのまま（www・末尾スラッシュ保持）保存される', async () => {
+    const config = FOREIGN_SOURCE_CONFIGS['Lobsters'];
+    expect(config).toBeDefined();
+    expect(config.ignoreFeedContent).toBe(true);
+    expect(config.useNormalizedUrl).toBeUndefined();
+
+    const fetcher = new GenericForeignRssFetcher(createMockSource(), config);
+    const result = await fetcher.fetch();
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].content).toBe('');
+    expect(result.articles[0].url).toBe(
+      'https://www.example.com/blog/Some-Article/'
+    );
+  });
+});
+
+describe('GenericForeignRssFetcher: Techmeme設定 (useNormalizedUrl)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('urlがフラグメント・www除去済みの正規化URLで保存される', async () => {
+    const mockParseURL = jest.fn().mockResolvedValue({
+      items: [
+        {
+          title: 'Some Headline About AI',
+          // Techmeme の link は自サイトのリバーページ・パーマリンク（#アンカー付き）
+          link: 'https://www.techmeme.com/260802/p6#a260802p6',
+          isoDate: '2026-08-02T09:00:00.000Z',
+          content:
+            '<img src="https://example.com/thumb.jpg" border="0" /> <a href="https://example.com/story-page">Company announces new AI product with expanded capabilities</a>',
+          contentSnippet:
+            'Company announces new AI product with expanded capabilities',
+        },
+      ],
+    });
+    MockedParser.mockImplementation(
+      () => ({ parseURL: mockParseURL }) as unknown as Parser
+    );
+
+    const config = FOREIGN_SOURCE_CONFIGS['Techmeme'];
+    expect(config).toBeDefined();
+    expect(config.useNormalizedUrl).toBe(true);
+    expect(config.skipEnrichment).toBe(true);
+
+    const fetcher = new GenericForeignRssFetcher(
+      createMockSource({ id: 'techmeme', name: 'Techmeme', url: 'https://www.techmeme.com' }),
+      config
+    );
+    const result = await fetcher.fetch();
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].url).toBe('https://www.techmeme.com/260802/p6');
+  });
+
+  it('アイテムごとに正規化URLが一意になる（別アンカー付きlinkは別URLとして保存される）', async () => {
+    const mockParseURL = jest.fn().mockResolvedValue({
+      items: [
+        {
+          title: 'Headline One',
+          link: 'https://www.techmeme.com/260802/p6#a260802p6',
+          isoDate: '2026-08-02T09:00:00.000Z',
+          content: 'Headline One body text is long enough to pass sanitize.',
+          contentSnippet: 'Headline One body text is long enough to pass sanitize.',
+        },
+        {
+          title: 'Headline Two',
+          link: 'https://www.techmeme.com/260802/p7#a260802p7',
+          isoDate: '2026-08-02T09:30:00.000Z',
+          content: 'Headline Two body text is long enough to pass sanitize.',
+          contentSnippet: 'Headline Two body text is long enough to pass sanitize.',
+        },
+      ],
+    });
+    MockedParser.mockImplementation(
+      () => ({ parseURL: mockParseURL }) as unknown as Parser
+    );
+
+    const config = FOREIGN_SOURCE_CONFIGS['Techmeme'];
+    const fetcher = new GenericForeignRssFetcher(
+      createMockSource({ id: 'techmeme', name: 'Techmeme', url: 'https://www.techmeme.com' }),
+      config
+    );
+    const result = await fetcher.fetch();
+
+    expect(result.articles).toHaveLength(2);
+    const urls = result.articles.map((a) => a.url);
+    expect(new Set(urls).size).toBe(2);
+    expect(urls).toEqual([
+      'https://www.techmeme.com/260802/p6',
+      'https://www.techmeme.com/260802/p7',
+    ]);
+  });
+});

--- a/__tests__/fetchers/feed-fixtures.test.ts
+++ b/__tests__/fetchers/feed-fixtures.test.ts
@@ -66,3 +66,64 @@ describe('Batch 1 フィード fixture パース検証', () => {
     }
   );
 });
+
+/**
+ * Batch 2 フィード fixture パーステスト（Issue #628, Lobsters / Techmeme）
+ *
+ * Lobsters / Techmeme は description の中身に強く依存する品質対処
+ * （ignoreFeedContent / skipEnrichment, plan_20260802_221749 §4.1）を
+ * 実施しているため、rss-parser が description をどう解釈するかという
+ * 「事実」自体を固定し、rss-parser 更新時の前提崩れを検知する。
+ *
+ * fixture採取日: 2026-08-02
+ */
+describe('Batch 2 フィード fixture パース検証', () => {
+  const parser = new Parser();
+
+  it('Lobsters: descriptionがCommentsリンクのみで、content/contentSnippetへ変換される', async () => {
+    const xml = fs.readFileSync(
+      path.join(__dirname, '../fixtures/feeds/lobsters.xml'),
+      'utf-8'
+    );
+    const feed = await parser.parseString(xml);
+    expect(feed.items.length).toBe(1);
+
+    const item = feed.items[0];
+    expect(item.title).toBe('Some article title');
+    // Lobsters の link は外部記事の生URL（www・末尾スラッシュ付きのまま）
+    expect(item.link).toBe('https://www.example.com/blog/Some-Article/');
+
+    // description はHTMLのまま content に、タグ除去済みテキストが
+    // contentSnippet に入る（rss-parser の仕様）。
+    // ignoreFeedContent はこの「Commentsのみ」という中身を前提に空文字化する。
+    expect(item.content).toBe(
+      '<p><a href="https://lobste.rs/s/abc123/some_article_title">Comments</a></p>'
+    );
+    expect(item.contentSnippet).toBe('Comments');
+  });
+
+  it('Techmeme: CDATA descriptionのIMG/Aタグ、アンカー付きlinkが期待通りに解釈される', async () => {
+    const xml = fs.readFileSync(
+      path.join(__dirname, '../fixtures/feeds/techmeme.xml'),
+      'utf-8'
+    );
+    const feed = await parser.parseString(xml);
+    expect(feed.items.length).toBe(1);
+
+    const item = feed.items[0];
+    expect(item.title).toBe('Some Headline About AI');
+    // Techmeme の link は自サイトのリバーページ・パーマリンク（#アンカー付き）
+    expect(item.link).toBe('https://www.techmeme.com/260802/p6#a260802p6');
+
+    // content にはIMG/Aタグを含むHTMLがそのまま残る
+    expect(item.content).toContain('<img src="https://example.com/thumb.jpg"');
+    expect(item.content).toContain('<a href="https://example.com/story-page">');
+
+    // contentSnippet はタグ除去済みの見出しテキスト（skipEnrichment時の本文の元になる）
+    expect(item.contentSnippet).toContain(
+      'Company announces new AI product with expanded capabilities'
+    );
+    expect(item.contentSnippet).not.toContain('<img');
+    expect(item.contentSnippet).not.toContain('<a href');
+  });
+});

--- a/__tests__/fetchers/ignore-feed-content.test.ts
+++ b/__tests__/fetchers/ignore-feed-content.test.ts
@@ -1,0 +1,129 @@
+/**
+ * GenericForeignRssFetcher ignoreFeedContent / isEnrichmentSkipped のテスト
+ * （Issue #628 Batch 2）
+ *
+ * ignoreFeedContent: description がコメントリンク等のノイズのみのソース
+ * （例: Lobsters）向けに、フィード本文を採用せず空文字で保存するオプション。
+ * isEnrichmentSkipped: enricher による本文上書きを行わないソース
+ * （例: Techmeme）を判定する共通ヘルパー。
+ */
+
+import {
+  GenericForeignRssFetcher,
+  ForeignSourceConfig,
+  FOREIGN_SOURCE_CONFIGS,
+  isEnrichmentSkipped,
+} from '@/lib/fetchers/generic-foreign-rss';
+import { Source } from '@/lib/prisma-exports';
+import Parser from 'rss-parser';
+
+jest.mock('rss-parser', () => {
+  return jest.fn().mockImplementation(() => ({
+    parseURL: jest.fn(),
+  }));
+});
+const MockedParser = jest.mocked(Parser);
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/utils/duplicate-detection', () => ({
+  isDuplicate: jest.fn().mockReturnValue(false),
+}));
+
+const createMockSource = (): Source => ({
+  id: 'lobsters',
+  name: 'Lobsters',
+  url: 'https://lobste.rs',
+  type: 'RSS',
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+const createConfig = (
+  overrides?: Partial<ForeignSourceConfig>
+): ForeignSourceConfig => ({
+  feedUrl: 'https://lobste.rs/rss',
+  tagPrefix: 'lobsters',
+  ...overrides,
+});
+
+const mockFeedWithDescription = () => {
+  const mockParseURL = jest.fn().mockResolvedValue({
+    items: [
+      {
+        title: 'テスト記事タイトル',
+        link: 'https://example.com/article',
+        isoDate: '2026-07-31T10:16:00Z',
+        description: 'Comments',
+      },
+    ],
+  });
+  MockedParser.mockImplementation(
+    () => ({ parseURL: mockParseURL }) as unknown as Parser
+  );
+};
+
+describe('GenericForeignRssFetcher ignoreFeedContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFeedWithDescription();
+  });
+
+  it('有効時はフィードのdescriptionを採用せず、contentが空文字になる', async () => {
+    const fetcher = new GenericForeignRssFetcher(
+      createMockSource(),
+      createConfig({ ignoreFeedContent: true })
+    );
+
+    const result = await fetcher.fetch();
+
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].content).toBe('');
+  });
+
+  it('未設定時は従来どおりdescriptionをcontentとして採用する', async () => {
+    const fetcher = new GenericForeignRssFetcher(
+      createMockSource(),
+      createConfig()
+    );
+
+    const result = await fetcher.fetch();
+
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].content).toBe('Comments');
+  });
+});
+
+describe('isEnrichmentSkipped', () => {
+  const TEST_SOURCE_NAME = '__test_skip_enrichment_source__';
+
+  afterEach(() => {
+    // テスト用に追加した一時エントリを必ず削除し、既存21ソースへの影響をゼロにする
+    delete FOREIGN_SOURCE_CONFIGS[TEST_SOURCE_NAME];
+  });
+
+  it('skipEnrichment: true が設定されたソース名でtrueを返す', () => {
+    FOREIGN_SOURCE_CONFIGS[TEST_SOURCE_NAME] = {
+      feedUrl: 'https://example.com/feed',
+      skipEnrichment: true,
+    };
+
+    expect(isEnrichmentSkipped(TEST_SOURCE_NAME)).toBe(true);
+  });
+
+  it('未設定ソース名ではfalseを返す（従来動作）', () => {
+    expect(isEnrichmentSkipped('Meta Engineering')).toBe(false);
+  });
+
+  it('FOREIGN_SOURCE_CONFIGSに存在しないソース名ではfalseを返す', () => {
+    expect(isEnrichmentSkipped('Nonexistent Source XYZ')).toBe(false);
+  });
+});

--- a/__tests__/fixtures/feeds/lobsters.xml
+++ b/__tests__/fixtures/feeds/lobsters.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+<title>Lobsters</title>
+<link>https://lobste.rs/</link>
+<description>Lobsters: Technology-centric community</description>
+<item>
+<title>Some article title</title>
+<link>https://www.example.com/blog/Some-Article/</link>
+<guid isPermaLink="true">https://lobste.rs/s/abc123/some_article_title</guid>
+<pubDate>Sun, 02 Aug 2026 10:00:00 +0000</pubDate>
+<description>&lt;p&gt;&lt;a href="https://lobste.rs/s/abc123/some_article_title"&gt;Comments&lt;/a&gt;&lt;/p&gt;</description>
+</item>
+</channel>
+</rss>

--- a/__tests__/fixtures/feeds/techmeme.xml
+++ b/__tests__/fixtures/feeds/techmeme.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+<title>Techmeme</title>
+<link>https://www.techmeme.com/</link>
+<description>Tech Meta-News, Aggregated</description>
+<item>
+<title>Some Headline About AI</title>
+<link>https://www.techmeme.com/260802/p6#a260802p6</link>
+<guid isPermaLink="false">https://www.techmeme.com/260802/p6#a260802p6</guid>
+<pubDate>Sun, 02 Aug 2026 09:00:00 +0000</pubDate>
+<description><![CDATA[<img src="https://example.com/thumb.jpg" border="0" /> <a href="https://example.com/story-page">Company announces new AI product with expanded capabilities</a> (<a href="https://twitter.com/someone">Some Person / Twitter</a>)]]></description>
+</item>
+</channel>
+</rss>

--- a/__tests__/scripts/scheduled/collect-feeds-accept-content.test.ts
+++ b/__tests__/scripts/scheduled/collect-feeds-accept-content.test.ts
@@ -1,0 +1,63 @@
+/**
+ * collect-feeds.ts の isAcceptableEnrichedContent 境界テスト
+ *
+ * 新規保存経路・既存記事の自己修復経路の両方が共有する受入基準:
+ * 500文字以上は無条件、250-499文字は isHighQuality（品質チェック）必須。
+ * isHighQuality はモックし、文字数の境界値だけを検証する。
+ */
+
+jest.mock('@/lib/enrichers/strategies/quality', () => ({
+  isHighQuality: jest.fn(),
+}));
+
+import { isAcceptableEnrichedContent } from '@/scripts/scheduled/collect-feeds';
+import { isHighQuality } from '@/lib/enrichers/strategies/quality';
+
+const mockIsHighQuality = isHighQuality as jest.Mock;
+
+describe('isAcceptableEnrichedContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('249文字はisHighQuality=trueでもfalse（250文字未満は無条件で不採用）', () => {
+    mockIsHighQuality.mockReturnValue(true);
+
+    expect(isAcceptableEnrichedContent('a'.repeat(249))).toBe(false);
+    expect(mockIsHighQuality).not.toHaveBeenCalled();
+  });
+
+  it('250文字はisHighQuality=trueならtrue', () => {
+    mockIsHighQuality.mockReturnValue(true);
+    const content = 'a'.repeat(250);
+
+    expect(isAcceptableEnrichedContent(content)).toBe(true);
+    expect(mockIsHighQuality).toHaveBeenCalledWith(content);
+  });
+
+  it('250文字はisHighQuality=falseならfalse', () => {
+    mockIsHighQuality.mockReturnValue(false);
+
+    expect(isAcceptableEnrichedContent('a'.repeat(250))).toBe(false);
+  });
+
+  it('499文字はisHighQuality=falseならfalse', () => {
+    mockIsHighQuality.mockReturnValue(false);
+
+    expect(isAcceptableEnrichedContent('a'.repeat(499))).toBe(false);
+  });
+
+  it('499文字はisHighQuality=trueならtrue', () => {
+    mockIsHighQuality.mockReturnValue(true);
+
+    expect(isAcceptableEnrichedContent('a'.repeat(499))).toBe(true);
+  });
+
+  it('500文字はisHighQuality=falseでも無条件でtrue', () => {
+    mockIsHighQuality.mockReturnValue(false);
+
+    expect(isAcceptableEnrichedContent('a'.repeat(500))).toBe(true);
+    // 500文字以上は短絡評価によりisHighQualityが呼ばれない
+    expect(mockIsHighQuality).not.toHaveBeenCalled();
+  });
+});

--- a/lib/constants/source-categories.ts
+++ b/lib/constants/source-categories.ts
@@ -96,6 +96,9 @@ export const SOURCE_CATEGORIES: Record<SourceCategoryId, SourceCategory> = {
       'rust_blog', // Rust Blog
       // Phase 3: Business Media
       'business_insider', // Business Insider
+      // Batch 2 (Issue #628): 海外アグリゲータ
+      'lobsters', // Lobsters
+      'techmeme', // Techmeme
     ],
   },
   domestic: {

--- a/lib/fetchers/generic-foreign-rss.ts
+++ b/lib/fetchers/generic-foreign-rss.ts
@@ -49,6 +49,21 @@ export interface ForeignSourceConfig {
    * 重複作成されるため、レコードを持たない新規ソースでのみ有効化すること。
    */
   useNormalizedUrl?: boolean;
+  /**
+   * フィードの description/content をコンテンツ抽出時に無視し、常に空文字を返す。
+   *
+   * description がコメントリンク等のノイズのみのソース向け。空文字を返すことで
+   * 保存時 content が空となり、保存後エンリッチメントが記事本文を取得する
+   * （エンリッチメント経路に本文取得を委ねる）。
+   */
+  ignoreFeedContent?: boolean;
+  /**
+   * enricher による本文上書きを行わないソース。
+   *
+   * リバーページ等、記事単位の本文が取得できず、enricher による抽出結果が
+   * ノイズ（広告含む）になるソース向け。`isEnrichmentSkipped()` で参照する。
+   */
+  skipEnrichment?: boolean;
 }
 
 export class GenericForeignRssFetcher extends BaseFetcher {
@@ -275,6 +290,11 @@ export class GenericForeignRssFetcher extends BaseFetcher {
    * RSS項目からコンテンツを抽出
    */
   private extractContent(item: RSSItem): string {
+    // ignoreFeedContent 有効時はフィード本文を採用せず、保存後エンリッチメントに委ねる
+    if (this.config.ignoreFeedContent) {
+      return '';
+    }
+
     // 優先順位: content:encoded > content > description > summary
     const content =
       item['content:encoded'] ||
@@ -509,4 +529,13 @@ export function getForeignSourceConfig(
   sourceName: string
 ): ForeignSourceConfig | undefined {
   return FOREIGN_SOURCE_CONFIGS[sourceName];
+}
+
+/**
+ * 指定ソースが enricher による本文上書きをスキップする対象かどうかを判定する
+ * （純粋関数）。collect-feeds.ts / enrich-thin-content.ts 等、enricher で
+ * 記事本文を上書きする全経路から参照すること。
+ */
+export function isEnrichmentSkipped(sourceName: string): boolean {
+  return FOREIGN_SOURCE_CONFIGS[sourceName]?.skipEnrichment === true;
 }

--- a/lib/fetchers/generic-foreign-rss.ts
+++ b/lib/fetchers/generic-foreign-rss.ts
@@ -520,6 +520,26 @@ export const FOREIGN_SOURCE_CONFIGS: Record<string, ForeignSourceConfig> = {
     tagPrefix: 'findy-engineer-lab',
     useNormalizedUrl: true,
   },
+  // Foreign Aggregators (Batch 2, Issue #628)
+  // Lobsters: item link が外部記事URL（Hacker News と同型のアグリゲータ）。
+  // HN が生URL保存のため useNormalizedUrl は有効化しない（正規化すると HN 既存記事
+  // とのURL照合が崩れて重複作成される。plan_20260802_221749 §4.2 参照）。
+  // description は Comments リンクのみのため ignoreFeedContent で本文を
+  // エンリッチメントに委ねる
+  Lobsters: {
+    feedUrl: 'https://lobste.rs/rss',
+    tagPrefix: 'lobsters',
+    ignoreFeedContent: true,
+  },
+  // Techmeme: item link が自サイトのリバーページ・パーマリンク（#アンカー付き）。
+  // enricher はリバーページ全体（広告含む）を抽出してしまうため skipEnrichment で
+  // description 由来の見出し本文を維持する
+  Techmeme: {
+    feedUrl: 'https://www.techmeme.com/feed.xml',
+    tagPrefix: 'techmeme',
+    useNormalizedUrl: true,
+    skipEnrichment: true,
+  },
 };
 
 /**

--- a/lib/fetchers/index.ts
+++ b/lib/fetchers/index.ts
@@ -202,7 +202,10 @@ export function createFetcher(source: Source): BaseFetcher {
     case 'JSer.info':
     case 'CodeZine':
     case 'gihyo.jp':
-    case 'Findy Engineer Lab': {
+    case 'Findy Engineer Lab':
+    // Foreign Aggregators (Batch 2, Issue #628)
+    case 'Lobsters':
+    case 'Techmeme': {
       const foreignConfig = getForeignSourceConfig(source.name);
       if (!foreignConfig) {
         throw new Error(`Invalid foreign source name: ${source.name}`);

--- a/scripts/maintenance/add-batch2-sources.ts
+++ b/scripts/maintenance/add-batch2-sources.ts
@@ -1,0 +1,87 @@
+/**
+ * Batch 2 海外アグリゲータ2ソースをDBに登録するスクリプト (Issue #628)
+ *
+ * 対象: Lobsters / Techmeme
+ *
+ * 使用方法:
+ *   npx tsx scripts/maintenance/add-batch2-sources.ts
+ *
+ * 本番実行時は事前に2つの id / name の既存行有無を SELECT で確認すること
+ * （plan_20260802_221749_batch2_sources.md「本番反映」参照）。
+ */
+
+import { createPrismaClient } from '@/lib/prisma/create-client';
+import { sourceCache } from '@/lib/cache/source-cache';
+
+const prisma = createPrismaClient();
+
+const BATCH2_SOURCES = [
+  {
+    id: 'lobsters',
+    name: 'Lobsters',
+    url: 'https://lobste.rs',
+    type: 'RSS',
+    enabled: true,
+  },
+  {
+    id: 'techmeme',
+    name: 'Techmeme',
+    url: 'https://www.techmeme.com',
+    type: 'RSS',
+    enabled: true,
+  },
+];
+
+async function main() {
+  console.log('=== Batch 2 海外アグリゲータ2ソース登録 (Issue #628) ===\n');
+
+  const { createFetcher } = await import('@/lib/fetchers/index');
+
+  // 2件を単一トランザクションで登録（1件でも失敗したら全件ロールバックし、
+  // 部分登録状態を作らない）
+  const results = await prisma.$transaction(async (tx) => {
+    const upserted = [];
+    for (const source of BATCH2_SOURCES) {
+      const row = await tx.source.upsert({
+        where: { id: source.id },
+        // 既存行の enabled は上書きしない（enabled=false による緊急停止を
+        // スクリプト再実行で黙って解除してしまわないため。create 時のみ true）
+        update: {
+          name: source.name,
+          url: source.url,
+          type: source.type,
+        },
+        create: source,
+      });
+      // createFetcher 失敗（設定辞書・switch 文との名前不一致）時は
+      // 例外送出でトランザクション全体をロールバック
+      createFetcher(row);
+      upserted.push(row);
+    }
+    return upserted;
+  });
+
+  for (const row of results) {
+    const isNew = row.createdAt.getTime() === row.updatedAt.getTime();
+    console.log(
+      `[${isNew ? 'ADDED' : 'UPDATED'}] ${row.name} (id=${row.id}, enabled=${row.enabled})`
+    );
+  }
+  console.log('[OK] createFetcher() name match verified for all sources');
+
+  // キャッシュ無効化はコミット後に実行（CLAUDE.md ソース追加時ルール）
+  await sourceCache.invalidate();
+  console.log('[OK] Source cache invalidated');
+
+  console.log('\n=== 完了 ===');
+}
+
+main()
+  .catch((error) => {
+    console.error('エラーが発生しました:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+    process.exit(process.exitCode ?? 0);
+  });

--- a/scripts/maintenance/enrich-single-article.ts
+++ b/scripts/maintenance/enrich-single-article.ts
@@ -6,6 +6,7 @@
 import { createPrismaClient } from '@/lib/prisma/create-client';
 import { GoogleAIEnricher } from '../../lib/enrichers/google-ai';
 import { UnifiedSummaryService } from '../../lib/ai/unified-summary-service';
+import { isEnrichmentSkipped } from '../../lib/fetchers/generic-foreign-rss';
 
 const prisma = createPrismaClient();
 const enricher = new GoogleAIEnricher();
@@ -34,7 +35,15 @@ async function enrichSingleArticle(articleId: string) {
     
     // エンリッチメント実行
     console.error('\n=== エンリッチメント実行 ===');
-    
+
+    // skipEnrichment 対象ソース（enricher による本文上書きを行わない）は中断
+    if (isEnrichmentSkipped(article.source.name)) {
+      console.error(
+        `中断: ソース「${article.source.name}」は設定（skipEnrichment）により本文上書き対象外です`
+      );
+      return;
+    }
+
     if (!enricher.canHandle(article.url)) {
       console.error('警告: URLがエンリッチャーの対象外ですが、強制実行を試みます');
     }

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -219,7 +219,10 @@ async function main() {
             // QUALITY_FAILED）と summaryError をクリアし、scripts:summarize
             // （skipReason: null 対象）で要約再生成されるようにする。
             // PDF / SLIDE は本文の有無と無関係の恒久理由のためクリアしない
+            // collect-feeds.ts の品質基準（250文字以上）と揃え、わずかな伸びでの
+            // クリアを防ぐ
             if (
+              enrichedData.content.length >= 250 &&
               article.skipReason &&
               article.skipReason !== 'PDF' &&
               article.skipReason !== 'SLIDE'

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -14,6 +14,7 @@
 
 import { createPrismaClient } from '@/lib/prisma/create-client';
 import { ContentEnricherFactory } from '../../lib/enrichers';
+import { isEnrichmentSkipped } from '../../lib/fetchers/generic-foreign-rss';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
@@ -144,6 +145,7 @@ async function main() {
     let failCount = 0;
     let skipCount = 0;
     let thumbnailCount = 0;
+    let skipEnrichmentCount = 0;
 
     for (let i = 0; i < thinArticles.length; i++) {
       const article = thinArticles[i];
@@ -153,6 +155,13 @@ async function main() {
       console.error(`  ソース: ${article.source.name}`);
       console.error(`  現在のコンテンツ: ${article.content?.length || 0}文字`);
       console.error(`  URL: ${article.url}`);
+
+      // skipEnrichment 対象ソース（enricher による本文上書きを行わない）は除外
+      if (isEnrichmentSkipped(article.source.name)) {
+        console.error(`  ⏭️  スキップ: ソース設定により本文上書き対象外`);
+        skipEnrichmentCount++;
+        continue;
+      }
 
       // エンリッチャーを取得
       const enricher = enricherFactory.getEnricher(article.url, article.source.id);
@@ -238,6 +247,7 @@ async function main() {
     console.error(`✅ 成功: ${successCount}件`);
     console.error(`❌ 失敗: ${failCount}件`);
     console.error(`⏭️  スキップ: ${skipCount}件`);
+    console.error(`⏭️  スキップ（対象外ソース）: ${skipEnrichmentCount}件`);
     console.error(`🖼️  サムネイル取得: ${thumbnailCount}件`);
     console.error(`📊 合計: ${thinArticles.length}件`);
 

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -219,14 +219,15 @@ async function main() {
             // 本文回復時は本文起因の skipReason（THIN_CONTENT / CONTENT_FETCH_FAILED /
             // QUALITY_FAILED）と summaryError をクリアし、scripts:summarize
             // （skipReason: null 対象）で要約再生成されるようにする。
-            // PDF / SLIDE は本文の有無と無関係の恒久理由のためクリアしない
+            // PDF / SLIDE は本文の有無と無関係の恒久理由のためクリアしない。
+            // skipReason が null で summaryError だけ残るケース（一時的な要約失敗）
+            // もクリア対象にするため truthy 判定はしない。
             // collect-feeds.ts の受入基準と同一（500文字以上は無条件、
             // 250-499文字は isHighQuality 必須）にし、わずかな伸びでの
             // クリアを防ぐ
             if (
               (enrichedData.content.length >= 500 ||
                 (enrichedData.content.length >= 250 && isHighQuality(enrichedData.content))) &&
-              article.skipReason &&
               article.skipReason !== 'PDF' &&
               article.skipReason !== 'SLIDE'
             ) {

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -15,6 +15,7 @@
 import { createPrismaClient } from '@/lib/prisma/create-client';
 import { ContentEnricherFactory } from '../../lib/enrichers';
 import { isEnrichmentSkipped } from '../../lib/fetchers/generic-foreign-rss';
+import { isHighQuality } from '../../lib/enrichers/strategies/quality';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
@@ -219,10 +220,12 @@ async function main() {
             // QUALITY_FAILED）と summaryError をクリアし、scripts:summarize
             // （skipReason: null 対象）で要約再生成されるようにする。
             // PDF / SLIDE は本文の有無と無関係の恒久理由のためクリアしない
-            // collect-feeds.ts の品質基準（250文字以上）と揃え、わずかな伸びでの
+            // collect-feeds.ts の受入基準と同一（500文字以上は無条件、
+            // 250-499文字は isHighQuality 必須）にし、わずかな伸びでの
             // クリアを防ぐ
             if (
-              enrichedData.content.length >= 250 &&
+              (enrichedData.content.length >= 500 ||
+                (enrichedData.content.length >= 250 && isHighQuality(enrichedData.content))) &&
               article.skipReason &&
               article.skipReason !== 'PDF' &&
               article.skipReason !== 'SLIDE'

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -215,9 +215,18 @@ async function main() {
               updateData.summaryVersion = 0;
               console.error(`    - 要約: リセット（再生成が必要）`);
             }
-            // 本文回復時は skipReason（CONTENT_FETCH_FAILED 等）をクリアし、
-            // scripts:summarize（skipReason: null 対象）で要約再生成されるようにする
-            updateData.skipReason = null;
+            // 本文回復時は本文起因の skipReason（THIN_CONTENT / CONTENT_FETCH_FAILED /
+            // QUALITY_FAILED）と summaryError をクリアし、scripts:summarize
+            // （skipReason: null 対象）で要約再生成されるようにする。
+            // PDF / SLIDE は本文の有無と無関係の恒久理由のためクリアしない
+            if (
+              article.skipReason &&
+              article.skipReason !== 'PDF' &&
+              article.skipReason !== 'SLIDE'
+            ) {
+              updateData.skipReason = null;
+              updateData.summaryError = null;
+            }
           }
           
           if (hasNewThumbnail) {

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -215,6 +215,9 @@ async function main() {
               updateData.summaryVersion = 0;
               console.error(`    - 要約: リセット（再生成が必要）`);
             }
+            // 本文回復時は skipReason（CONTENT_FETCH_FAILED 等）をクリアし、
+            // scripts:summarize（skipReason: null 対象）で要約再生成されるようにする
+            updateData.skipReason = null;
           }
           
           if (hasNewThumbnail) {

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -102,6 +102,7 @@ import { classifyEnrichmentError } from '@/lib/enrichers/error-classifier';
 import { HATENA_BLOG_DEV_SOURCE_ID } from '@/lib/enrichers/hatena';
 import { logger } from '@/lib/logger';
 import { isHighQuality } from '@/lib/enrichers/strategies/quality';
+import { isEnrichmentSkipped } from '@/lib/fetchers/generic-foreign-rss';
 
 /**
  * Local ArticleInfo for collect-feeds internal use.
@@ -374,7 +375,7 @@ async function processSource({
           sourceName: sourceName
         });
 
-        if (env.SKIP_POST_SAVE_ENRICHMENT !== '1') {
+        if (env.SKIP_POST_SAVE_ENRICHMENT !== '1' && !isEnrichmentSkipped(sourceName)) {
           const enricher = enricherFactory.getEnricher(article.url, source.id);
           if (enricher) {
             try {

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -344,24 +344,24 @@ async function processSource({
                       };
 
                       // 本文回復時は本文起因の skipReason / summaryError をクリアし、
-                      // 要約再生成対象にする。PDF / SLIDE は本文の有無と無関係の
-                      // 恒久理由のためクリアしない（enrich-thin-content.ts の同型ロジックを踏襲）。
+                      // 古い要約も無効化して generateSummaries の再生成対象に載せる。
+                      // PDF / SLIDE は本文の有無と無関係の恒久理由のため、クリア・
+                      // 要約リセットとも行わない（ID 指定の generateSummaries は
+                      // skipReason: null を要求しないため、リセットすると恒久スキップ
+                      // 記事が生成経路に入ってしまう）。
                       // skipReason が null で summaryError だけ残るケース（一時的な要約失敗）
                       // もクリア対象にするため truthy 判定はしない
-                      if (
+                      const isSummaryEligible =
                         existing.skipReason !== 'PDF' &&
-                        existing.skipReason !== 'SLIDE'
-                      ) {
+                        existing.skipReason !== 'SLIDE';
+                      if (isSummaryEligible) {
                         enricherUpdates.skipReason = null;
                         enricherUpdates.summaryError = null;
+                        // enrich-thin-content.ts の本文回復時と同じ流儀
+                        enricherUpdates.summary = null;
+                        enricherUpdates.detailedSummary = null;
+                        enricherUpdates.summaryVersion = 0;
                       }
-
-                      // 本文が変わったため古い要約を無効化し、generateSummaries の
-                      // 再生成対象（summary null/空）に載せる
-                      // （enrich-thin-content.ts の本文回復時と同じ流儀）
-                      enricherUpdates.summary = null;
-                      enricherUpdates.detailedSummary = null;
-                      enricherUpdates.summaryVersion = 0;
 
                       // 並列実行中の他ソースが先に本文を書き込んでいた場合に上書きしないよう、
                       // contentLength が null/0 のままであることを条件に更新する（CAS）
@@ -375,7 +375,10 @@ async function processSource({
 
                       if (count > 0) {
                         articleUpdated = true;
-                        result.newArticleIds.push(existing.id);
+                        // PDF / SLIDE（恒久スキップ）は要約生成キューに入れない
+                        if (isSummaryEligible) {
+                          result.newArticleIds.push(existing.id);
+                        }
                         debugLog(`   既存記事を自己修復（エンリッチャー）: ${article.title.substring(0, 50)}...`);
                       } else {
                         debugLog(`   既存記事の自己修復スキップ（並行更新で本文既存）: ${article.title.substring(0, 50)}...`);

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -144,6 +144,19 @@ function resolveEnrichSleepMs(sourceId: string): number {
   return POST_SAVE_ENRICH_SLEEP_MS;
 }
 
+// 1ソース1実行あたりの自己修復エンリッチ試行数の上限
+// （既存記事の空本文をエンリッチャーで再取得する処理の暴走・レート制限違反を防ぐ）
+const MAX_SELF_HEAL_ENRICH_PER_RUN = 5;
+
+/**
+ * エンリッチ済みコンテンツが保存に足る品質かを判定する。
+ * 新規保存経路（500文字以上は無条件、250-499文字は isHighQuality 必須）と
+ * 同一基準を、既存記事の自己修復経路でも適用するための共通ヘルパー。
+ */
+function isAcceptableEnrichedContent(content: string): boolean {
+  return content.length >= 500 || (content.length >= 250 && isHighQuality(content));
+}
+
 interface ProcessSourceContext {
   source: Source;
   recentTitlesSet: Set<string>;
@@ -204,6 +217,7 @@ async function processSource({
   let duplicateCount = 0;
   let updatedCount = 0;
   let fetchedArticlesCount = 0;
+  let selfHealEnrichCount = 0;
 
   // createFetcherを使用してフェッチャーを生成
   // 未対応ソースの場合は "Unsupported source:" で始まるエラーがスローされる
@@ -257,7 +271,7 @@ async function processSource({
     const articleUrls = articles.map(a => a.url);
     const existingArticles = await prisma.article.findMany({
       where: { url: { in: articleUrls } },
-      select: { id: true, sourceId: true, contentLength: true, thumbnail: true, url: true }
+      select: { id: true, sourceId: true, contentLength: true, thumbnail: true, url: true, skipReason: true }
     });
     const existingArticleMap = new Map(existingArticles.map(a => [a.url, a]));
 
@@ -274,6 +288,10 @@ async function processSource({
             console.error(`   [INFO] sourceId更新: ${source.name} <- Hatena`);
           }
 
+          // エンリッチャーによる自己修復が成功したか（成功時は updateMany で反映済みのため、
+          // 下の update 呼び出し・duplicateCount への計上から除外する）
+          let selfHealedViaEnricher = false;
+
           // content=null/empty の場合は更新を許可（全ソース共通の自己修復メカニズム）
           if (!existing.contentLength || existing.contentLength === 0) {
             if (article.content && article.content.length > 0) {
@@ -287,30 +305,74 @@ async function processSource({
               // エンリッチャーで自己修復する（skipEnrichment ソースは上書き禁止ポリシーを維持）
               const enricher = enricherFactory.getEnricher(article.url, source.id);
               if (enricher) {
-                try {
-                  const enrichedData = await runWithTimeout(
-                    (signal) => enricher.enrich(article.url, signal),
-                    POST_SAVE_ENRICH_TIMEOUT_MS,
-                    `Post-save enrichment timeout after ${POST_SAVE_ENRICH_TIMEOUT_MS}ms for ${sourceName}`
-                  );
-                  if (enrichedData?.content && enrichedData.content.length > 0) {
-                    Object.assign(updates, {
-                      content: enrichedData.content,
-                      thumbnail: isValidThumbnailUrl(enrichedData.thumbnail)
-                        ? enrichedData.thumbnail
-                        : existing.thumbnail,
-                      contentUpdatedAt: new Date(),
-                    });
+                if (selfHealEnrichCount >= MAX_SELF_HEAL_ENRICH_PER_RUN) {
+                  debugLog(`   [INFO] 自己修復エンリッチ上限(${MAX_SELF_HEAL_ENRICH_PER_RUN}件)到達のためスキップ: ${article.title.substring(0, 50)}...`);
+                } else {
+                  selfHealEnrichCount++;
+                  try {
+                    const enrichedData = await runWithTimeout(
+                      (signal) => enricher.enrich(article.url, signal),
+                      POST_SAVE_ENRICH_TIMEOUT_MS,
+                      `Post-save enrichment timeout after ${POST_SAVE_ENRICH_TIMEOUT_MS}ms for ${sourceName}`
+                    );
+                    if (enrichedData?.content && isAcceptableEnrichedContent(enrichedData.content)) {
+                      const enricherUpdates: Prisma.ArticleUpdateInput = {
+                        content: enrichedData.content,
+                        thumbnail: isValidThumbnailUrl(enrichedData.thumbnail)
+                          ? enrichedData.thumbnail
+                          : existing.thumbnail,
+                        contentUpdatedAt: new Date(),
+                      };
+
+                      // 本文回復時は本文起因の skipReason / summaryError をクリアし、
+                      // 要約再生成対象にする。PDF / SLIDE は本文の有無と無関係の
+                      // 恒久理由のためクリアしない（enrich-thin-content.ts の同型ロジックを踏襲）
+                      if (
+                        existing.skipReason &&
+                        existing.skipReason !== 'PDF' &&
+                        existing.skipReason !== 'SLIDE'
+                      ) {
+                        enricherUpdates.skipReason = null;
+                        enricherUpdates.summaryError = null;
+                      }
+
+                      // 並列実行中の他ソースが先に本文を書き込んでいた場合に上書きしないよう、
+                      // contentLength が null/0 のままであることを条件に更新する（CAS）
+                      const { count } = await prisma.article.updateMany({
+                        where: {
+                          id: existing.id,
+                          OR: [{ contentLength: null }, { contentLength: 0 }],
+                        },
+                        data: enricherUpdates,
+                      });
+
+                      if (count > 0) {
+                        selfHealedViaEnricher = true;
+                        updatedCount++;
+                        result.newArticleIds.push(existing.id);
+                        debugLog(`   既存記事を自己修復（エンリッチャー）: ${article.title.substring(0, 50)}...`);
+                      } else {
+                        debugLog(`   既存記事の自己修復スキップ（並行更新で本文既存）: ${article.title.substring(0, 50)}...`);
+                      }
+                    } else {
+                      debugLog(`   既存記事の自己修復エンリッチメント: 品質基準未達またはデータなし (${sourceName}, ${enrichedData?.content?.length ?? 0}文字)`);
+                    }
+                  } catch (enrichError) {
+                    const classified = classifyEnrichmentError(enrichError);
+                    console.error(`   [WARN] 既存記事の空本文エンリッチメント失敗: ${classified.errorMessage}`);
                   }
-                } catch (enrichError) {
-                  const classified = classifyEnrichmentError(enrichError);
-                  console.error(`   [WARN] 既存記事の空本文エンリッチメント失敗: ${classified.errorMessage}`);
+
+                  const enrichSleepMs = resolveEnrichSleepMs(source.id);
+                  if (enrichSleepMs > 0) {
+                    await new Promise(resolve => setTimeout(resolve, enrichSleepMs));
+                  }
                 }
               }
             }
           }
 
-          // まとめて更新
+          // まとめて更新（sourceId移管 / フィード本文由来の補完のみ。
+          // エンリッチャーによる自己修復は上の updateMany(CAS) で処理済み）
           if (Object.keys(updates).length > 0) {
             await prisma.article.update({
               where: { id: existing.id },
@@ -322,7 +384,7 @@ async function processSource({
             } else {
               debugLog(`   既存記事を更新（content補完）: ${article.title.substring(0, 50)}...`);
             }
-          } else {
+          } else if (!selfHealedViaEnricher) {
             duplicateCount++;
           }
           continue;
@@ -423,9 +485,10 @@ async function processSource({
                   const enrichedContentLength = enrichedData.content.length;
 
                   if (enrichedContentLength > originalContentLength && enrichedContentLength >= 250) {
-                    // 250-499 chars: require quality check
-                    const needsQualityCheck = enrichedContentLength < 500;
-                    const passesQualityCheck = !needsQualityCheck || isHighQuality(enrichedData.content);
+                    // 250-499 chars は isHighQuality 必須、500字以上は無条件
+                    // （enrichedContentLength >= 250 は外側の if で保証済みのため、
+                    //   共通ヘルパー isAcceptableEnrichedContent と判定基準は完全に同一）
+                    const passesQualityCheck = isAcceptableEnrichedContent(enrichedData.content);
 
                     if (passesQualityCheck) {
                       await prisma.article.update({
@@ -739,4 +802,4 @@ if (require.main === module) {
     });
 }
 
-export { collectFeeds };
+export { collectFeeds, isAcceptableEnrichedContent };

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -326,9 +326,10 @@ async function processSource({
 
                       // 本文回復時は本文起因の skipReason / summaryError をクリアし、
                       // 要約再生成対象にする。PDF / SLIDE は本文の有無と無関係の
-                      // 恒久理由のためクリアしない（enrich-thin-content.ts の同型ロジックを踏襲）
+                      // 恒久理由のためクリアしない（enrich-thin-content.ts の同型ロジックを踏襲）。
+                      // skipReason が null で summaryError だけ残るケース（一時的な要約失敗）
+                      // もクリア対象にするため truthy 判定はしない
                       if (
-                        existing.skipReason &&
                         existing.skipReason !== 'PDF' &&
                         existing.skipReason !== 'SLIDE'
                       ) {
@@ -359,6 +360,19 @@ async function processSource({
                     }
                   } catch (enrichError) {
                     const classified = classifyEnrichmentError(enrichError);
+                    logger.warn(
+                      {
+                        url: article.url,
+                        sourceId: source.id,
+                        sourceName,
+                        enricher: enricher.constructor.name,
+                        errorCode: classified.errorCode,
+                        status: classified.status,
+                        errorName: classified.errorName,
+                        errorMessage: classified.errorMessage,
+                      },
+                      '[Enrichment] self-heal failed: exception thrown'
+                    );
                     console.error(`   [WARN] 既存記事の空本文エンリッチメント失敗: ${classified.errorMessage}`);
                   }
 
@@ -378,7 +392,10 @@ async function processSource({
               where: { id: existing.id },
               data: updates,
             });
-            updatedCount++;
+            // 自己修復（updateMany）側で計上済みの記事は二重計上しない
+            if (!selfHealedViaEnricher) {
+              updatedCount++;
+            }
             if (updates.sourceId) {
               debugLog(`   既存記事を更新（sourceId + content）: ${article.title.substring(0, 50)}...`);
             } else {
@@ -727,7 +744,9 @@ async function collectFeeds(sourceTypes?: string[]): Promise<CollectResult> {
     const duration = Math.round((Date.now() - startTime) / 1000);
     console.error(`\n📊 収集完了: 新規${totalNewArticles}件, 更新${totalUpdated}件, 重複${totalDuplicates}件 (${duration}秒)`);
 
-    if (totalNewArticles > 0) {
+    // 自己修復のみ成功した実行（totalNewArticles === 0）でも要約生成・
+    // キャッシュ無効化を起動するため、newArticleIds の件数で判定する
+    if (newArticleIds.length > 0) {
       console.error('[INFO] キャッシュを無効化中...');
       try {
         await cacheInvalidator.onBulkImport();

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -280,26 +280,45 @@ async function processSource({
         const existing = existingArticleMap.get(article.url);
 
         if (existing) {
-          const updates: Prisma.ArticleUpdateInput = {};
+          // 記事単位の更新フラグ。sourceId移管・content補完CASの成功・
+          // 自己修復の成功のいずれかがあれば true にし、末尾で一度だけ計上する
+          let articleUpdated = false;
 
           // はてぶ経由 → 企業ブログの場合、sourceIdを更新
+          // （content補完のCASとは独立させ、無条件で適用する）
           if (existing.sourceId === HATENA_SOURCE_ID && source.id !== HATENA_SOURCE_ID) {
-            updates.sourceId = source.id;
+            await prisma.article.update({
+              where: { id: existing.id },
+              data: { sourceId: source.id },
+            });
             console.error(`   [INFO] sourceId更新: ${source.name} <- Hatena`);
+            articleUpdated = true;
           }
-
-          // エンリッチャーによる自己修復が成功したか（成功時は updateMany で反映済みのため、
-          // 下の update 呼び出し・duplicateCount への計上から除外する）
-          let selfHealedViaEnricher = false;
 
           // content=null/empty の場合は更新を許可（全ソース共通の自己修復メカニズム）
           if (!existing.contentLength || existing.contentLength === 0) {
             if (article.content && article.content.length > 0) {
-              Object.assign(updates, {
-                content: article.content,
-                thumbnail: article.thumbnail ?? existing.thumbnail,
-                contentUpdatedAt: new Date(),
+              // フィード本文由来の補完。並行実行中の他ソースが既に本文を確定させて
+              // いないことを CAS で確認してから反映する（existing.contentLength は
+              // バッチ先頭の一括取得時点のスナップショットで古い可能性があるため。
+              // enricher 自己修復経路と同一の保護方式）
+              const { count: contentUpdateCount } = await prisma.article.updateMany({
+                where: {
+                  id: existing.id,
+                  OR: [{ contentLength: null }, { contentLength: 0 }],
+                },
+                data: {
+                  content: article.content,
+                  thumbnail: article.thumbnail ?? existing.thumbnail,
+                  contentUpdatedAt: new Date(),
+                },
               });
+              if (contentUpdateCount > 0) {
+                articleUpdated = true;
+                debugLog(`   既存記事を更新（content補完）: ${article.title.substring(0, 50)}...`);
+              } else {
+                debugLog(`   既存記事の更新スキップ（並行更新で本文既存）: ${article.title.substring(0, 50)}...`);
+              }
             } else if (env.SKIP_POST_SAVE_ENRICHMENT !== '1' && !isEnrichmentSkipped(sourceName)) {
               // ignoreFeedContent ソース等でフィード本文が空のまま保存された既存記事を
               // エンリッチャーで自己修復する（skipEnrichment ソースは上書き禁止ポリシーを維持）
@@ -337,6 +356,13 @@ async function processSource({
                         enricherUpdates.summaryError = null;
                       }
 
+                      // 本文が変わったため古い要約を無効化し、generateSummaries の
+                      // 再生成対象（summary null/空）に載せる
+                      // （enrich-thin-content.ts の本文回復時と同じ流儀）
+                      enricherUpdates.summary = null;
+                      enricherUpdates.detailedSummary = null;
+                      enricherUpdates.summaryVersion = 0;
+
                       // 並列実行中の他ソースが先に本文を書き込んでいた場合に上書きしないよう、
                       // contentLength が null/0 のままであることを条件に更新する（CAS）
                       const { count } = await prisma.article.updateMany({
@@ -348,8 +374,7 @@ async function processSource({
                       });
 
                       if (count > 0) {
-                        selfHealedViaEnricher = true;
-                        updatedCount++;
+                        articleUpdated = true;
                         result.newArticleIds.push(existing.id);
                         debugLog(`   既存記事を自己修復（エンリッチャー）: ${article.title.substring(0, 50)}...`);
                       } else {
@@ -385,33 +410,11 @@ async function processSource({
             }
           }
 
-          // まとめて更新（sourceId移管 / フィード本文由来の補完のみ。
-          // エンリッチャーによる自己修復は上の updateMany(CAS) で処理済み）
-          if (Object.keys(updates).length > 0) {
-            // content を含む更新は、並行実行中の他ソースが既に本文を確定させて
-            // いないことを CAS で確認してから反映する（existing.contentLength は
-            // バッチ先頭の一括取得時点のスナップショットで古い可能性があるため。
-            // enricher 自己修復経路と同一の保護方式）
-            const casWhere = 'content' in updates
-              ? { id: existing.id, OR: [{ contentLength: null }, { contentLength: 0 }] }
-              : { id: existing.id };
-            const { count: plainUpdateCount } = await prisma.article.updateMany({
-              where: casWhere,
-              data: updates,
-            });
-            if (plainUpdateCount === 0 && 'content' in updates) {
-              debugLog(`   既存記事の更新スキップ（並行更新で本文既存）: ${article.title.substring(0, 50)}...`);
-            }
-            // 自己修復（updateMany）側で計上済みの記事は二重計上しない
-            if (!selfHealedViaEnricher && plainUpdateCount > 0) {
-              updatedCount++;
-            }
-            if (updates.sourceId) {
-              debugLog(`   既存記事を更新（sourceId + content）: ${article.title.substring(0, 50)}...`);
-            } else {
-              debugLog(`   既存記事を更新（content補完）: ${article.title.substring(0, 50)}...`);
-            }
-          } else if (!selfHealedViaEnricher) {
+          // カウンタは記事単位で一度だけ計上する（sourceId移管・content補完CASの成功・
+          // 自己修復の成功のいずれかがあれば updated、それ以外は duplicate）
+          if (articleUpdated) {
+            updatedCount++;
+          } else {
             duplicateCount++;
           }
           continue;
@@ -626,36 +629,42 @@ async function processSource({
           });
 
           if (latestExisting) {
-            const updates: Prisma.ArticleUpdateInput = {};
+            // メイン分岐と同様、記事単位のフラグで一度だけ計上する
+            let articleUpdated = false;
 
             if (latestExisting.sourceId === HATENA_SOURCE_ID && source.id !== HATENA_SOURCE_ID) {
-              updates.sourceId = source.id;
+              // sourceId移管はcontent補完のCASとは独立させ、無条件で適用する
+              await prisma.article.update({
+                where: { id: latestExisting.id },
+                data: { sourceId: source.id },
+              });
               console.error(`   [INFO] sourceId更新: ${source.name} <- Hatena`);
+              articleUpdated = true;
             }
 
             if ((!latestExisting.contentLength || latestExisting.contentLength === 0) &&
                 article.content && article.content.length > 0) {
-              Object.assign(updates, {
-                content: article.content,
-                thumbnail: article.thumbnail ?? latestExisting.thumbnail,
-                contentUpdatedAt: new Date(),
-              });
-            }
-
-            if (Object.keys(updates).length > 0) {
               // メイン分岐と同様、content を含む更新は CAS で並行上書きを防ぐ
-              const casWhere = 'content' in updates
-                ? { id: latestExisting.id, OR: [{ contentLength: null }, { contentLength: 0 }] }
-                : { id: latestExisting.id };
               const { count: recoveryUpdateCount } = await prisma.article.updateMany({
-                where: casWhere,
-                data: updates,
+                where: {
+                  id: latestExisting.id,
+                  OR: [{ contentLength: null }, { contentLength: 0 }],
+                },
+                data: {
+                  content: article.content,
+                  thumbnail: article.thumbnail ?? latestExisting.thumbnail,
+                  contentUpdatedAt: new Date(),
+                },
               });
               if (recoveryUpdateCount > 0) {
-                updatedCount++;
+                articleUpdated = true;
               } else {
                 debugLog(`   P2002リカバリ更新スキップ（並行更新で本文既存）: ${article.title.substring(0, 50)}...`);
               }
+            }
+
+            if (articleUpdated) {
+              updatedCount++;
             } else {
               duplicateCount++;
             }

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -309,7 +309,9 @@ async function processSource({
                 },
                 data: {
                   content: article.content,
-                  thumbnail: article.thumbnail ?? existing.thumbnail,
+                  thumbnail: isValidThumbnailUrl(article.thumbnail)
+                    ? article.thumbnail
+                    : existing.thumbnail,
                   contentUpdatedAt: new Date(),
                 },
               });
@@ -655,7 +657,9 @@ async function processSource({
                 },
                 data: {
                   content: article.content,
-                  thumbnail: article.thumbnail ?? latestExisting.thumbnail,
+                  thumbnail: isValidThumbnailUrl(article.thumbnail)
+                    ? article.thumbnail
+                    : latestExisting.thumbnail,
                   contentUpdatedAt: new Date(),
                 },
               });

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -275,13 +275,39 @@ async function processSource({
           }
 
           // content=null/empty の場合は更新を許可（全ソース共通の自己修復メカニズム）
-          if ((!existing.contentLength || existing.contentLength === 0) &&
-              article.content && article.content.length > 0) {
-            Object.assign(updates, {
-              content: article.content,
-              thumbnail: article.thumbnail ?? existing.thumbnail,
-              contentUpdatedAt: new Date(),
-            });
+          if (!existing.contentLength || existing.contentLength === 0) {
+            if (article.content && article.content.length > 0) {
+              Object.assign(updates, {
+                content: article.content,
+                thumbnail: article.thumbnail ?? existing.thumbnail,
+                contentUpdatedAt: new Date(),
+              });
+            } else if (env.SKIP_POST_SAVE_ENRICHMENT !== '1' && !isEnrichmentSkipped(sourceName)) {
+              // ignoreFeedContent ソース等でフィード本文が空のまま保存された既存記事を
+              // エンリッチャーで自己修復する（skipEnrichment ソースは上書き禁止ポリシーを維持）
+              const enricher = enricherFactory.getEnricher(article.url, source.id);
+              if (enricher) {
+                try {
+                  const enrichedData = await runWithTimeout(
+                    (signal) => enricher.enrich(article.url, signal),
+                    POST_SAVE_ENRICH_TIMEOUT_MS,
+                    `Post-save enrichment timeout after ${POST_SAVE_ENRICH_TIMEOUT_MS}ms for ${sourceName}`
+                  );
+                  if (enrichedData?.content && enrichedData.content.length > 0) {
+                    Object.assign(updates, {
+                      content: enrichedData.content,
+                      thumbnail: isValidThumbnailUrl(enrichedData.thumbnail)
+                        ? enrichedData.thumbnail
+                        : existing.thumbnail,
+                      contentUpdatedAt: new Date(),
+                    });
+                  }
+                } catch (enrichError) {
+                  const classified = classifyEnrichmentError(enrichError);
+                  console.error(`   [WARN] 既存記事の空本文エンリッチメント失敗: ${classified.errorMessage}`);
+                }
+              }
+            }
           }
 
           // まとめて更新

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -388,12 +388,22 @@ async function processSource({
           // まとめて更新（sourceId移管 / フィード本文由来の補完のみ。
           // エンリッチャーによる自己修復は上の updateMany(CAS) で処理済み）
           if (Object.keys(updates).length > 0) {
-            await prisma.article.update({
-              where: { id: existing.id },
+            // content を含む更新は、並行実行中の他ソースが既に本文を確定させて
+            // いないことを CAS で確認してから反映する（existing.contentLength は
+            // バッチ先頭の一括取得時点のスナップショットで古い可能性があるため。
+            // enricher 自己修復経路と同一の保護方式）
+            const casWhere = 'content' in updates
+              ? { id: existing.id, OR: [{ contentLength: null }, { contentLength: 0 }] }
+              : { id: existing.id };
+            const { count: plainUpdateCount } = await prisma.article.updateMany({
+              where: casWhere,
               data: updates,
             });
+            if (plainUpdateCount === 0 && 'content' in updates) {
+              debugLog(`   既存記事の更新スキップ（並行更新で本文既存）: ${article.title.substring(0, 50)}...`);
+            }
             // 自己修復（updateMany）側で計上済みの記事は二重計上しない
-            if (!selfHealedViaEnricher) {
+            if (!selfHealedViaEnricher && plainUpdateCount > 0) {
               updatedCount++;
             }
             if (updates.sourceId) {
@@ -633,11 +643,19 @@ async function processSource({
             }
 
             if (Object.keys(updates).length > 0) {
-              await prisma.article.update({
-                where: { id: latestExisting.id },
+              // メイン分岐と同様、content を含む更新は CAS で並行上書きを防ぐ
+              const casWhere = 'content' in updates
+                ? { id: latestExisting.id, OR: [{ contentLength: null }, { contentLength: 0 }] }
+                : { id: latestExisting.id };
+              const { count: recoveryUpdateCount } = await prisma.article.updateMany({
+                where: casWhere,
                 data: updates,
               });
-              updatedCount++;
+              if (recoveryUpdateCount > 0) {
+                updatedCount++;
+              } else {
+                debugLog(`   P2002リカバリ更新スキップ（並行更新で本文既存）: ${article.title.substring(0, 50)}...`);
+              }
             } else {
               duplicateCount++;
             }

--- a/scripts/scheduled/scheduler.ts
+++ b/scripts/scheduled/scheduler.ts
@@ -284,6 +284,9 @@ const RSS_SOURCES = [
   'CodeZine',
   'gihyo.jp',
   'Findy Engineer Lab',
+  // 海外アグリゲータ（Batch 2, Issue #628）
+  'Lobsters',
+  'Techmeme',
 ];
 
 // スクレイピング系ソース（12時間ごとに更新）


### PR DESCRIPTION
## 概要

- Issue #628 Batch 2 として海外アグリゲータ 2 ソース（**Lobsters** / **Techmeme**）を追加
- 調査で判明した品質問題 2 点への対処を同時実装: Lobsters の「Comments」本文汚染防止（`ignoreFeedContent`）と Techmeme のリバーページ本文上書き防止（`skipEnrichment`）
- **SRE Weekly は候補から除外**（後述）。SSRF ガード不在は #633 として別 Issue 化

## 実装内容

### ソース追加（6 箇所同期）
- `FOREIGN_SOURCE_CONFIGS` / `createFetcher` switch / GHA hourly YAML / `scheduler.ts` RSS_SOURCES / `source-categories.ts`（foreign）/ DB 登録スクリプト `add-batch2-sources.ts`（Batch 1 雛形踏襲: 単一トランザクション + enabled 非上書き + createFetcher 検証 + sourceCache.invalidate）
- **Lobsters は `useNormalizedUrl` を有効化しない**: 最大の重複相手 Hacker News が生 URL 保存のため、正規化すると URL 照合が崩れて重複記事を生む（dev 実測: 生 URL 照合 6 件ヒット vs 正規化 5 件。正規化は HN 一致 2 件を失い OpenAI Blog 一致 1 件を得るのみ）

### 品質制御オプション（`ForeignSourceConfig` 拡張）
- `ignoreFeedContent`（Lobsters）: description が Comments リンクのみのため本文を空にし、保存後エンリッチメントに本文取得を委ねる。これがないと本文 "Comments"（7 文字）が保存され、collect-feeds の自己修復機構が既存の空本文記事（HN に 2,203 件存在）を汚染しうる
- `skipEnrichment`（Techmeme）: エンリッチャーはリバーページ全体（スポンサー広告込み 2,549 字・実測）を抽出し、500 字以上は品質チェックなしで本文を上書きするため、description 由来のヘッドライン本文を維持する。`isEnrichmentSkipped()` 共通ヘルパーとして提供し、本文上書き全経路（`collect-feeds.ts` / `enrich-thin-content.ts` / `enrich-single-article.ts`）に適用

### cross-review（Codex + Devil's Advocate）指摘対応
- `enrich-thin-content.ts`: 本文回復時に本文起因の skipReason（THIN_CONTENT / CONTENT_FETCH_FAILED / QUALITY_FAILED）と summaryError をクリアし、`scripts:summarize` で要約再生成されるように修正（PDF / SLIDE は保持）
- `enrich-single-article.ts`: skipEnrichment 対象ソースへの本文上書きを中断するガードを追加（enricherFactory 非経由のため grep 横展開から漏れていた箇所）

### テスト
- フィクスチャ 2 層: `feed-fixtures.test.ts`（XML→rss-parser の形状契約: Lobsters の Comments description / Techmeme の CDATA・アンカー付き link）+ `batch2-sources.test.ts`（parseURL モックで実設定の本文空・生 URL / 正規化 URL 保存を検証）
- `ignore-feed-content.test.ts`: 新オプションと `isEnrichmentSkipped()` の単体テスト

## テスト結果（verify フェーズ）

- Lint / Type Check: 0 errors / 0 warnings
- Security Audit: high 以上 0 件
- Docker 本番ビルド: 成功
- 影響範囲テスト 6 スイート **111 passed / 0 failed**（scheduler-yaml-consistency 49 / create-fetcher 46 / feed-fixtures 6 / ignore-feed-content 5 / batch2-sources 3 / normalized-url 2）

### dev 実データ検証（2 ソース限定収集）
- "Comments" 本文汚染: **0 件**（既存記事への書き込みも 0 件）
- Techmeme: 15 件全件 description 由来本文（min 262 / avg 307 字）、Sponsor 混入 0 件、Duration 1s（エンリッチメント抑止を確認）
- Lobsters: 25 item 中新規 18 / 重複スキップ 7（HN 既存 URL 等）、エンリッチメント成功 11/18（失敗分は #629 の既存課題範囲）
- 保存 URL: Techmeme は正規化済みで item ごとに一意、Lobsters は生 URL

## マージ後の作業（本番反映）

1. preflight: 本番 DB で `lobsters` / `techmeme` の id・name 衝突を SELECT 確認
2. `add-batch2-sources.ts` を本番実行（ユーザー確認のうえ）→ `sourceCache.invalidate()` の成否確認（tsx 実行環境に Redis 認証が渡らない場合は手動無効化）
3. 次回 hourly から収集開始
4. **初回 hourly 後に Techmeme の要約品質を確認（採用停止ゲート）**: ローカル Gemini キー無効のため dev で未検証（合意済み）。品質不良時は `UPDATE "Source" SET enabled=false WHERE id='techmeme'` で即停止

## Issue #628 チェックリスト更新（マージ時に反映してください）

- [x] Lobsters — https://lobste.rs/rss
- [x] Techmeme — https://www.techmeme.com/feed.xml
- ~~SRE Weekly~~ — **対象外**: 既存「SRE」ソース（6 フィード統合フェッチャー `lib/fetchers/sre.ts`）が同一フィードを収集済み（dev DB に sreweekly.com 記事 38 件）。専用ソース化すると既存分はスキップ・新規分は実行順で帰属が揺れるため追加しない

## チェックリスト

- [x] テスト通過（verify フェーズ全ステップ PASSED）
- [x] ドキュメント更新済み（investigate / plan / implement レポート）
- [x] 破壊的変更なし（既存 21 ソースの設定・挙動は不変。新オプション未設定時は従来動作）

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - RSS収集対象に、海外技術系アグリゲータ「Lobsters」と「Techmeme」を追加しました。
  - サイトごとに記事URLを正規化し、重複登録を防止します。
  - ソースに応じて本文取得や本文エンリッチメントを制御します。

- **改善**
  - RSS解析とURL処理の安定性を向上しました。
  - 本文が不足する記事の自動補完・復旧に対応しました。
  - 復旧した記事を要約生成の対象に含めるよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->