### PR TITLE
fix(deps): Dependabot Alert #179 js-yaml を 4.3.1 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15725,9 +15725,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "whatwg-fetch": "^3.6.20"
   },
   "overrides": {
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "glob": "11.1.0",
     "test-exclude": {
       "glob": "7.2.3"


### PR DESCRIPTION
## 概要

Dependabot セキュリティアラート **#179**（severity: **high**）を解消します。

- パッケージ: `js-yaml`
- アドバイザリ: [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj)
- 概要: `!!omap` 解決時の二次的（quadratic）CPU 消費。CVE-2026-59870 の修正が 3.x / 4.x に未バックポートだった
- 影響範囲: `>= 4.0.0, < 4.3.1`
- 関係: transitive / dev scope

## 実装内容

`package.json` の `overrides` の `js-yaml` を `4.3.0` → `4.3.1` に更新しました。

```diff
   "overrides": {
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
```

**Dependabot の自動 PR では解消できない種類の更新です。** `overrides` で `4.3.0` に pin 済みだったため、上流の依存が更新されても pin が優先されます。pin 先を手動で引き上げる必要がありました。

## 検証結果

| 項目 | コマンド | 結果 |
|------|---------|------|
| バージョン反映 | `npm ls js-yaml --all` | 全経路 `4.3.1`（deduped / overridden） |
| 該当脆弱性 | `npm audit --json \| jq '.vulnerabilities["js-yaml"]'` | 報告なし ✅ |
| 本番 high/critical ゲート | `npm audit --omit=dev --audit-level=high` | exit 0 |
| ESLint | `npm run lint` | exit 0 |
| 型チェック | `npm run type-check` | exit 0 |
| 全単体テスト | `npm run docker:test` | exit 0（48 suites / 602 passed, 25 skipped） |
| 本番ビルド | `npm run docker:build` | exit 0 |

diff は `js-yaml` の version / resolved / integrity の 3 行のみに限定されており、他パッケージへの巻き込み更新はありません。

## 残存する脆弱性（本 PR のスコープ外）

`npm audit` に残るのは以下 6 件で、いずれも別パッケージです:

- moderate: `@hono/node-server` / `hono` / `@prisma/dev` / `prisma` / `valibot`
- low: `body-parser`

本番 high/critical は 0 件です。

## チェックリスト

- [x] テスト通過
- [x] 破壊的変更なし（patch 更新、dev scope）

🤖 Generated with [Claude Code](https://claude.com/claude-code)