### PR TITLE
fix(deps): Dependabot Alert #178 postcss を 8.5.23 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1617,9 +1617,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1698,9 +1698,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8724,9 +8724,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11260,9 +11260,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11351,9 +11351,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11435,9 +11435,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11506,9 +11506,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19440,9 +19440,9 @@
       "license": "MIT-0"
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -19459,7 +19459,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -22090,9 +22090,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -286,7 +286,7 @@
     "hono": "4.12.27",
     "@hono/node-server": "2.0.10",
     "follow-redirects": "1.16.0",
-    "postcss": "8.5.18",
+    "postcss": "8.5.23",
     "uuid": "^14.0.0",
     "esbuild": "0.28.1",
     "ws": "8.21.0",
@@ -296,7 +296,7 @@
     "fast-uri": "3.1.5",
     "ip-address": "10.3.1",
     "sharp": "0.35.0",
-    "brace-expansion@1": "1.1.17",
-    "brace-expansion@5": "5.0.8"
+    "brace-expansion@1": "1.1.18",
+    "brace-expansion@5": "5.0.9"
   }
 }


### PR DESCRIPTION
## 概要

- Dependabot Alert #178（postcss / medium）を解消する
- あわせて `npm audit` に残っていた high 36 件（`brace-expansion` の後続アドバイザリ）を解消する
- 変更は `package.json` の `overrides` 3 エントリと `package-lock.json` のみ。アプリケーションコードの変更なし

## 実装内容

### 1. postcss 8.5.18 → 8.5.23（Alert #178）

- **アドバイザリ**: GHSA-fxqj-rqcc-2cmp / CVE-2026-69153（severity: medium）
- **内容**: `from` オプション未設定時、攻撃者が制御可能な `sourceMappingURL` を経由して任意の `.map` ファイルを読み取られる。GHSA-6g55-p6wh-862q の修正が不完全だったことによる追加アドバイザリ
- **依存関係**: transitive。`next` / `@tailwindcss/postcss` / `critters` / `sanitize-html` の 4 経路から参照されるため、直接の依存宣言ではなく `overrides` で一括して 8.5.23 を強制する（既存の overrides エントリを更新）
- lock 側では postcss 自身の依存レンジ `nanoid: ^3.3.12 → ^3.3.16` も追随。インストール済み nanoid は新レンジを既に満たすためバージョン変更なし

### 2. brace-expansion 1.1.17 → 1.1.18 / 5.0.8 → 5.0.9

- **アドバイザリ**: brace-expansion: DoS via unbounded intermediate arrays（CVE-2026-14257 の緩和策をバイパス, severity: high）
- **WHY**: 前回のセキュリティ対応（#639）で pin した 1.1.17 / 5.0.8 が、その後公開された後続アドバイザリの影響範囲（`<1.1.18` / `>=4.0.0 <5.0.9`）に入っていた。Dependabot にはまだ open アラートが出ていないが、`npm audit` が報告する high 36 件はすべてこれが実体（eslint / jest / typescript-eslint の minimatch → brace-expansion 経路）
- **対応**: 既存の `brace-expansion@1` / `brace-expansion@5` overrides を patch bump。`npm audit fix` が提案する `eslint-config-next` の major ダウングレードは採用せず、overrides のみで解決している
- lock 側では nested な 7 箇所（`@eslint/config-array` / `@eslint/eslintrc` / `eslint` / `eslint-plugin-import` / `eslint-plugin-jsx-a11y` / `eslint-plugin-react` / `test-exclude` 配下、およびトップレベル）に伝播

## テスト結果

`/verify` フェーズの結果（implement.md / test.md は本タスクでは未作成のため、実行ログを直接記載）:

| 項目 | 結果 |
|------|------|
| ESLint + `tsc --noEmit` | 0 errors / 0 warnings |
| `npm audit --production --audit-level=high` | exit 0（high / critical 0 件） |
| `npm audit`（全体） | high 36 → **0**、total 42 → 6（残りは low 1 / moderate 5） |
| `npm run docker:build` | exit 0 / Compiled successfully |
| `npm run docker:test`（全単体テスト） | exit 0 — **5057 passed / 0 failed / 75 skipped** |
| Visual 検証 | SKIP（`.tsx` 変更なし） |

### 検証時の注意点

`node-ci` イメージは `node_modules` をイメージ内にベイクしており volume mount がないため、`docker:build` / `docker:test` は **`npm run docker:build:ci` でイメージを再ビルドしないと変更前の依存で実行される**。本 PR では CI イメージを再ビルドし、コンテナ内で postcss 8.5.23 / brace-expansion 1.1.18・5.0.9 が解決されていることを確認したうえで build・test を実施している。

### 残存する npm audit（本 PR のスコープ外）

いずれも Dependabot に open アラートはなく、tooling / dev 依存チェーン内:

- moderate: `prisma` → `@prisma/dev` → `hono` / `@hono/node-server` / `valibot`
- low: `body-parser`

## チェックリスト

- [x] テスト通過（全単体テスト 5057 件）
- [x] ドキュメント更新済み（更新対象なし）
- [x] 破壊的変更なし（すべて patch レベルのバージョン更新）

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * アプリケーションの基盤コンポーネントを更新し、互換性と安定性を向上しました。
  * 既存機能への影響はなく、通常どおりご利用いただけます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->