### PR TITLE
feat(sources): 海外企業・プロダクトブログ5ソースを追加 (Issue #628 Batch 3)

### DIFF
--- a/.github/workflows/scheduler-rss-hourly.yml
+++ b/.github/workflows/scheduler-rss-hourly.yml
@@ -105,7 +105,12 @@ jobs:
             "gihyo.jp" \
             "Findy Engineer Lab" \
             "Lobsters" \
-            "Techmeme"
+            "Techmeme" \
+            "Vercel Blog" \
+            "TypeScript Blog" \
+            "VS Code Blog" \
+            "Dropbox Tech" \
+            "Fly.io Blog"
           # 要約生成はcollect-feeds.ts内で実行済み
           # 品質スコアと難易度計算は1日1回に移動 (scheduler-daily-quality.yml)
       - name: Notify failure to Slack

--- a/__tests__/fetchers/batch3-sources.test.ts
+++ b/__tests__/fetchers/batch3-sources.test.ts
@@ -16,6 +16,7 @@ import {
   FOREIGN_SOURCE_CONFIGS,
 } from '@/lib/fetchers/generic-foreign-rss';
 import { SOURCE_CATEGORIES } from '@/lib/constants/source-categories';
+import { BATCH3_SOURCES } from '@/scripts/maintenance/add-batch3-sources';
 import { Source } from '@/lib/prisma-exports';
 import Parser from 'rss-parser';
 
@@ -105,6 +106,27 @@ describe('Batch 3: 設定辞書とカテゴリ定義の整合', () => {
       expect(SOURCE_CATEGORIES.foreign.sourceIds).toContain(id);
     }
   );
+
+  // 登録スクリプトの定義（DBに書き込まれる name / id）が設定辞書・カテゴリ定義と
+  // ずれると、収集されない（name不一致）またはUIに出ない（id不一致）状態になる。
+  // 登録スクリプトは手動実行のため CI では走らず、この検証が唯一の恒久検出器
+  describe('登録スクリプト BATCH3_SOURCES との整合', () => {
+    it('登録スクリプトの対象が Batch 3 の5ソースと一致する', () => {
+      const scriptNames = BATCH3_SOURCES.map((s) => s.name).sort();
+      expect(scriptNames).toEqual(Object.keys(BATCH3_SOURCE_IDS).sort());
+    });
+
+    it.each(BATCH3_SOURCES)(
+      '$name: name が設定辞書キー、id が foreign カテゴリと一致する',
+      ({ name, id, type, enabled }) => {
+        expect(FOREIGN_SOURCE_CONFIGS[name]).toBeDefined();
+        expect(SOURCE_CATEGORIES.foreign.sourceIds).toContain(id);
+        expect(BATCH3_SOURCE_IDS[name]).toBe(id);
+        expect(type).toBe('RSS');
+        expect(enabled).toBe(true);
+      }
+    );
+  });
 });
 
 describe('Vercel Blog: urlPathFilter による /blog/ 絞り込み', () => {

--- a/__tests__/fetchers/batch3-sources.test.ts
+++ b/__tests__/fetchers/batch3-sources.test.ts
@@ -1,0 +1,270 @@
+/**
+ * GenericForeignRssFetcher の Batch 3 設定リグレッションテスト
+ * （Issue #628, 海外企業・プロダクトブログ5ソース）
+ *
+ * FOREIGN_SOURCE_CONFIGS の実設定をそのまま使用し、feed-fixtures.test.ts で
+ * 固定した rss-parser のパース結果相当を parseURL としてモックして fetch() を
+ * 実行する。設定判断（urlPathFilter / categoryFilter / useNormalizedUrl）が
+ * 保存内容に正しく反映されることを検証する。
+ *
+ * useNormalizedUrl は「新規ソースなら常に有効化」ではなく、既存レコードの
+ * 保存URL形式に合わせる判断のため、末尾スラッシュの保持・除去を明示的に固定する。
+ */
+
+import {
+  GenericForeignRssFetcher,
+  FOREIGN_SOURCE_CONFIGS,
+} from '@/lib/fetchers/generic-foreign-rss';
+import { SOURCE_CATEGORIES } from '@/lib/constants/source-categories';
+import { Source } from '@/lib/prisma-exports';
+import Parser from 'rss-parser';
+
+jest.mock('rss-parser', () => {
+  return jest.fn().mockImplementation(() => ({
+    parseURL: jest.fn(),
+  }));
+});
+const MockedParser = jest.mocked(Parser);
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/utils/duplicate-detection', () => ({
+  isDuplicate: jest.fn().mockReturnValue(false),
+}));
+
+/** Batch 3 で追加する5ソースの ソース名 -> Source.id 対応 */
+const BATCH3_SOURCE_IDS: Record<string, string> = {
+  'Vercel Blog': 'vercel_blog',
+  'TypeScript Blog': 'typescript_blog',
+  'VS Code Blog': 'vscode_blog',
+  'Dropbox Tech': 'dropbox_tech',
+  'Fly.io Blog': 'flyio_blog',
+};
+
+const createMockSource = (name: string): Source => ({
+  id: BATCH3_SOURCE_IDS[name],
+  name,
+  url: 'https://example.com',
+  type: 'RSS',
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+interface MockItem {
+  title: string;
+  link?: string;
+  isoDate?: string;
+  content?: string;
+  contentSnippet?: string;
+  'content:encoded'?: string;
+  category?: Array<{ $?: { term?: string } }>;
+  categories?: string[];
+}
+
+const mockFeed = (items: MockItem[]) => {
+  const mockParseURL = jest.fn().mockResolvedValue({ items });
+  MockedParser.mockImplementation(
+    () => ({ parseURL: mockParseURL }) as unknown as Parser
+  );
+};
+
+const fetchSource = async (name: string) => {
+  const config = FOREIGN_SOURCE_CONFIGS[name];
+  expect(config).toBeDefined();
+  const fetcher = new GenericForeignRssFetcher(createMockSource(name), config);
+  return fetcher.fetch();
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Batch 3: 設定辞書とカテゴリ定義の整合', () => {
+  it.each(Object.keys(BATCH3_SOURCE_IDS))(
+    '"%s" が FOREIGN_SOURCE_CONFIGS に定義されている',
+    (name) => {
+      expect(FOREIGN_SOURCE_CONFIGS[name]).toBeDefined();
+      expect(FOREIGN_SOURCE_CONFIGS[name].feedUrl).toMatch(/^https:\/\//);
+    }
+  );
+
+  // Source.id と カテゴリ定義の一致は他のテスト（scheduler-yaml-consistency /
+  // create-fetcher）では検証されない。誤ると記事は収集されてもフィルタUIの
+  // 海外ソースに表示されないため、ここで固定する
+  it.each(Object.entries(BATCH3_SOURCE_IDS))(
+    '"%s" の id "%s" が foreign カテゴリに登録されている',
+    (_name, id) => {
+      expect(SOURCE_CATEGORIES.foreign.sourceIds).toContain(id);
+    }
+  );
+});
+
+describe('Vercel Blog: urlPathFilter による /blog/ 絞り込み', () => {
+  it('changelog・kb を除外し、blog記事のみを正規化URLで保存する', async () => {
+    mockFeed([
+      {
+        title: 'Example changelog entry',
+        link: 'https://vercel.com/changelog/example-changelog-entry',
+        isoDate: '2026-07-31T17:00:00.000Z',
+        content: '<div type="xhtml"><p>Product update description.</p></div>',
+        contentSnippet: 'Product update description.',
+      },
+      {
+        title: 'Example blog post',
+        link: 'https://vercel.com/blog/example-blog-post',
+        isoDate: '2026-07-30T12:00:00.000Z',
+        content: '<div type="xhtml"><p>Blog article body.</p></div>',
+        contentSnippet: 'Blog article body.',
+      },
+      {
+        title: 'Example knowledge base bulletin',
+        link: 'https://vercel.com/kb/bulletin/example-bulletin',
+        isoDate: '2026-07-29T09:00:00.000Z',
+        content: '<div type="xhtml"><p>Bulletin body.</p></div>',
+        contentSnippet: 'Bulletin body.',
+      },
+    ]);
+
+    const config = FOREIGN_SOURCE_CONFIGS['Vercel Blog'];
+    expect(config.urlPathFilter).toBe('/blog/');
+    expect(config.useNormalizedUrl).toBe(true);
+    // Atom category を持たないフィードのため categoryFilter は使えない
+    expect(config.categoryFilter).toBeUndefined();
+
+    const result = await fetchSource('Vercel Blog');
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].url).toBe(
+      'https://vercel.com/blog/example-blog-post'
+    );
+    expect(result.articles[0].content).toContain('Blog article body');
+  });
+});
+
+describe('TypeScript Blog: 既存レコードに合わせた生URL保存', () => {
+  it('末尾スラッシュ付きURLが正規化されずそのまま保存される', async () => {
+    const rawUrl =
+      'https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/';
+    mockFeed([
+      {
+        title: 'Announcing TypeScript 7.0',
+        link: rawUrl,
+        isoDate: '2026-07-08T15:58:29.000Z',
+        'content:encoded':
+          '<p>Today we are proud to announce the availability of TypeScript 7.</p>',
+        categories: ['TypeScript'],
+      },
+    ]);
+
+    const config = FOREIGN_SOURCE_CONFIGS['TypeScript Blog'];
+    // 既存の Hacker News / はてなブックマーク経由レコードが末尾スラッシュ付きの
+    // 生URLで保存済みのため、正規化すると重複作成される
+    expect(config.useNormalizedUrl).toBeUndefined();
+
+    const result = await fetchSource('TypeScript Blog');
+
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].url).toBe(rawUrl);
+    expect(result.articles[0].url.endsWith('/')).toBe(true);
+    // content:encoded が本文として採用される
+    expect(result.articles[0].content).toContain('TypeScript 7');
+  });
+});
+
+describe('Fly.io Blog: 既存レコードに合わせた生URL保存', () => {
+  it('末尾スラッシュ付きURLが正規化されずそのまま保存される', async () => {
+    const rawUrl = 'https://fly.io/blog/example-blog-post/';
+    mockFeed([
+      {
+        title: 'Example Blog Post Title',
+        link: rawUrl,
+        isoDate: '2026-07-24T00:00:00.000Z',
+        content: '<p>We are a public cloud platform.</p>',
+        contentSnippet: 'We are a public cloud platform.',
+      },
+    ]);
+
+    const config = FOREIGN_SOURCE_CONFIGS['Fly.io Blog'];
+    expect(config.useNormalizedUrl).toBeUndefined();
+
+    const result = await fetchSource('Fly.io Blog');
+
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].url).toBe(rawUrl);
+    expect(result.articles[0].url.endsWith('/')).toBe(true);
+  });
+});
+
+describe('VS Code Blog: categoryFilter による blog 絞り込み', () => {
+  it('release カテゴリを除外し、blog記事のみ保存する', async () => {
+    mockFeed([
+      {
+        title: 'Visual Studio Code 1.131',
+        link: 'https://code.visualstudio.com/updates/v1_131',
+        isoDate: '2026-07-29T17:00:00.000Z',
+        content: "<p>Learn what's new in Visual Studio Code 1.131</p>",
+        contentSnippet: "Learn what's new in Visual Studio Code 1.131",
+        category: [{ $: { term: 'release' } }],
+      },
+      {
+        title: 'Example engineering blog post',
+        link: 'https://code.visualstudio.com/blogs/2026/07/29/example-post',
+        isoDate: '2026-07-29T10:00:00.000Z',
+        content: '<p>Early results from an experiment.</p>',
+        contentSnippet: 'Early results from an experiment.',
+        category: [{ $: { term: 'blog' } }],
+      },
+    ]);
+
+    const config = FOREIGN_SOURCE_CONFIGS['VS Code Blog'];
+    expect(config.categoryFilter).toEqual(['blog']);
+    expect(config.useNormalizedUrl).toBe(true);
+
+    const result = await fetchSource('VS Code Blog');
+
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].url).toBe(
+      'https://code.visualstudio.com/blogs/2026/07/29/example-post'
+    );
+    expect(result.articles[0].title).toBe('Example engineering blog post');
+  });
+});
+
+describe('Dropbox Tech: content:encoded 由来の本文と正規化URL', () => {
+  it('content:encodedが本文として採用され、トラッキングパラメータは除去される', async () => {
+    mockFeed([
+      {
+        title: 'How our universal content processing platform evolved',
+        link: 'https://dropbox.tech/infrastructure/example-platform?utm_source=feed',
+        isoDate: '2026-07-20T15:00:00.000Z',
+        content: 'Short description text.',
+        'content:encoded':
+          '<p>Our products transform a lot of content behind the scenes.</p>',
+        categories: ['Dash', 'architecture', 'AI'],
+      },
+    ]);
+
+    const config = FOREIGN_SOURCE_CONFIGS['Dropbox Tech'];
+    expect(config.useNormalizedUrl).toBe(true);
+
+    const result = await fetchSource('Dropbox Tech');
+
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].url).toBe(
+      'https://dropbox.tech/infrastructure/example-platform'
+    );
+    // description ではなく content:encoded が優先される
+    expect(result.articles[0].content).toContain(
+      'transform a lot of content behind the scenes'
+    );
+  });
+});

--- a/__tests__/fetchers/batch3-sources.test.ts
+++ b/__tests__/fetchers/batch3-sources.test.ts
@@ -17,8 +17,11 @@ import {
 } from '@/lib/fetchers/generic-foreign-rss';
 import { SOURCE_CATEGORIES } from '@/lib/constants/source-categories';
 import { BATCH3_SOURCES } from '@/scripts/maintenance/add-batch3-sources';
-import { Source } from '@/lib/prisma-exports';
 import Parser from 'rss-parser';
+import {
+  createMockSource as createMockSourceBase,
+  mockFeed as mockFeedBase,
+} from '../helpers/generic-foreign-rss-mocks';
 
 jest.mock('rss-parser', () => {
   return jest.fn().mockImplementation(() => ({
@@ -49,15 +52,8 @@ const BATCH3_SOURCE_IDS: Record<string, string> = {
   'Fly.io Blog': 'flyio_blog',
 };
 
-const createMockSource = (name: string): Source => ({
-  id: BATCH3_SOURCE_IDS[name],
-  name,
-  url: 'https://example.com',
-  type: 'RSS',
-  enabled: true,
-  createdAt: new Date(),
-  updatedAt: new Date(),
-});
+const createMockSource = (name: string) =>
+  createMockSourceBase({ id: BATCH3_SOURCE_IDS[name], name });
 
 interface MockItem {
   title: string;
@@ -70,12 +66,7 @@ interface MockItem {
   categories?: string[];
 }
 
-const mockFeed = (items: MockItem[]) => {
-  const mockParseURL = jest.fn().mockResolvedValue({ items });
-  MockedParser.mockImplementation(
-    () => ({ parseURL: mockParseURL }) as unknown as Parser
-  );
-};
+const mockFeed = (items: MockItem[]) => mockFeedBase(MockedParser, items);
 
 const fetchSource = async (name: string) => {
   const config = FOREIGN_SOURCE_CONFIGS[name];

--- a/__tests__/fetchers/feed-fixtures.test.ts
+++ b/__tests__/fetchers/feed-fixtures.test.ts
@@ -127,3 +127,131 @@ describe('Batch 2 フィード fixture パース検証', () => {
     expect(item.contentSnippet).not.toContain('<a href');
   });
 });
+
+/**
+ * Batch 3 フィード fixture パーステスト（Issue #628, 海外企業・プロダクトブログ）
+ *
+ * Batch 3 の設定判断は rss-parser のパース結果に強く依存する:
+ * - Vercel の urlPathFilter: link が絶対URLで /blog/ と /changelog/ が混在する
+ * - VS Code の categoryFilter: Atom category が { $: { term } } 形状で得られる
+ * - TypeScript / Fly.io の useNormalizedUrl 無効: link が末尾スラッシュ付きで、
+ *   既存の Hacker News / はてなブックマーク経由レコードと同形式である
+ *
+ * これらの「事実」を固定し、rss-parser 更新時の前提崩れを検知する。
+ *
+ * fixture採取日: 2026-08-03
+ */
+describe('Batch 3 フィード fixture パース検証', () => {
+  // GenericForeignRssFetcher と同じ customFields を与える
+  // （Atom category を配列として保持するために必要）
+  const parser = new Parser({
+    customFields: {
+      item: [['category', 'category', { keepArray: true }]],
+    },
+  });
+
+  const parseFixture = async (file: string) => {
+    const xml = fs.readFileSync(
+      path.join(__dirname, '../fixtures/feeds', file),
+      'utf-8'
+    );
+    return parser.parseString(xml);
+  };
+
+  it('Vercel Blog: xhtml contentが文字列化され、/blog/と/changelog/が絶対URLで混在する', async () => {
+    const feed = await parseFixture('vercel-blog.xml');
+    expect(feed.items.length).toBe(3);
+
+    const links = feed.items.map((i) => i.link);
+    // urlPathFilter の前提: link は絶対URL（相対解決に依存しない）
+    expect(links.every((l) => l?.startsWith('https://vercel.com/'))).toBe(true);
+    // フィードに blog 以外のパスが混在する（フィルタが必要な理由）
+    expect(links).toContain('https://vercel.com/blog/example-blog-post');
+    expect(links).toContain(
+      'https://vercel.com/changelog/example-changelog-entry'
+    );
+    expect(links).toContain('https://vercel.com/kb/bulletin/example-bulletin');
+
+    // Atom の <content type="xhtml"> は入れ子divを含むが文字列として得られる
+    // （オブジェクトで返るとsanitizeTextが機能しないため、型を固定する）
+    const blogItem = feed.items.find((i) => i.link?.includes('/blog/'));
+    expect(typeof blogItem?.content).toBe('string');
+    expect(blogItem?.contentSnippet).toContain('Blog article body');
+
+    // categoryFilter が使えない（Atom category を持たない）ことの確認
+    const record = blogItem as unknown as Record<string, unknown>;
+    expect(record['category']).toBeUndefined();
+    expect(blogItem?.categories).toBeUndefined();
+  });
+
+  it('VS Code Blog: Atom categoryが{ $: { term } }形状で、blog/releaseを判別できる', async () => {
+    const feed = await parseFixture('vscode-blog.xml');
+    expect(feed.items.length).toBe(2);
+
+    const terms = feed.items.map((item) => {
+      const record = item as unknown as Record<string, unknown>;
+      const categories = record['category'] as Array<{
+        $?: { term?: string };
+      }>;
+      return categories?.[0]?.$?.term;
+    });
+    // categoryFilter: ['blog'] が依存する形状
+    expect(terms).toEqual(['release', 'blog']);
+
+    // link は rel なし（=alternate）が採用され、rel="related" の画像URLではない
+    const blogItem = feed.items.find((_, i) => terms[i] === 'blog');
+    expect(blogItem?.link).toBe(
+      'https://code.visualstudio.com/blogs/2026/07/29/example-post'
+    );
+    expect(blogItem?.link).not.toContain('/assets/');
+
+    // 本文はリンク付き要旨のみで短い（保存後エンリッチメントに依存する根拠）
+    expect(blogItem?.contentSnippet?.length).toBeLessThan(200);
+  });
+
+  it('TypeScript Blog: linkが末尾スラッシュ付きで、content:encodedに本文が入る', async () => {
+    const feed = await parseFixture('typescript-blog.xml');
+    expect(feed.items.length).toBe(1);
+
+    const item = feed.items[0];
+    // useNormalizedUrl を有効化しない根拠（既存レコードと同じ末尾スラッシュ付き形式）
+    expect(item.link).toBe(
+      'https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/'
+    );
+    expect(item.link?.endsWith('/')).toBe(true);
+
+    const record = item as unknown as Record<string, unknown>;
+    expect(typeof record['content:encoded']).toBe('string');
+    expect(record['content:encoded'] as string).toContain('TypeScript 7');
+    expect(item.categories).toEqual(['TypeScript']);
+  });
+
+  it('Dropbox Tech: 複数categoryが文字列配列で、content:encodedに本文が入る', async () => {
+    const feed = await parseFixture('dropbox-tech.xml');
+    expect(feed.items.length).toBe(1);
+
+    const item = feed.items[0];
+    expect(item.link).toBe(
+      'https://dropbox.tech/infrastructure/example-content-processing-platform'
+    );
+    // 末尾スラッシュなし（useNormalizedUrl 有効化が安全な根拠）
+    expect(item.link?.endsWith('/')).toBe(false);
+
+    const record = item as unknown as Record<string, unknown>;
+    expect(typeof record['content:encoded']).toBe('string');
+    expect(item.categories).toEqual(['Dash', 'architecture', 'AI']);
+  });
+
+  it('Fly.io Blog: rel="alternate"のlinkが末尾スラッシュ付きで採用される', async () => {
+    const feed = await parseFixture('flyio-blog.xml');
+    expect(feed.items.length).toBe(1);
+
+    const item = feed.items[0];
+    // useNormalizedUrl を有効化しない根拠（既存 Hacker News レコードと同形式）
+    expect(item.link).toBe('https://fly.io/blog/example-blog-post/');
+    expect(item.link?.endsWith('/')).toBe(true);
+
+    expect(typeof item.content).toBe('string');
+    expect(item.contentSnippet).toContain('public cloud platform');
+  });
+});

--- a/__tests__/fetchers/url-path-filter.test.ts
+++ b/__tests__/fetchers/url-path-filter.test.ts
@@ -17,6 +17,7 @@
 import {
   GenericForeignRssFetcher,
   ForeignSourceConfig,
+  FOREIGN_SOURCE_CONFIGS,
 } from '@/lib/fetchers/generic-foreign-rss';
 import { Source } from '@/lib/prisma-exports';
 import Parser from 'rss-parser';
@@ -165,8 +166,10 @@ describe('urlPathFilter: URL解決とスキーム制限', () => {
     const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
 
     expect(result.articles).toHaveLength(1);
-    // 保存URLは既存挙動どおり item.link をそのまま使う（解決結果で上書きしない）
-    expect(result.articles[0].url).toBe('/blog/relative-post');
+    // 保存URLも feedUrl 基準で解決した絶対URLにする。相対URLのまま保存すると
+    // URL一意制約がサイトを跨いで衝突し、エンリッチメントの fetch も
+    // 記事カードの外部リンクも機能しない
+    expect(result.articles[0].url).toBe('https://example.com/blog/relative-post');
   });
 
   it('相対linkが対象外パスなら除外される', async () => {
@@ -334,5 +337,45 @@ describe('urlPathFilter: 未設定時の従来挙動', () => {
     const result = await fetchWith(BASE_CONFIG);
 
     expect(result.articles).toHaveLength(1);
+    // urlPathFilter の有無にかかわらず、相対linkは絶対URLへ解決して保存する
+    expect(result.articles[0].url).toBe('https://example.com/changelog/relative');
+  });
+
+  it('絶対URLは URL コンストラクタを通さずそのまま保存される', async () => {
+    // パーセントエンコーディング等の正規化で既存レコードとの完全一致照合が
+    // 崩れると重複作成につながるため、絶対URLは書き換えない
+    const rawUrl = 'https://example.com/blog/Some-Article/';
+    mockFeed([
+      {
+        title: 'Absolute entry',
+        link: rawUrl,
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'body',
+      },
+    ]);
+
+    const result = await fetchWith(BASE_CONFIG);
+
+    expect(result.articles[0].url).toBe(rawUrl);
+  });
+});
+
+describe('urlPathFilter と categoryFilter の併用', () => {
+  // urlPathFilter は slice(0, 30) の前、categoryFilter は後に適用される。
+  // 併用すると「パス一致の先頭30件が全てカテゴリ不一致なら、31件目以降に
+  // 該当記事があっても0件」という直感に反する挙動になる。
+  // categoryFilter の適用位置は既存ソースの収集量を変えるため動かせないので、
+  // 併用設定が生まれないことを機械的に検出する
+  it('両オプションを同時に設定しているソースが存在しない', () => {
+    const bothConfigured = Object.entries(FOREIGN_SOURCE_CONFIGS)
+      .filter(
+        ([, config]) =>
+          config.urlPathFilter &&
+          config.categoryFilter &&
+          config.categoryFilter.length > 0
+      )
+      .map(([name]) => name);
+
+    expect(bothConfigured).toEqual([]);
   });
 });

--- a/__tests__/fetchers/url-path-filter.test.ts
+++ b/__tests__/fetchers/url-path-filter.test.ts
@@ -19,8 +19,11 @@ import {
   ForeignSourceConfig,
   FOREIGN_SOURCE_CONFIGS,
 } from '@/lib/fetchers/generic-foreign-rss';
-import { Source } from '@/lib/prisma-exports';
 import Parser from 'rss-parser';
+import {
+  createMockSource as createMockSourceBase,
+  mockFeed as mockFeedBase,
+} from '../helpers/generic-foreign-rss-mocks';
 
 jest.mock('rss-parser', () => {
   return jest.fn().mockImplementation(() => ({
@@ -49,15 +52,12 @@ const BASE_CONFIG: ForeignSourceConfig = {
   tagPrefix: 'example',
 };
 
-const createMockSource = (): Source => ({
-  id: 'url_path_filter_test',
-  name: 'URL Path Filter Test',
-  url: 'https://example.com',
-  type: 'RSS',
-  enabled: true,
-  createdAt: new Date(),
-  updatedAt: new Date(),
-});
+const createMockSource = () =>
+  createMockSourceBase({
+    id: 'url_path_filter_test',
+    name: 'URL Path Filter Test',
+    url: 'https://example.com',
+  });
 
 interface MockItem {
   title: string;
@@ -66,12 +66,7 @@ interface MockItem {
   content?: string;
 }
 
-const mockFeed = (items: MockItem[]) => {
-  const mockParseURL = jest.fn().mockResolvedValue({ items });
-  MockedParser.mockImplementation(
-    () => ({ parseURL: mockParseURL }) as unknown as Parser
-  );
-};
+const mockFeed = (items: MockItem[]) => mockFeedBase(MockedParser, items);
 
 const fetchWith = async (config: ForeignSourceConfig) => {
   const fetcher = new GenericForeignRssFetcher(createMockSource(), config);
@@ -377,5 +372,36 @@ describe('urlPathFilter と categoryFilter の併用', () => {
       .map(([name]) => name);
 
     expect(bothConfigured).toEqual([]);
+  });
+
+  it('urlPathFilterとcategoryFilterを同時に設定するとコンストラクタがthrowする', () => {
+    expect(
+      () =>
+        new GenericForeignRssFetcher(createMockSource(), {
+          ...BASE_CONFIG,
+          urlPathFilter: '/blog/',
+          categoryFilter: ['blog'],
+        })
+    ).toThrow('urlPathFilter と categoryFilter は併用できません');
+  });
+
+  it('urlPathFilterのみ設定してもthrowしない', () => {
+    expect(
+      () =>
+        new GenericForeignRssFetcher(createMockSource(), {
+          ...BASE_CONFIG,
+          urlPathFilter: '/blog/',
+        })
+    ).not.toThrow();
+  });
+
+  it('categoryFilterのみ設定してもthrowしない', () => {
+    expect(
+      () =>
+        new GenericForeignRssFetcher(createMockSource(), {
+          ...BASE_CONFIG,
+          categoryFilter: ['blog'],
+        })
+    ).not.toThrow();
   });
 });

--- a/__tests__/fetchers/url-path-filter.test.ts
+++ b/__tests__/fetchers/url-path-filter.test.ts
@@ -1,0 +1,338 @@
+/**
+ * GenericForeignRssFetcher の urlPathFilter オプション単体テスト
+ * （Issue #628 Batch 3）
+ *
+ * urlPathFilter は「1つのフィードに記事と別種のエントリが混在し、category で
+ * 判別できないソース」向けの絞り込みオプション（Vercel の /blog/ と /changelog/）。
+ *
+ * 本テストで固定する契約:
+ * - フィルタは slice(0, 30) の**前**に全 item へ適用される
+ * - 相対 link は feedUrl 基準で解決される（rss-parser は Atom の href を
+ *   相対のまま返すため）
+ * - http / https 以外のスキームは除外される
+ * - 判定は解決後 pathname の前方一致（セグメント境界は設定値どおり）
+ * - 未設定時は従来どおり全 item が対象
+ */
+
+import {
+  GenericForeignRssFetcher,
+  ForeignSourceConfig,
+} from '@/lib/fetchers/generic-foreign-rss';
+import { Source } from '@/lib/prisma-exports';
+import Parser from 'rss-parser';
+
+jest.mock('rss-parser', () => {
+  return jest.fn().mockImplementation(() => ({
+    parseURL: jest.fn(),
+  }));
+});
+const MockedParser = jest.mocked(Parser);
+
+jest.mock('@/lib/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/utils/duplicate-detection', () => ({
+  isDuplicate: jest.fn().mockReturnValue(false),
+}));
+
+const FEED_URL = 'https://example.com/atom';
+
+const BASE_CONFIG: ForeignSourceConfig = {
+  feedUrl: FEED_URL,
+  tagPrefix: 'example',
+};
+
+const createMockSource = (): Source => ({
+  id: 'url_path_filter_test',
+  name: 'URL Path Filter Test',
+  url: 'https://example.com',
+  type: 'RSS',
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+interface MockItem {
+  title: string;
+  link?: string;
+  isoDate?: string;
+  content?: string;
+}
+
+const mockFeed = (items: MockItem[]) => {
+  const mockParseURL = jest.fn().mockResolvedValue({ items });
+  MockedParser.mockImplementation(
+    () => ({ parseURL: mockParseURL }) as unknown as Parser
+  );
+};
+
+const fetchWith = async (config: ForeignSourceConfig) => {
+  const fetcher = new GenericForeignRssFetcher(createMockSource(), config);
+  return fetcher.fetch();
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('urlPathFilter: slice(0, 30) との適用順序', () => {
+  it('フィルタが slice の前に適用され、対象パスの記事を30件取得できる', async () => {
+    // フィード先頭を対象外パス（/changelog/）40件が占め、その後に
+    // 対象パス（/blog/）35件が続く。Vercel の実フィード構造を模す
+    const items: MockItem[] = [
+      ...Array.from({ length: 40 }, (_, i) => ({
+        title: `Changelog entry ${i}`,
+        link: `https://example.com/changelog/entry-${i}`,
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'changelog body',
+      })),
+      ...Array.from({ length: 35 }, (_, i) => ({
+        title: `Blog post ${i}`,
+        link: `https://example.com/blog/post-${i}`,
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'blog body',
+      })),
+    ];
+    mockFeed(items);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    // slice を先に適用していたら 0 件になる（先頭30件は全て changelog のため）
+    expect(result.articles).toHaveLength(30);
+    expect(
+      result.articles.every((a) => a.url.includes('/blog/post-'))
+    ).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('フィルタ後の件数が30件未満ならその件数だけ取得される', async () => {
+    mockFeed([
+      {
+        title: 'Blog post',
+        link: 'https://example.com/blog/only-one',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'blog body',
+      },
+      {
+        title: 'Changelog entry',
+        link: 'https://example.com/changelog/entry',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'changelog body',
+      },
+    ]);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].url).toBe('https://example.com/blog/only-one');
+  });
+
+  it('フィルタ後が0件でもエラーにならず空配列を返す', async () => {
+    mockFeed([
+      {
+        title: 'Changelog entry',
+        link: 'https://example.com/changelog/entry',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'changelog body',
+      },
+    ]);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    expect(result.articles).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+describe('urlPathFilter: URL解決とスキーム制限', () => {
+  it('相対linkはfeedUrl基準で解決され、対象パスなら取得される', async () => {
+    // rss-parser は Atom の <link href="/blog/post"> を相対のまま返す
+    mockFeed([
+      {
+        title: 'Relative link post',
+        link: '/blog/relative-post',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'blog body',
+      },
+    ]);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    expect(result.articles).toHaveLength(1);
+    // 保存URLは既存挙動どおり item.link をそのまま使う（解決結果で上書きしない）
+    expect(result.articles[0].url).toBe('/blog/relative-post');
+  });
+
+  it('相対linkが対象外パスなら除外される', async () => {
+    mockFeed([
+      {
+        title: 'Relative changelog',
+        link: '/changelog/relative-entry',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'changelog body',
+      },
+    ]);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    expect(result.articles).toHaveLength(0);
+  });
+
+  it('http/https以外のスキームはパスが一致しても除外される', async () => {
+    mockFeed([
+      {
+        title: 'Data URL entry',
+        link: 'data:text/html,/blog/fake',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'body',
+      },
+      {
+        title: 'FTP entry',
+        link: 'ftp://example.com/blog/file',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'body',
+      },
+      {
+        title: 'Valid https entry',
+        link: 'https://example.com/blog/valid',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'body',
+      },
+    ]);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].url).toBe('https://example.com/blog/valid');
+  });
+
+  it('別ホストでも対象パスなら取得される（ホスト制限はしない）', async () => {
+    mockFeed([
+      {
+        title: 'Cross host post',
+        link: 'https://other.example.org/blog/cross-host',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'body',
+      },
+    ]);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    expect(result.articles).toHaveLength(1);
+  });
+
+  it('linkが無いitemは除外される', async () => {
+    mockFeed([
+      {
+        title: 'No link entry',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'body',
+      },
+    ]);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    expect(result.articles).toHaveLength(0);
+  });
+});
+
+describe('urlPathFilter: pathname前方一致のセグメント境界', () => {
+  it('クエリ・フラグメント付きURLでもpathnameだけで判定される', async () => {
+    mockFeed([
+      {
+        title: 'Post with query',
+        link: 'https://example.com/blog/post?utm_source=feed#section',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'body',
+      },
+    ]);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    expect(result.articles).toHaveLength(1);
+  });
+
+  it('パス途中に対象文字列があっても前方一致しなければ除外される', async () => {
+    // 文字列 includes 判定なら誤って通ってしまうケース
+    mockFeed([
+      {
+        title: 'Changelog about blog',
+        link: 'https://example.com/changelog/blog-redesign',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'body',
+      },
+    ]);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    expect(result.articles).toHaveLength(0);
+  });
+
+  it('末尾スラッシュ付き設定は別セグメント（/blogger）に一致しない', async () => {
+    mockFeed([
+      {
+        title: 'Blogger post',
+        link: 'https://example.com/blogger/post',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'body',
+      },
+    ]);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    expect(result.articles).toHaveLength(0);
+  });
+
+  it('末尾スラッシュ付き設定はインデックスページ（/blog）自体を除外する', async () => {
+    mockFeed([
+      {
+        title: 'Blog index',
+        link: 'https://example.com/blog',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'body',
+      },
+    ]);
+
+    const result = await fetchWith({ ...BASE_CONFIG, urlPathFilter: '/blog/' });
+
+    expect(result.articles).toHaveLength(0);
+  });
+});
+
+describe('urlPathFilter: 未設定時の従来挙動', () => {
+  it('未設定なら全itemが対象になり、slice(0,30)のみ適用される', async () => {
+    const items: MockItem[] = Array.from({ length: 35 }, (_, i) => ({
+      title: `Entry ${i}`,
+      link: `https://example.com/changelog/entry-${i}`,
+      isoDate: '2026-08-01T00:00:00.000Z',
+      content: 'body',
+    }));
+    mockFeed(items);
+
+    const result = await fetchWith(BASE_CONFIG);
+
+    expect(result.articles).toHaveLength(30);
+    expect(result.articles[0].url).toBe('https://example.com/changelog/entry-0');
+  });
+
+  it('未設定なら相対linkのitemも従来どおり取得される', async () => {
+    mockFeed([
+      {
+        title: 'Relative entry',
+        link: '/changelog/relative',
+        isoDate: '2026-08-01T00:00:00.000Z',
+        content: 'body',
+      },
+    ]);
+
+    const result = await fetchWith(BASE_CONFIG);
+
+    expect(result.articles).toHaveLength(1);
+  });
+});

--- a/__tests__/fixtures/feeds/dropbox-tech.xml
+++ b/__tests__/fixtures/feeds/dropbox-tech.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:media="http://search.yahoo.com/mrss/">
+    <channel>
+         <title> Dropbox Tech Blog </title>
+        <atom:link  href="https://dropbox.tech/feed" rel="self" type="application/rss+xml" />
+        <link>https://dropbox.tech</link>
+        <description>Dropbox engineering blog</description>
+        <item>
+            <title>How our universal content processing platform evolved for AI and beyond</title>
+            <link>https://dropbox.tech/infrastructure/example-content-processing-platform</link>
+            <dc:creator>
+                Example Author
+            </dc:creator>
+            <category>Dash</category>
+            <category>architecture</category>
+            <category>AI</category>
+            <description><![CDATA[The content processing platform has been iteratively improving content transformation in our products for roughly a decade.]]></description>
+            <guid>https://dropbox.tech/infrastructure/example-content-processing-platform</guid>
+            <pubDate>Mon, 20 Jul 2026 08:00:00 -0700</pubDate>
+            <content:encoded><![CDATA[<p>Our products transform a lot of content behind the scenes. Open a presentation deck on your phone, and it is rendered into a crisp preview you can quickly browse.</p>
+<p>Finalize an agreement, and it is flattened into a PDF. Upload a video, and it is transcoded into a lightweight version that streams instantly.</p>
+]]></content:encoded>
+        </item>
+    </channel>
+</rss>

--- a/__tests__/fixtures/feeds/flyio-blog.xml
+++ b/__tests__/fixtures/feeds/flyio-blog.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+  <title>The Fly Blog</title>
+  <subtitle>News, tips, and tricks from the team at Fly</subtitle>
+  <id>https://fly.io/blog/</id>
+  <link href="https://fly.io/blog/"/>
+  <link href="https://fly.io/blog/" rel="self"/>
+  <updated>2026-07-24T00:00:00+00:00</updated>
+  <author>
+    <name>Fly</name>
+  </author>
+  <entry>
+    <title>Example Blog Post Title</title>
+    <link rel="alternate" href="https://fly.io/blog/example-blog-post/"/>
+    <id>https://fly.io/blog/example-blog-post/</id>
+    <published>2026-07-24T00:00:00+00:00</published>
+    <updated>2026-07-30T15:47:48+00:00</updated>
+    <media:thumbnail url="https://fly.io/blog/example-blog-post/assets/cover.webp"/>
+    <content type="html">&lt;div class="lead"&gt;&lt;p&gt;We are a public cloud platform. This is a post about our company, the future, and computers for agents.&lt;/p&gt;
+&lt;/div&gt;
+&lt;p&gt;This is a complicated post, so here is a longer body paragraph describing the technical background in more detail.&lt;/p&gt;
+</content>
+  </entry>
+</feed>

--- a/__tests__/fixtures/feeds/typescript-blog.xml
+++ b/__tests__/fixtures/feeds/typescript-blog.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	>
+<channel>
+	<title>TypeScript</title>
+	<atom:link href="https://devblogs.microsoft.com/typescript/feed/" rel="self" type="application/rss+xml" />
+	<link>https://devblogs.microsoft.com/typescript/</link>
+	<description>The official blog of the TypeScript team</description>
+	<item>
+		<title>Announcing TypeScript 7.0</title>
+		<link>https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/</link>
+		<comments>https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#comments</comments>
+		<dc:creator><![CDATA[Example Author]]></dc:creator>
+		<pubDate>Wed, 08 Jul 2026 15:58:29 +0000</pubDate>
+		<category><![CDATA[TypeScript]]></category>
+		<guid isPermaLink="false">https://devblogs.microsoft.com/typescript/?p=5246</guid>
+		<description><![CDATA[<p>Today we are proud to announce the availability of TypeScript 7, a native port of TypeScript. [&#8230;]</p>
+<p>The post <a href="https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/">Announcing TypeScript 7.0</a> appeared first on <a href="https://devblogs.microsoft.com/typescript">TypeScript</a>.</p>
+]]></description>
+		<content:encoded><![CDATA[<p>Today we are proud to announce the availability of TypeScript 7, a native port of TypeScript. By bringing strong type-checking and rich tooling to the world of JavaScript, TypeScript made it possible to build non-trivial high-quality apps across platforms.</p>
+<p>Last year, our team unveiled the next step in scaling: making every part of the compiler faster.</p>
+]]></content:encoded>
+	</item>
+</channel>
+</rss>

--- a/__tests__/fixtures/feeds/vercel-blog.xml
+++ b/__tests__/fixtures/feeds/vercel-blog.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+  <feed xmlns="http://www.w3.org/2005/Atom">
+    <title>Vercel News</title>
+    <subtitle>Blog</subtitle>
+    <link href="https://vercel.com/atom" rel="self" type="application/rss+xml"/>
+    <link href="https://vercel.com/" />
+    <updated>2026-07-31T17:00:00.000Z</updated>
+    <id>https://vercel.com/</id>
+    <entry>
+      <id>https://vercel.com/changelog/example-changelog-entry</id>
+      <title>Example changelog entry</title>
+      <link href="https://vercel.com/changelog/example-changelog-entry"/>
+      <updated>2026-07-31T17:00:00.000Z</updated>
+      <content type="xhtml">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+          <p>Product update description for the changelog entry.</p><h2>Scopes</h2><p>Additional changelog detail.</p>
+        </div>
+      </content>
+      <author>
+        <name>Vercel</name>
+      </author>
+    </entry>
+    <entry>
+      <id>https://vercel.com/blog/example-blog-post</id>
+      <title>Example blog post</title>
+      <link href="https://vercel.com/blog/example-blog-post"/>
+      <updated>2026-07-30T12:00:00.000Z</updated>
+      <content type="xhtml">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+          <p>Blog article body describing an engineering topic in detail.</p>
+        </div>
+      </content>
+      <author>
+        <name>Vercel</name>
+      </author>
+    </entry>
+    <entry>
+      <id>https://vercel.com/kb/bulletin/example-bulletin</id>
+      <title>Example knowledge base bulletin</title>
+      <link href="https://vercel.com/kb/bulletin/example-bulletin"/>
+      <updated>2026-07-29T09:00:00.000Z</updated>
+      <content type="xhtml">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+          <p>Knowledge base bulletin body.</p>
+        </div>
+      </content>
+      <author>
+        <name>Vercel</name>
+      </author>
+    </entry>
+  </feed>

--- a/__tests__/fixtures/feeds/vscode-blog.xml
+++ b/__tests__/fixtures/feeds/vscode-blog.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title type="text" xml:lang="en">Visual Studio Code - Code Editing. Redefined.</title>
+  <link type="application/atom+xml" href="https://code.visualstudio.com/feed.xml" rel="self"/>
+  <link type="text/html" href="https://code.visualstudio.com/" rel="alternate"/>
+  <updated>2026-07-29T17:00:00.000Z</updated>
+  <id>https://code.visualstudio.com/</id>
+  <entry>
+    <title>Visual Studio Code 1.131</title>
+    <link href="https://code.visualstudio.com/updates/v1_131"/>
+    <link rel="related" href="https://code.visualstudio.com/assets/updates/1_131/release-highlights.webp"/>
+    <updated>2026-07-29T17:00:00.000Z</updated>
+    <id>https://code.visualstudio.com/updates/v1_131</id>
+    <category term="release" />
+    <content type="html">
+      &lt;p&gt;Learn what's new in Visual Studio Code 1.131&lt;/p&gt;
+      &lt;p&gt;&lt;a href="https://code.visualstudio.com/updates/v1_131"&gt;Read the full article&lt;/a&gt;&lt;/p&gt;
+    </content>
+    <author>
+        <name>Visual Studio Code Team</name>
+        <uri>https://code.visualstudio.com/branding/code-stable.png</uri>
+    </author>
+  </entry>
+  <entry>
+    <title>Example engineering blog post</title>
+    <link href="https://code.visualstudio.com/blogs/2026/07/29/example-post"/>
+    <link rel="related" href="https://code.visualstudio.com/assets/blogs/2026/07/29/hero.png"/>
+    <updated>2026-07-29T10:00:00.000Z</updated>
+    <id>https://code.visualstudio.com/blogs/2026/07/29/example-post</id>
+    <category term="blog" />
+    <content type="html">
+      &lt;p&gt;Early results from an experiment with real developer workflows.&lt;/p&gt;
+      &lt;p&gt;&lt;a href="https://code.visualstudio.com/blogs/2026/07/29/example-post"&gt;Read the full article&lt;/a&gt;&lt;/p&gt;
+    </content>
+    <author>
+        <name>Visual Studio Code Team</name>
+        <uri>https://code.visualstudio.com/branding/code-stable.png</uri>
+    </author>
+  </entry>
+</feed>

--- a/__tests__/helpers/generic-foreign-rss-mocks.ts
+++ b/__tests__/helpers/generic-foreign-rss-mocks.ts
@@ -1,0 +1,29 @@
+/**
+ * GenericForeignRssFetcher テスト共通モックヘルパー
+ *
+ * jest.mock('rss-parser', ...) はJestのホイスティング制約により、
+ * 使用側の各テストファイルに宣言を残すこと（このヘルパーへは移動しない）。
+ */
+import { Source } from '@/lib/prisma-exports';
+import Parser from 'rss-parser';
+
+export const createMockSource = (overrides: Partial<Source> = {}): Source => ({
+  id: 'test_source',
+  name: 'Test Source',
+  url: 'https://example.com',
+  type: 'RSS',
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+export const mockFeed = (
+  MockedParser: jest.MockedClass<typeof Parser>,
+  items: unknown[]
+) => {
+  const mockParseURL = jest.fn().mockResolvedValue({ items });
+  MockedParser.mockImplementation(
+    () => ({ parseURL: mockParseURL }) as unknown as Parser
+  );
+};

--- a/lib/constants/source-categories.ts
+++ b/lib/constants/source-categories.ts
@@ -99,6 +99,12 @@ export const SOURCE_CATEGORIES: Record<SourceCategoryId, SourceCategory> = {
       // Batch 2 (Issue #628): 海外アグリゲータ
       'lobsters', // Lobsters
       'techmeme', // Techmeme
+      // Batch 3 (Issue #628): 海外企業・プロダクトブログ
+      'vercel_blog', // Vercel Blog
+      'typescript_blog', // TypeScript Blog
+      'vscode_blog', // VS Code Blog
+      'dropbox_tech', // Dropbox Tech
+      'flyio_blog', // Fly.io Blog
     ],
   },
   domestic: {

--- a/lib/fetchers/generic-foreign-rss.ts
+++ b/lib/fetchers/generic-foreign-rss.ts
@@ -610,6 +610,45 @@ export const FOREIGN_SOURCE_CONFIGS: Record<string, ForeignSourceConfig> = {
     useNormalizedUrl: true,
     skipEnrichment: true,
   },
+  // Foreign Company / Product Blogs (Batch 3, Issue #628)
+  // useNormalizedUrl は「新規ソースなら常に有効化」ではなく、既存レコードの
+  // 保存URL形式に合わせる（重複判定は保存URL文字列の完全一致のため）。
+  // 既存が末尾スラッシュ付きの生URLで保存されているソースで有効化すると、
+  // normalizeUrl() の末尾スラッシュ除去により照合が崩れて重複作成される
+  //
+  // Vercel: フィード（/atom）に blog と changelog が混在し Atom category も
+  // 持たないため、categoryFilter ではなく urlPathFilter で /blog/ に絞る
+  'Vercel Blog': {
+    feedUrl: 'https://vercel.com/atom',
+    tagPrefix: 'vercel',
+    useNormalizedUrl: true,
+    urlPathFilter: '/blog/',
+  },
+  // TypeScript: Hacker News / はてなブックマーク経由の既存記事が
+  // 末尾スラッシュ付きの生URLで保存済みのため useNormalizedUrl は有効化しない
+  'TypeScript Blog': {
+    feedUrl: 'https://devblogs.microsoft.com/typescript/feed/',
+    tagPrefix: 'typescript',
+  },
+  // VS Code: Atom category term が blog / release に分かれる。リリースノートは
+  // 本文がリンクのみで記事性が薄いため blog のみ収集する
+  'VS Code Blog': {
+    feedUrl: 'https://code.visualstudio.com/feed.xml',
+    tagPrefix: 'vscode',
+    useNormalizedUrl: true,
+    categoryFilter: ['blog'],
+  },
+  'Dropbox Tech': {
+    feedUrl: 'https://dropbox.tech/feed',
+    tagPrefix: 'dropbox',
+    useNormalizedUrl: true,
+  },
+  // Fly.io: Hacker News 経由の既存記事が末尾スラッシュ付きの生URLで保存済みの
+  // ため useNormalizedUrl は有効化しない（TypeScript Blog と同じ理由）
+  'Fly.io Blog': {
+    feedUrl: 'https://fly.io/blog/feed.xml',
+    tagPrefix: 'flyio',
+  },
 };
 
 /**

--- a/lib/fetchers/generic-foreign-rss.ts
+++ b/lib/fetchers/generic-foreign-rss.ts
@@ -64,6 +64,20 @@ export interface ForeignSourceConfig {
    * ノイズ（広告含む）になるソース向け。`isEnrichmentSkipped()` で参照する。
    */
   skipEnrichment?: boolean;
+  /**
+   * 記事URLのパス前方一致で item を絞り込む。
+   *
+   * 1つのフィードにブログ記事と別種のエントリ（製品チェンジログ等）が混在し、
+   * かつ category による判別ができないソース向け。
+   *
+   * 設定値は先頭スラッシュを含むパス prefix（例: `/blog/`）。解決後 pathname に
+   * 対する `startsWith` 判定のため、`/blog/` は `/blogger` に一致せず、
+   * 末尾スラッシュなしの `/blog` 単体も除外する。
+   *
+   * `categoryFilter` と異なり `slice()` の**前**に全 item へ適用する
+   * （フィード先頭が対象外パスで占められるソースで取りこぼさないため）。
+   */
+  urlPathFilter?: string;
 }
 
 export class GenericForeignRssFetcher extends BaseFetcher {
@@ -107,8 +121,37 @@ export class GenericForeignRssFetcher extends BaseFetcher {
 
       const feed = await this.parser.parseURL(this.config.feedUrl);
 
+      const allItems = feed.items || [];
+
+      // URLパスフィルタリング（設定がある場合のみ）
+      // categoryFilter と異なり slice() の前に全 item へ適用する。slice 後だと、
+      // フィード先頭が対象外パスで占められるソース（例: Vercel は /changelog/ が
+      // 支配的）で対象記事をほとんど取得できない
+      let pathFilteredItems = allItems;
+      if (this.config.urlPathFilter) {
+        pathFilteredItems = allItems.filter((item) =>
+          this.matchesUrlPathFilter(item.link)
+        );
+        logger.info(
+          {
+            source: this.source.name,
+            // フィード肥大化の追跡用にフィルタ前の全item数も記録する
+            totalItems: allItems.length,
+            after: pathFilteredItems.length,
+            filter: this.config.urlPathFilter,
+          },
+          'URLパスフィルタ適用'
+        );
+        if (pathFilteredItems.length === 0) {
+          logger.warn(
+            { source: this.source.name, filter: this.config.urlPathFilter },
+            'URLパスフィルタ後の記事が0件'
+          );
+        }
+      }
+
       // 最新30件まで処理
-      const items = feed.items?.slice(0, 30) || [];
+      const items = pathFilteredItems.slice(0, 30);
 
       // カテゴリフィルタリング（設定がある場合のみ）
       let filteredItems = items;
@@ -255,6 +298,33 @@ export class GenericForeignRssFetcher extends BaseFetcher {
       )
       .map((term) => term.trim())
       .filter((term) => term.length > 0);
+  }
+
+  /**
+   * URLパスフィルタに一致するかチェック
+   *
+   * - 相対URL（Atom の `<link href="/blog/post">`）は feedUrl 基準で解決する。
+   *   rss-parser は Atom の href を相対のまま返すため、絶対URL前提で判定すると
+   *   有効な相対 link を不正URLとして落としてしまう。`xml:base` は考慮しない
+   * - http / https 以外のスキーム（data:, ftp: 等）は対象外とする
+   * - 判定は解決後 pathname の前方一致。文字列 includes ではないため
+   *   `/changelog/blog-post` のような別パスの誤マッチは起きない
+   */
+  private matchesUrlPathFilter(link: string | undefined): boolean {
+    const pathPrefix = this.config.urlPathFilter;
+    if (!pathPrefix) return true;
+    if (!link) return false;
+
+    try {
+      const resolved = new URL(link, this.config.feedUrl);
+      if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
+        return false;
+      }
+      return resolved.pathname.startsWith(pathPrefix);
+    } catch {
+      // 解決不能なURLは後段へ流さない
+      return false;
+    }
   }
 
   /**

--- a/lib/fetchers/generic-foreign-rss.ts
+++ b/lib/fetchers/generic-foreign-rss.ts
@@ -181,8 +181,11 @@ export class GenericForeignRssFetcher extends BaseFetcher {
         if (!item.link || !item.title) continue;
 
         try {
+          // 相対 link は絶対URLへ解決してから保存する（詳細は resolveItemLink）
+          const itemUrl = this.resolveItemLink(item.link);
+
           // URLを正規化
-          const normalizedUrl = normalizeUrl(item.link);
+          const normalizedUrl = normalizeUrl(itemUrl);
 
           // 重複チェック（同一バッチ内）
           if (this.isDuplicateInBatch(normalizedUrl, item.title)) {
@@ -198,7 +201,7 @@ export class GenericForeignRssFetcher extends BaseFetcher {
             // 既定は元URL（エンリッチメントで正しくアクセスするため）。
             // useNormalizedUrl 有効時はトラッキングパラメータ除去後のURLで保存し、
             // 他ソース経由で収集済みの同一記事と重複しないようにする
-            url: this.config.useNormalizedUrl ? normalizedUrl : item.link,
+            url: this.config.useNormalizedUrl ? normalizedUrl : itemUrl,
             content: this.extractContent(item),
             publishedAt: this.extractPublishDate(item),
             sourceId: this.source.id,
@@ -301,11 +304,35 @@ export class GenericForeignRssFetcher extends BaseFetcher {
   }
 
   /**
+   * item の link を保存用の絶対URLへ解決する
+   *
+   * rss-parser は Atom の `<link href="/blog/post">` を相対URLのまま返す。
+   * 相対URLをそのまま保存すると、URLの一意制約がサイトを跨いで衝突し、
+   * エンリッチメントの fetch も記事カードの外部リンクも機能しないため、
+   * feedUrl を基準に解決する（`xml:base` は考慮しない）。
+   *
+   * 既に絶対URLの場合は URL コンストラクタを通さず元の文字列を返す。
+   * 通すとパーセントエンコーディング等が正規化され、既存レコードとの
+   * 完全一致照合が崩れて重複作成につながるため。
+   */
+  private resolveItemLink(link: string): string {
+    try {
+      new URL(link);
+      return link;
+    } catch {
+      try {
+        return new URL(link, this.config.feedUrl).href;
+      } catch {
+        return link;
+      }
+    }
+  }
+
+  /**
    * URLパスフィルタに一致するかチェック
    *
-   * - 相対URL（Atom の `<link href="/blog/post">`）は feedUrl 基準で解決する。
-   *   rss-parser は Atom の href を相対のまま返すため、絶対URL前提で判定すると
-   *   有効な相対 link を不正URLとして落としてしまう。`xml:base` は考慮しない
+   * - 相対URLは feedUrl 基準で解決してから判定する（絶対URL前提で判定すると
+   *   有効な相対 link を不正URLとして落としてしまう）
    * - http / https 以外のスキーム（data:, ftp: 等）は対象外とする
    * - 判定は解決後 pathname の前方一致。文字列 includes ではないため
    *   `/changelog/blog-post` のような別パスの誤マッチは起きない

--- a/lib/fetchers/generic-foreign-rss.ts
+++ b/lib/fetchers/generic-foreign-rss.ts
@@ -91,6 +91,11 @@ export class GenericForeignRssFetcher extends BaseFetcher {
 
   constructor(source: Source, config: ForeignSourceConfig) {
     super(source);
+    if (config.urlPathFilter && config.categoryFilter?.length) {
+      throw new Error(
+        `${source.name}: urlPathFilter と categoryFilter は併用できません`
+      );
+    }
     const parserOptions: Parser.ParserOptions<
       Record<string, unknown>,
       Record<string, unknown>
@@ -304,6 +309,18 @@ export class GenericForeignRssFetcher extends BaseFetcher {
   }
 
   /**
+   * link を feedUrl 基準で URL オブジェクトへ解決する共通ヘルパー
+   * 解決できない場合は null を返す
+   */
+  private tryResolveUrl(link: string): URL | null {
+    try {
+      return new URL(link, this.config.feedUrl);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * item の link を保存用の絶対URLへ解決する
    *
    * rss-parser は Atom の `<link href="/blog/post">` を相対URLのまま返す。
@@ -320,11 +337,7 @@ export class GenericForeignRssFetcher extends BaseFetcher {
       new URL(link);
       return link;
     } catch {
-      try {
-        return new URL(link, this.config.feedUrl).href;
-      } catch {
-        return link;
-      }
+      return this.tryResolveUrl(link)?.href ?? link;
     }
   }
 
@@ -342,16 +355,13 @@ export class GenericForeignRssFetcher extends BaseFetcher {
     if (!pathPrefix) return true;
     if (!link) return false;
 
-    try {
-      const resolved = new URL(link, this.config.feedUrl);
-      if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
-        return false;
-      }
-      return resolved.pathname.startsWith(pathPrefix);
-    } catch {
-      // 解決不能なURLは後段へ流さない
+    // 解決不能なURLは後段へ流さない
+    const resolved = this.tryResolveUrl(link);
+    if (!resolved) return false;
+    if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
       return false;
     }
+    return resolved.pathname.startsWith(pathPrefix);
   }
 
   /**

--- a/lib/fetchers/index.ts
+++ b/lib/fetchers/index.ts
@@ -205,7 +205,13 @@ export function createFetcher(source: Source): BaseFetcher {
     case 'Findy Engineer Lab':
     // Foreign Aggregators (Batch 2, Issue #628)
     case 'Lobsters':
-    case 'Techmeme': {
+    case 'Techmeme':
+    // Foreign Company / Product Blogs (Batch 3, Issue #628)
+    case 'Vercel Blog':
+    case 'TypeScript Blog':
+    case 'VS Code Blog':
+    case 'Dropbox Tech':
+    case 'Fly.io Blog': {
       const foreignConfig = getForeignSourceConfig(source.name);
       if (!foreignConfig) {
         throw new Error(`Invalid foreign source name: ${source.name}`);

--- a/scripts/maintenance/add-batch3-sources.ts
+++ b/scripts/maintenance/add-batch3-sources.ts
@@ -10,6 +10,8 @@
  * （plan_20260803_111504_issue628_batch3_sources.md「本番反映」参照）。
  */
 
+import path from 'path';
+
 /**
  * 登録対象のソース定義。
  *
@@ -114,8 +116,10 @@ async function main() {
 }
 
 // スクリプトとして直接実行された場合のみ main() を走らせる
-// （テストから BATCH3_SOURCES を import しても DB 接続が発生しないようにする）
-if (process.argv[1]?.includes('add-batch3-sources')) {
+// （テストから BATCH3_SOURCES を import しても DB 接続が発生しないようにする）。
+// 部分一致だと `verify-add-batch3-sources.ts` のような別スクリプトからの
+// import でも DB 更新が走るため、ファイル名の完全一致で判定する
+if (path.basename(process.argv[1] ?? '') === 'add-batch3-sources.ts') {
   main()
     .catch((error) => {
       console.error('エラーが発生しました:', error);

--- a/scripts/maintenance/add-batch3-sources.ts
+++ b/scripts/maintenance/add-batch3-sources.ts
@@ -1,0 +1,127 @@
+/**
+ * Batch 3 海外企業・プロダクトブログ5ソースをDBに登録するスクリプト (Issue #628)
+ *
+ * 対象: Vercel Blog / TypeScript Blog / VS Code Blog / Dropbox Tech / Fly.io Blog
+ *
+ * 使用方法:
+ *   npx tsx scripts/maintenance/add-batch3-sources.ts
+ *
+ * 本番実行時は事前に5つの id / name の既存行有無を SELECT で確認すること
+ * （plan_20260803_111504_issue628_batch3_sources.md「本番反映」参照）。
+ */
+
+/**
+ * 登録対象のソース定義。
+ *
+ * name は FOREIGN_SOURCE_CONFIGS のキー、id は SOURCE_CATEGORIES.foreign の
+ * sourceIds と完全一致させる必要がある。この一致は create-fetcher /
+ * scheduler-yaml-consistency の各テストでは検証されないため、
+ * batch3-sources.test.ts がこの定義を import して検証する。
+ *
+ * そのため、この定義の import が DB 接続等の副作用を持たないよう、
+ * Prisma クライアントの生成は main() 内で行う。
+ */
+export const BATCH3_SOURCES = [
+  {
+    id: 'vercel_blog',
+    name: 'Vercel Blog',
+    url: 'https://vercel.com/blog',
+    type: 'RSS',
+    enabled: true,
+  },
+  {
+    id: 'typescript_blog',
+    name: 'TypeScript Blog',
+    url: 'https://devblogs.microsoft.com/typescript',
+    type: 'RSS',
+    enabled: true,
+  },
+  {
+    id: 'vscode_blog',
+    name: 'VS Code Blog',
+    url: 'https://code.visualstudio.com/blogs',
+    type: 'RSS',
+    enabled: true,
+  },
+  {
+    id: 'dropbox_tech',
+    name: 'Dropbox Tech',
+    url: 'https://dropbox.tech',
+    type: 'RSS',
+    enabled: true,
+  },
+  {
+    id: 'flyio_blog',
+    name: 'Fly.io Blog',
+    url: 'https://fly.io/blog',
+    type: 'RSS',
+    enabled: true,
+  },
+];
+
+async function main() {
+  const { createPrismaClient } = await import('@/lib/prisma/create-client');
+  const { sourceCache } = await import('@/lib/cache/source-cache');
+  const { createFetcher } = await import('@/lib/fetchers/index');
+
+  const prisma = createPrismaClient();
+
+  try {
+    console.log(
+      '=== Batch 3 海外企業・プロダクトブログ5ソース登録 (Issue #628) ===\n'
+    );
+
+    // 5件を単一トランザクションで登録（1件でも失敗したら全件ロールバックし、
+    // 部分登録状態を作らない）
+    const results = await prisma.$transaction(async (tx) => {
+      const upserted = [];
+      for (const source of BATCH3_SOURCES) {
+        const row = await tx.source.upsert({
+          where: { id: source.id },
+          // 既存行の enabled は上書きしない（enabled=false による緊急停止を
+          // スクリプト再実行で黙って解除してしまわないため。create 時のみ true）
+          update: {
+            name: source.name,
+            url: source.url,
+            type: source.type,
+          },
+          create: source,
+        });
+        // createFetcher 失敗（設定辞書・switch 文との名前不一致）時は
+        // 例外送出でトランザクション全体をロールバック
+        createFetcher(row);
+        upserted.push(row);
+      }
+      return upserted;
+    });
+
+    for (const row of results) {
+      const isNew = row.createdAt.getTime() === row.updatedAt.getTime();
+      console.log(
+        `[${isNew ? 'ADDED' : 'UPDATED'}] ${row.name} (id=${row.id}, enabled=${row.enabled})`
+      );
+    }
+    console.log('[OK] createFetcher() name match verified for all sources');
+
+    // キャッシュ無効化はコミット後に実行（CLAUDE.md ソース追加時ルール）
+    await sourceCache.invalidate();
+    console.log('[OK] Source cache invalidated');
+
+    console.log('\n=== 完了 ===');
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// スクリプトとして直接実行された場合のみ main() を走らせる
+// （テストから BATCH3_SOURCES を import しても DB 接続が発生しないようにする）
+if (process.argv[1]?.includes('add-batch3-sources')) {
+  main()
+    .catch((error) => {
+      console.error('エラーが発生しました:', error);
+      process.exitCode = 1;
+    })
+    .finally(() => {
+      process.exit(process.exitCode ?? 0);
+    });
+}

--- a/scripts/scheduled/scheduler.ts
+++ b/scripts/scheduled/scheduler.ts
@@ -287,6 +287,12 @@ const RSS_SOURCES = [
   // 海外アグリゲータ（Batch 2, Issue #628）
   'Lobsters',
   'Techmeme',
+  // 海外企業・プロダクトブログ（Batch 3, Issue #628）
+  'Vercel Blog',
+  'TypeScript Blog',
+  'VS Code Blog',
+  'Dropbox Tech',
+  'Fly.io Blog',
 ];
 
 // スクレイピング系ソース（12時間ごとに更新）


### PR DESCRIPTION
## 概要

- Issue #628 Batch 3 として、海外企業・プロダクトブログ5ソース（Vercel Blog / TypeScript Blog / VS Code Blog / Dropbox Tech / Fly.io Blog）を追加します
- Vercel のフィードは記事と製品チェンジログが混在し Atom category を持たないため、URL パスで絞り込む `urlPathFilter` オプションを新設しました
- Airbnb Engineering は **対象外** とします。既存「Medium Engineering」（`lib/fetchers/medium-engineering.ts:47`）が同一フィードを収集済みで、dev DB に28件（最新 2026-07-28）が存在するためです（Batch 2 の SRE Weekly と同型の判断）

## 実装内容

### 1. `urlPathFilter` オプションの新設（`lib/fetchers/generic-foreign-rss.ts`）

1つのフィードに記事と別種のエントリが混在し、category で判別できないソース向けの絞り込みオプションです。

- **適用位置は `slice(0, 30)` の前**。後に適用すると、フィード先頭が対象外パスで占められる Vercel（1,414件中 changelog が834件）で blog をほとんど取得できません
- **相対 link は feedUrl 基準で解決してから判定**。rss-parser は Atom の `href` を相対のまま返すため、絶対URL前提で判定すると有効な相対 link を不正URLとして落とします
- `http:` / `https:` 以外のスキームは除外
- 判定は解決後 pathname の前方一致。文字列 `includes` ではないため `/changelog/blog-post` のような別パスの誤マッチが起きません

あわせて、**相対 link を絶対URLへ解決してから保存する**よう修正しました（`resolveItemLink()`）。相対URLのまま保存すると URL 一意制約がサイトを跨いで衝突し、エンリッチメントの fetch も記事カードの外部リンクも機能しません。既に絶対URLの場合は `URL` コンストラクタを通さず元の文字列を返します（パーセントエンコーディングが正規化されると既存レコードとの完全一致照合が崩れて重複作成につながるため）。dev DB の全101,514件が絶対URL・空白なしであることを SELECT で確認済みです。

### 2. ソース設定と収集経路6箇所の整合

| ソース | id | useNormalizedUrl | その他 |
|--------|----|-----------------|--------|
| Vercel Blog | `vercel_blog` | 有効 | `urlPathFilter: '/blog/'` |
| TypeScript Blog | `typescript_blog` | **無効** | 既存記事が末尾スラッシュ付き生URL |
| VS Code Blog | `vscode_blog` | 有効 | `categoryFilter: ['blog']` |
| Dropbox Tech | `dropbox_tech` | 有効 | — |
| Fly.io Blog | `flyio_blog` | **無効** | 既存記事が末尾スラッシュ付き生URL |

`useNormalizedUrl` は「新規ソースなら常に有効化」ではなく、**既存レコードの保存URL形式に合わせます**（重複判定が保存URL文字列の完全一致のため）。TypeScript / Fly.io は Hacker News・はてなブックマーク経由の既存記事が末尾スラッシュ付きの生URLで保存済みで、有効化すると `normalizeUrl()` の末尾スラッシュ除去で照合が崩れ重複作成されます。

ソース名は6箇所で完全一致させる必要があるため、以下をすべて更新しています（1箇所でも漏れると無言で収集されません）:

| 箇所 | ファイル |
|------|---------|
| 設定辞書 | `lib/fetchers/generic-foreign-rss.ts` |
| `createFetcher` の switch | `lib/fetchers/index.ts` |
| GHA の CLI 引数 | `.github/workflows/scheduler-rss-hourly.yml` |
| ローカル収集リスト | `scripts/scheduled/scheduler.ts` |
| カテゴリ定義（foreign） | `lib/constants/source-categories.ts` |
| DB 登録定義 | `scripts/maintenance/add-batch3-sources.ts`（新規） |

### 3. テスト

- `url-path-filter.test.ts`（新規）: フィルタと slice の適用順序、相対link解決、スキーム制限、pathname 前方一致のセグメント境界、未設定時の挙動不変
- `batch3-sources.test.ts`（新規）: 5ソースの設定値・URL保存形式・フィルタ動作。加えて **他テストで検証されない「Source.id と foreign カテゴリの一致」「登録スクリプト `BATCH3_SOURCES` と設定辞書の一致」** を固定
- `feed-fixtures.test.ts` + `__tests__/fixtures/feeds/` に実フィード構造の最小フィクスチャ5件（`vercel-blog.xml` / `typescript-blog.xml` / `vscode-blog.xml` / `dropbox-tech.xml` / `flyio-blog.xml`）を追加: 設定判断の根拠になっている rss-parser のパース結果（Atom category の形状、末尾スラッシュの有無、xhtml content の文字列化）を実パーサで固定
- `urlPathFilter` と `categoryFilter` の併用は 30件上限の意味が変わるため、併用設定が生まれないことを検出するテストを追加

既存の自動走査テスト（`create-fetcher` / `scheduler-yaml-consistency`）が5ソース分を自動検出し、テストが15件自動増加しています。

## テスト結果

verify フェーズの結果（test.md は未作成のため verify 結果を記載）:

| Step | 結果 |
|------|------|
| Lint + Type Check | 0 errors / 0 warnings（exit 0） |
| Security Audit | high 以上なし（exit 0）。moderate 3件は Prisma CLI 経由の既存 dev 依存で本変更と無関係 |
| Build | `✓ Compiled successfully in 33.6s`（exit 0） |
| Test | 7 suites / 166 tests passed（変更影響範囲） |
| Diff Review | 機密ファイル・デバッグコードの混入なし |
| Visual | `.tsx` 変更なしのためスキップ |

### dev 環境での実データ検証

Source: 71 → 76件、Article: 101,446 → 101,514件（新規68件 + 移管5件 = 新ソース計73件で整合）。

| ソース | 保存 | contentLength (min/avg/max) | 要約 |
|--------|------|---------------------------|------|
| Vercel Blog | 30 | 562 / 8,892 / 26,493 | 29/30 |
| Fly.io Blog | 22 | 3,053 / 8,530 / 21,827 | 22 |
| Dropbox Tech | 10 | 9,276 / 14,251 / 18,603 | 10 |
| VS Code Blog | 8 | 6,165 / 12,127 / 14,979 | 8 |
| TypeScript Blog | 3 | 12,744 / 21,680 / 36,915 | 3 |

| 検証項目 | 結果 |
|---------|------|
| Vercel の非 `/blog/` URL | **0件**（urlPathFilter 動作確認） |
| VS Code の非 `/blogs/` URL | **0件**（categoryFilter 動作確認） |
| 正規化後URLの重複 | **0件** |
| Fly.io / TypeScript の重複スキップ | フィード30件中22件・10件中3件を保存（既存 HN/はてブ記事を正しくスキップ） |
| はてブ→専用ソースの sourceId 移管 | 5件 |
| 再収集の冪等性 | 新規0件 / 更新0件 / 重複68件 |
| Vercel の fetch() 所要時間 | 455ms（3MB / 1,414 item のDL + パース + フィルタ。timeout 30s に対し余裕あり） |
| エンリッチメント時の 429 / ブロック | 発生なし |

VS Code はフィード本文が126〜248字ですが、保存後エンリッチメントで6,165〜14,979字に補完されることを確認しました（計画時点の最大リスクが解消）。

## レビュー対応（cross-review Full Tier: Codex + Devil's Advocate 盲検2並列）

Critical 0 / Warning 6 / Suggestion 2。両レビュアーが独立に検出した最重要指摘（相対URL保存）を含め3件を修正し、4件は理由を明記して見送りました。

- **FIX**: 相対link保存の不整合（上記1に反映）/ 登録スクリプトの直接実行判定を部分一致から完全一致へ / フィルタ併用の機械的ガードテスト追加
- **SKIP**: HN帰属記事が移管されない（`collect-feeds.ts:287` の既存仕様）/ canonical URL 設計（スキーマ変更を伴う全体設計でスコープ外）/ フィルタ0件が warn のみ（既存 categoryFilter と同一挙動）/ 登録スクリプトの console 使用（batch1・batch2 スクリプトとの統一を優先。Batch 2 でも同じ判断）

## 既知の制約・申し送り

1. **登録スクリプトの `[OK] Source cache invalidated` は無効化失敗時も表示されます**。`sourceCache.invalidate()` が `void` を返し、内部でエラーを WARN ログに留めて握り潰すためです。add-batch1/batch2-sources.ts も同一構造のため本PRでは変更していません（修正には cache 層の API 変更が必要）。**本番実行後はホームページで新ソースが表示されることを目視確認してください**
2. **VS Code の初回収集は8件**です。`categoryFilter` が `slice(0, 30)` の後に適用されるためで、新着記事はフィード先頭に入るため以降の毎時収集で取りこぼしは発生しません
3. **Hacker News 帰属の既存記事は専用ソースへ移管されません**（sourceId 移管条件がはてブ帰属のみという既存仕様）
4. **SSRF ガード未実装**（#633 で追跡）。Batch 3 は全て固定の企業ドメインのフィードで、フィード投稿者が任意URLを注入できるアグリゲータ型ではないため、Batch 2 と同じ「既存リスクとして受容」を踏襲しています

## 本番反映手順（マージ後・ユーザー確認のうえ実施）

1. 本番DBで5つの id / name の既存行有無を SELECT で確認
2. `npx dotenv -e <本番env> -- npx tsx scripts/maintenance/add-batch3-sources.ts` を実行
3. ホームページで新ソースがフィルタUIに表示されることを確認（上記「既知の制約1」対応）
4. 次回 hourly で収集開始

## チェックリスト

- [x] テスト通過（7 suites / 166 tests、lint・build・audit も通過）
- [x] ドキュメント更新済み（コード内コメントに設定判断の根拠を記載）
- [x] 破壊的変更なし（DBスキーマ変更なし。既存ソースの収集挙動は不変）

Refs #628

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Vercel、TypeScript、VS Code、Dropbox Tech、Fly.io の公式ブログをRSS収集対象に追加しました。
  * 記事URLのパスに基づく絞り込みと、相対URLの自動解決に対応しました。
  * 各フィードに応じた記事本文・カテゴリ・URLの処理を追加しました。

* **テスト**
  * 新規RSSソースの取得、フィルタリング、URL処理を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->