### PR TITLE
fix: Issue #638 フレーキーテスト解消 + #607 enricher body drain 共通化

### DIFF
--- a/__tests__/components/agent-search-bar.test.tsx
+++ b/__tests__/components/agent-search-bar.test.tsx
@@ -2,20 +2,28 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import { AgentSearchBar } from '@/app/search/agent/_components/agent-search-bar';
 import type { SearchHistoryItem } from '@/lib/hooks/useSearchHistory';
 
+// 固定基準時刻。fixture と mockGetRelativeTime の双方をこの値基準に揃え、実時計への依存を排除する。
+// Date.now() 基準だとモジュール評価時刻(T0)と描画時刻(T1)の差に結果が左右され、
+// T1 < T0（システム時刻の巻き戻り）で2件目まで '1分前' と判定されて
+// getByText('1分前') が複数マッチし確率的に失敗していた（Issue #638）。
+const FIXED_NOW = 1_700_000_000_000; // 2023-11-14T22:13:20.000Z
+
 const mockHistoryItems: SearchHistoryItem[] = [
-  { query: 'query 1', timestamp: Date.now() - 60000 },
-  { query: 'query 2', timestamp: Date.now() - 3600000 },
+  { query: 'query 1', timestamp: FIXED_NOW - 60000 },
+  { query: 'query 2', timestamp: FIXED_NOW - 3600000 },
 ];
 
 const mockSaveToHistory = jest.fn();
-const mockGetSearchHistory = jest.fn(() => mockHistoryItems.map(item => item.query));
+const mockGetSearchHistory = jest.fn(() =>
+  mockHistoryItems.map((item) => item.query)
+);
 const mockGetSearchHistoryWithTimestamp = jest.fn(() => mockHistoryItems);
 const mockRemoveFromHistory = jest.fn((timestamp: number) => {
-  return mockHistoryItems.filter(item => item.timestamp !== timestamp);
+  return mockHistoryItems.filter((item) => item.timestamp !== timestamp);
 });
 const mockClearHistory = jest.fn();
 const mockGetRelativeTime = jest.fn((timestamp: number) => {
-  const diff = Date.now() - timestamp;
+  const diff = FIXED_NOW - timestamp;
   if (diff < 3600000) return '1分前';
   return '1時間前';
 });
@@ -50,7 +58,12 @@ describe('AgentSearchBar', () => {
   });
 
   test('renders with custom helper text when provided', () => {
-    render(<AgentSearchBar onSearch={mockOnSearch} helperText="カスタムヘルパーテキスト" />);
+    render(
+      <AgentSearchBar
+        onSearch={mockOnSearch}
+        helperText="カスタムヘルパーテキスト"
+      />
+    );
     expect(screen.getByText('カスタムヘルパーテキスト')).toBeInTheDocument();
   });
 
@@ -137,7 +150,9 @@ describe('AgentSearchBar', () => {
   });
 
   test('renders initial query', () => {
-    render(<AgentSearchBar onSearch={mockOnSearch} initialQuery="initial test" />);
+    render(
+      <AgentSearchBar onSearch={mockOnSearch} initialQuery="initial test" />
+    );
 
     const input = screen.getByLabelText('AI検索クエリ入力') as HTMLInputElement;
     expect(input.value).toBe('initial test');
@@ -174,7 +189,12 @@ describe('AgentSearchBar', () => {
   describe('AgentSearchBar - Prefill', () => {
     test('should call onPrefillQuery callback on mount with prefill handler', () => {
       const mockOnPrefillQuery = jest.fn();
-      render(<AgentSearchBar onSearch={mockOnSearch} onPrefillQuery={mockOnPrefillQuery} />);
+      render(
+        <AgentSearchBar
+          onSearch={mockOnSearch}
+          onPrefillQuery={mockOnPrefillQuery}
+        />
+      );
 
       expect(mockOnPrefillQuery).toHaveBeenCalledTimes(1);
       expect(typeof mockOnPrefillQuery.mock.calls[0][0]).toBe('function');
@@ -182,13 +202,22 @@ describe('AgentSearchBar', () => {
 
     test('should prefill query when callback is invoked', () => {
       let prefillHandler: ((query: string) => void) | null = null;
-      const mockOnPrefillQuery = jest.fn((callback: (query: string) => void) => {
-        prefillHandler = callback;
-      });
+      const mockOnPrefillQuery = jest.fn(
+        (callback: (query: string) => void) => {
+          prefillHandler = callback;
+        }
+      );
 
-      render(<AgentSearchBar onSearch={mockOnSearch} onPrefillQuery={mockOnPrefillQuery} />);
+      render(
+        <AgentSearchBar
+          onSearch={mockOnSearch}
+          onPrefillQuery={mockOnPrefillQuery}
+        />
+      );
 
-      const input = screen.getByLabelText('AI検索クエリ入力') as HTMLInputElement;
+      const input = screen.getByLabelText(
+        'AI検索クエリ入力'
+      ) as HTMLInputElement;
       expect(input.value).toBe('');
 
       act(() => {
@@ -201,11 +230,18 @@ describe('AgentSearchBar', () => {
 
     test('should allow manual edit after prefill', () => {
       let prefillHandler: ((query: string) => void) | null = null;
-      const mockOnPrefillQuery = jest.fn((callback: (query: string) => void) => {
-        prefillHandler = callback;
-      });
+      const mockOnPrefillQuery = jest.fn(
+        (callback: (query: string) => void) => {
+          prefillHandler = callback;
+        }
+      );
 
-      render(<AgentSearchBar onSearch={mockOnSearch} onPrefillQuery={mockOnPrefillQuery} />);
+      render(
+        <AgentSearchBar
+          onSearch={mockOnSearch}
+          onPrefillQuery={mockOnPrefillQuery}
+        />
+      );
 
       const input = screen.getByLabelText('AI検索クエリ入力');
 
@@ -223,11 +259,18 @@ describe('AgentSearchBar', () => {
 
     test('should reuse applyQueryFromExternal for both history and prefill', () => {
       let prefillHandler: ((query: string) => void) | null = null;
-      const mockOnPrefillQuery = jest.fn((callback: (query: string) => void) => {
-        prefillHandler = callback;
-      });
+      const mockOnPrefillQuery = jest.fn(
+        (callback: (query: string) => void) => {
+          prefillHandler = callback;
+        }
+      );
 
-      render(<AgentSearchBar onSearch={mockOnSearch} onPrefillQuery={mockOnPrefillQuery} />);
+      render(
+        <AgentSearchBar
+          onSearch={mockOnSearch}
+          onPrefillQuery={mockOnPrefillQuery}
+        />
+      );
 
       const input = screen.getByLabelText('AI検索クエリ入力');
 
@@ -276,8 +319,12 @@ describe('AgentSearchBar', () => {
     );
 
     expect(screen.getByText('記事Q&A')).toBeInTheDocument();
-    expect(screen.getByText('記事の内容に関する質問を入力')).toBeInTheDocument();
-    expect(screen.queryByText(/キーボードショートカット/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText('記事の内容に関する質問を入力')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/キーボードショートカット/)
+    ).not.toBeInTheDocument();
     expect(screen.getByLabelText('記事QA質問入力')).toBeInTheDocument();
   });
 
@@ -304,7 +351,12 @@ describe('AgentSearchBar', () => {
 
     test('calls onHistoryCleared callback when history is cleared', () => {
       const mockOnHistoryCleared = jest.fn();
-      render(<AgentSearchBar onSearch={mockOnSearch} onHistoryCleared={mockOnHistoryCleared} />);
+      render(
+        <AgentSearchBar
+          onSearch={mockOnSearch}
+          onHistoryCleared={mockOnHistoryCleared}
+        />
+      );
       const input = screen.getByLabelText('AI検索クエリ入力');
       fireEvent.focus(input);
 
@@ -315,7 +367,9 @@ describe('AgentSearchBar', () => {
     });
 
     test('displays relative timestamps when showHistoryTimestamp=true', () => {
-      render(<AgentSearchBar onSearch={mockOnSearch} showHistoryTimestamp={true} />);
+      render(
+        <AgentSearchBar onSearch={mockOnSearch} showHistoryTimestamp={true} />
+      );
       const input = screen.getByLabelText('AI検索クエリ入力');
       fireEvent.focus(input);
 
@@ -325,7 +379,9 @@ describe('AgentSearchBar', () => {
     });
 
     test('hides timestamps when showHistoryTimestamp=false', () => {
-      render(<AgentSearchBar onSearch={mockOnSearch} showHistoryTimestamp={false} />);
+      render(
+        <AgentSearchBar onSearch={mockOnSearch} showHistoryTimestamp={false} />
+      );
       const input = screen.getByLabelText('AI検索クエリ入力');
       fireEvent.focus(input);
 
@@ -342,14 +398,18 @@ describe('AgentSearchBar', () => {
       fireEvent.focus(input);
 
       // Suggestions should be visible
-      expect(screen.getByTestId('search-history-suggestions')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('search-history-suggestions')
+      ).toBeInTheDocument();
 
       // Clear history
       const clearButton = screen.getByTestId('clear-history-button');
       fireEvent.click(clearButton);
 
       // After clicking clear, the dropdown should hide since items are now empty
-      expect(screen.queryByTestId('search-history-suggestions')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('search-history-suggestions')
+      ).not.toBeInTheDocument();
     });
 
     test('displays individual remove buttons for each history item', () => {
@@ -359,7 +419,10 @@ describe('AgentSearchBar', () => {
 
       const removeButtons = screen.getAllByTestId('remove-history-item-button');
       expect(removeButtons).toHaveLength(2);
-      expect(removeButtons[0]).toHaveAttribute('aria-label', 'この検索履歴を削除');
+      expect(removeButtons[0]).toHaveAttribute(
+        'aria-label',
+        'この検索履歴を削除'
+      );
     });
 
     test('calls removeFromHistory when individual remove button is clicked', () => {
@@ -371,12 +434,16 @@ describe('AgentSearchBar', () => {
       fireEvent.click(removeButtons[0]);
 
       expect(mockRemoveFromHistory).toHaveBeenCalledTimes(1);
-      expect(mockRemoveFromHistory).toHaveBeenCalledWith(mockHistoryItems[0].timestamp);
+      expect(mockRemoveFromHistory).toHaveBeenCalledWith(
+        mockHistoryItems[0].timestamp
+      );
     });
 
     test('does not trigger query prefill when clicking remove button', () => {
       render(<AgentSearchBar onSearch={mockOnSearch} />);
-      const input = screen.getByLabelText('AI検索クエリ入力') as HTMLInputElement;
+      const input = screen.getByLabelText(
+        'AI検索クエリ入力'
+      ) as HTMLInputElement;
       fireEvent.focus(input);
 
       const removeButtons = screen.getAllByTestId('remove-history-item-button');

--- a/lib/enrichers/anthropic-blog.ts
+++ b/lib/enrichers/anthropic-blog.ts
@@ -31,11 +31,7 @@ export class ClaudeBlogEnricher extends BaseContentEnricher {
 
       if (!response.ok) {
         // 接続プールの socket 保持を避けるため body を drain
-        try {
-          await response.body?.cancel();
-        } catch {
-          /* ignore: drain 失敗は失敗判定に影響させない */
-        }
+        await this.safeReleaseBody(response);
         logger.error(
           { status: response.status, url },
           '[Claude Blog Enricher] Failed to fetch'

--- a/lib/enrichers/anthropic-news.ts
+++ b/lib/enrichers/anthropic-news.ts
@@ -41,11 +41,7 @@ export class AnthropicNewsEnricher extends BaseContentEnricher {
 
       if (!response.ok) {
         // 接続プールの socket 保持を避けるため body を drain
-        try {
-          await response.body?.cancel();
-        } catch {
-          /* ignore: drain 失敗は失敗判定に影響させない */
-        }
+        await this.safeReleaseBody(response);
         logger.error(
           { status: response.status, url },
           '[Anthropic News Enricher] Failed to fetch'

--- a/lib/enrichers/aws.ts
+++ b/lib/enrichers/aws.ts
@@ -42,11 +42,7 @@ export class AWSEnricher extends BaseContentEnricher {
 
       if (!response.ok) {
         // 接続プールの socket 保持を避けるため body を drain
-        try {
-          await response.body?.cancel();
-        } catch {
-          /* ignore: drain 失敗は失敗判定に影響させない */
-        }
+        await this.safeReleaseBody(response);
         logger.error(
           { status: response.status, url },
           '[AWS Enricher] Failed to fetch'

--- a/lib/enrichers/base.ts
+++ b/lib/enrichers/base.ts
@@ -145,22 +145,14 @@ export abstract class BaseContentEnricher implements IContentEnricher {
         if (response.status === 429) {
           // Rate limit: 短縮 (1.5秒)。呼び出し側の source 別 sleep で本質的な rate 制御を行う
           // 接続プールの socket 保持を避けるため body を drain してから retry
-          try {
-            await response.body?.cancel();
-          } catch {
-            // body drain 失敗は retry 判定に影響させない
-          }
+          await this.safeReleaseBody(response);
           await this.delay(1500, externalSignal);
           previousWas429 = true;
           continue;
         }
 
         if (!response.ok) {
-          try {
-            await response.body?.cancel();
-          } catch {
-            // body drain 失敗は元の HTTP error を優先
-          }
+          await this.safeReleaseBody(response);
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
 
@@ -180,6 +172,22 @@ export abstract class BaseContentEnricher implements IContentEnricher {
     }
 
     throw lastError || new Error('Failed to fetch content');
+  }
+
+  /**
+   * 非OK応答の body を安全に drain して socket を解放する
+   *
+   * 接続プールに socket が保持されたままになるのを防ぐ。drain 自体の失敗は
+   * 呼び出し側の判定（retry 継続・元の HTTP error のスロー等）に影響させない。
+   *
+   * @param response drain 対象のレスポンス
+   */
+  protected async safeReleaseBody(response: Response): Promise<void> {
+    try {
+      await response.body?.cancel();
+    } catch {
+      // body drain 失敗は呼び出し側の判定に影響させない
+    }
   }
 
   /**

--- a/lib/enrichers/cloudflare-blog.ts
+++ b/lib/enrichers/cloudflare-blog.ts
@@ -33,11 +33,7 @@ export class CloudflareBlogEnricher extends BaseContentEnricher {
 
       if (!response.ok) {
         // 接続プールの socket 保持を避けるため body を drain
-        try {
-          await response.body?.cancel();
-        } catch {
-          /* ignore: drain 失敗は失敗判定に影響させない */
-        }
+        await this.safeReleaseBody(response);
         logger.error(
           { status: response.status, url },
           '[Cloudflare Blog Enricher] Failed to fetch'

--- a/lib/enrichers/generic.ts
+++ b/lib/enrichers/generic.ts
@@ -60,11 +60,7 @@ export class GenericContentEnricher extends BaseContentEnricher {
 
         if (!response.ok) {
           // 接続プールの socket 保持を避けるため body を drain してから retry/return
-          try {
-            await response.body?.cancel();
-          } catch {
-            // body drain 失敗は retry/failure 判定に影響させない
-          }
+          await this.safeReleaseBody(response);
 
           if (response.status === 429) {
             // 429 時の sleep 短縮 (1.5秒)。呼び出し側の source 別 sleep で本質的な rate 制御

--- a/lib/enrichers/github-blog.ts
+++ b/lib/enrichers/github-blog.ts
@@ -33,11 +33,7 @@ export class GitHubBlogEnricher extends BaseContentEnricher {
 
       if (!response.ok) {
         // 接続プールの socket 保持を避けるため body を drain
-        try {
-          await response.body?.cancel();
-        } catch {
-          /* ignore: drain 失敗は失敗判定に影響させない */
-        }
+        await this.safeReleaseBody(response);
         logger.error(
           { status: response.status, url },
           '[GitHub Blog Enricher] Failed to fetch'

--- a/lib/enrichers/hacker-news.ts
+++ b/lib/enrichers/hacker-news.ts
@@ -63,11 +63,7 @@ export class HackerNewsEnricher extends BaseContentEnricher {
       // ステータスコードが200以外の場合はGenericEnricherにフォールバック
       if (!response.ok) {
         // 接続プールの socket 保持を避けるため body を drain
-        try {
-          await response.body?.cancel();
-        } catch {
-          /* ignore: drain 失敗は fallback 判定に影響させない */
-        }
+        await this.safeReleaseBody(response);
         logger.warn(
           { status: response.status, url },
           '[HackerNewsEnricher] HTTP error, falling back to GenericEnricher'
@@ -136,11 +132,7 @@ export class HackerNewsEnricher extends BaseContentEnricher {
                   $repo('meta[property="og:image"]').attr('content') || '';
               } else {
                 // 接続プールの socket 保持を避けるため body を drain
-                try {
-                  await repoResponse.body?.cancel();
-                } catch {
-                  /* ignore: drain 失敗は失敗判定に影響させない */
-                }
+                await this.safeReleaseBody(repoResponse);
                 logger.debug(
                   { status: repoResponse.status, repoRootUrl },
                   '[HackerNewsEnricher] Repo root fetch returned non-OK status'

--- a/lib/enrichers/medium-engineering.ts
+++ b/lib/enrichers/medium-engineering.ts
@@ -30,11 +30,7 @@ export class MediumEngineeringEnricher extends BaseContentEnricher {
 
       if (!response.ok) {
         // 接続プールの socket 保持を避けるため body を drain
-        try {
-          await response.body?.cancel();
-        } catch {
-          /* ignore: drain 失敗は失敗判定に影響させない */
-        }
+        await this.safeReleaseBody(response);
         logger.warn(
           { status: response.status, url },
           '[MediumEngineeringEnricher] Failed to fetch URL'

--- a/lib/enrichers/mozilla-hacks.ts
+++ b/lib/enrichers/mozilla-hacks.ts
@@ -30,11 +30,7 @@ export class MozillaHacksEnricher extends BaseContentEnricher {
 
       if (!response.ok) {
         // 接続プールの socket 保持を避けるため body を drain
-        try {
-          await response.body?.cancel();
-        } catch {
-          /* ignore: drain 失敗は失敗判定に影響させない */
-        }
+        await this.safeReleaseBody(response);
         logger.error(
           { status: response.status, url },
           '[Mozilla Hacks Enricher] Failed to fetch'

--- a/lib/enrichers/speakerdeck.ts
+++ b/lib/enrichers/speakerdeck.ts
@@ -109,11 +109,7 @@ export class SpeakerDeckEnricher extends BaseContentEnricher {
 
       if (!response.ok) {
         // 接続プールの socket 保持を避けるため body を drain
-        try {
-          await response.body?.cancel();
-        } catch {
-          /* ignore: drain 失敗は失敗判定に影響させない */
-        }
+        await this.safeReleaseBody(response);
         logger.debug(
           { status: response.status, url },
           '[SpeakerDeckEnricher] oEmbed request failed'


### PR DESCRIPTION
## 概要

- **#638**: `agent-search-bar.test.tsx` の相対時刻テストが全体実行時に確率的に失敗する問題を、実時計依存の排除で恒久解消
- **#607**: 13 箇所に直書きされていた `response.body?.cancel()` を `BaseContentEnricher.safeReleaseBody()` に共通化
- いずれも挙動変更を伴わない保守変更（ユーザー影響なし）

Closes #638
Closes #607

## 実装内容

### #638 — 実時計依存の排除

fixture の `timestamp` はモジュール評価時刻（T0）基準、`mockGetRelativeTime` の分岐は呼び出し時刻（T1）基準で、両者がずれると期待値が壊れる構造だった。

**Issue で「分析上説明できていない」とされていた点への回答**: `T1 < T0`（システム時刻の巻き戻り）なら 2 件目の `diff = (T1 − T0) + 3600000 < 3600000` となり `1分前` に分岐する。このとき 1 件目も当然 `1分前` になるため、報告された「`1分前` が 2 つ描画されて `getByText` が複数マッチする」症状と完全に一致する。他の仮説（他ファイルの fake timers 漏れ等）では「2 件目だけが変わる」説明がつかない。

他仮説の排除根拠として、グローバルな fake timers 設定が存在しないことも確認済み（`jest.setup.dom.js` に `useFakeTimers` / `setSystemTime` は 0 件、`jest.config.dom.js` に `fakeTimers` 設定なし）。

**修正**: `FIXED_NOW` 定数を導入し fixture と mock の双方を同一の固定基準に揃え、`Date.now()` への参照をテストから完全に除去した。**真因の確定を待たずに恒久解消**できる方式を採った。

> ⚠️ 実質的な変更は 6 行です。`__tests__/components/agent-search-bar.test.tsx` の diff が 137 行あるのは、PostToolUse の Prettier hook がファイル全体を整形したためです。レビュー時は冒頭の `FIXED_NOW` 導入部と `mockGetRelativeTime` の 2 箇所のみが実質差分になります。

### #607 — `safeReleaseBody` 共通化

`BaseContentEnricher` に共通ヘルパーを追加し、13 箇所の同型コードを置換した。

```ts
protected async safeReleaseBody(response: Response): Promise<void> {
  try {
    await response.body?.cancel();
  } catch {
    // body drain 失敗は呼び出し側の判定に影響させない
  }
}
```

置換箇所（Issue 記載の 13 件と完全一致）:

| ファイル | 文脈 |
|---------|------|
| `base.ts` (2 箇所) | 429 retry path / non-OK throw path |
| `generic.ts` | non-OK retry/return path |
| `anthropic-blog.ts` / `anthropic-news.ts` / `aws.ts` / `cloudflare-blog.ts` / `github-blog.ts` / `medium-engineering.ts` / `mozilla-hacks.ts` | non-OK return null |
| `speakerdeck.ts` | `fetchOEmbed` 内 |
| `hacker-news.ts` (2 箇所) | 主経路 + repo OGP fallback（`repoResponse` を引数に渡す） |

**`this` 束縛の安全性**: 呼び出し元 10 ファイルは全て `BaseContentEnricher` を継承しており、いずれも同一スコープで `this.composeSignal()` を既に呼んでいるため `this` は正しく束縛されている。

## テスト結果

| 項目 | コマンド | 結果 |
|------|---------|------|
| #607 完了条件 | `grep -rn 'body?\.cancel' lib scripts app --include='*.ts' \| grep -v __tests__` | 1 件（`base.ts` の `safeReleaseBody` 内のみ）✅ |
| 置換件数 | `grep -rn 'this.safeReleaseBody' lib --include='*.ts'` | 13 件 ✅ |
| ESLint | `npm run lint` | exit 0 |
| 型チェック | `npm run type-check` | exit 0 |
| #638 対象テスト | `docker:test:react:file` | 27/27 passed |
| エンリッチャー全テスト | `TEST_FILE=enrichers docker:test:file` | 26 suites / 374 passed, 1 skipped |
| 全単体テスト | `npm run docker:test` | exit 0（DOM 48 suites / 602 passed, 25 skipped まで到達。`npm test` は `test:node && test:node:serial && test:dom` の連鎖のため Node 側も通過） |
| 本番ビルド | `npm run docker:build` | exit 0 |

Visual 確認は UI コンポーネント自体が未変更のため省略しました。

## ⚠️ cross-review 未実施

変更規模が cross-review 必須ライン（5 ファイル以上）に該当しますが、**外部レビュアー 2 系統とも実行不可**でした:

- Codex: 使用量上限（`try again at Aug 8th, 2026 12:55 PM`、rc=1）
- Gemini: 認証ティア廃止（`IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals`、rc=1）

マージ前に Codex 復旧後の `/cross-review` 実施を推奨します。ただし本変更は (a) テスト fixture の定数化、(b) 同型コード 13 箇所の機械的な抽出 のみで、挙動変更を伴いません。

## 関連 Issue の実態確認（本 PR にコード変更なし）

同じトリアージ調査で、以下 2 件が Issue 記述と実態が乖離していることを確認し、各 Issue にコメントで記録しました:

- **#605 Thread 1**（sourceId 伝播）は既に解消済み — `lib/fetchers/publickey.ts:91-94` / `scripts/maintenance/re-enrich-publickey-nulls.ts:116-124` の両方が伝播済み
- **#628 Batch 3** は PR #635 で完了済み（候補 6 件中 5 件登録済み、`Airbnb Engineering` のみ未追加）

## チェックリスト

- [x] テスト通過
- [x] 破壊的変更なし
- [ ] cross-review（外部 CLI 障害により未実施 — 上記参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)