### PR TITLE
fix: Issue #629 手動エンリッチスクリプトのCAS化と回復対象漏れの修正

### DIFF
--- a/scripts/maintenance/enrich-single-article.ts
+++ b/scripts/maintenance/enrich-single-article.ts
@@ -70,11 +70,28 @@ async function enrichSingleArticle(articleId: string) {
       // （manage-quality-scores.ts / quality-score-batch.ts）は raw SQL で
       // `"updatedAt" = NOW()` を明示セットするため、qualityScore しか変えていなくても
       // ここで敗北する。安全側に倒れるだけで取りこぼしは起きないため許容する。
+      // 本文を差し替えると、既存の summary / detailedSummary は古い本文に基づく内容に
+      // なる。直後に要約を再生成するが、生成に失敗した場合や本文が短くて生成をスキップ
+      // した場合に「新本文 + 旧要約」が残らないよう、本文更新と同一の CAS 更新で
+      // 要約をリセットしておく（collect-feeds.ts の自己修復パスと同じ流儀）。
+      // リセットしておけば、このスクリプトでの再生成に失敗しても定期の要約生成ジョブが
+      // 再生成対象として拾える。
+      // PDF / SLIDE は本文の有無と無関係な恒久スキップ理由のため対象外にする。
+      const isSummaryEligible =
+        article.skipReason !== 'PDF' && article.skipReason !== 'SLIDE';
+
       const { count } = await prisma.article.updateMany({
         where: { id: articleId, updatedAt: article.updatedAt },
         data: {
           content: enrichedData.content,
-          ...(enrichedData.thumbnail && { thumbnail: enrichedData.thumbnail })
+          ...(enrichedData.thumbnail && { thumbnail: enrichedData.thumbnail }),
+          ...(isSummaryEligible && {
+            skipReason: null,
+            summaryError: null,
+            summary: null,
+            detailedSummary: null,
+            summaryVersion: 0
+          })
         }
       });
 
@@ -91,7 +108,9 @@ async function enrichSingleArticle(articleId: string) {
       console.error('\n=== 要約再生成 ===');
       
       if (enrichedData.content.length < 100) {
-        console.error('⚠️ コンテンツが不十分のため要約再生成をスキップ');
+        // 本文更新時に要約はリセット済みのため、「新本文 + 旧要約」は残らない。
+        // 本文が十分に伸びた時点で定期の要約生成ジョブが生成する。
+        console.error('⚠️ コンテンツが不十分のため要約再生成をスキップ（既存要約はリセット済み）');
         return;
       }
       
@@ -122,10 +141,10 @@ async function enrichSingleArticle(articleId: string) {
         });
 
         if (summaryUpdateCount === 0) {
-          // ここで summary をリセットしないのは意図的。本文を書き換えた側
-          // （collect-feeds.ts の自己修復パス）が summary / detailedSummary /
-          // summaryVersion のリセットまで責務として持つため、こちらでリセットすると
-          // 相手が既に生成した正しい要約を消しかねない。
+          // 本文はこちらが書いたものではなくなっているため、生成結果は破棄する。
+          // summary は本文更新時に既にリセット済みであり、本文を書き換えた側
+          // （collect-feeds.ts の自己修復パス）も同様にリセットするため、
+          // 「新本文 + 旧要約」の状態は残らない。定期の要約生成ジョブが再生成する。
           console.error('⏭️  要約更新スキップ（CAS敗北）: 要約生成中に他プロセスが本文を更新したため、生成結果は保存しませんでした');
           return;
         }

--- a/scripts/maintenance/enrich-single-article.ts
+++ b/scripts/maintenance/enrich-single-article.ts
@@ -54,12 +54,24 @@ async function enrichSingleArticle(articleId: string) {
       const newLength = enrichedData.content.length;
       console.error(`✅ エンリッチメント成功: ${newLength}文字`);
 
-      // CAS: 記事取得時に観測した contentLength と現在値が一致する場合のみ更新する。
+      // CAS: 記事取得時に観測した updatedAt と現在値が一致する場合のみ更新する。
       // enrich() のネットワークI/O中に他プロセス（例: hourly の collect-feeds.ts）が
       // 先に本文を更新している可能性があるため、古いスナップショット基準で
-      // 上書きしないための保護（Issue #629 項目6、collect-feeds.ts の自己修復パスと同一方針）。
+      // 上書きしないための保護（Issue #629 項目6）。
+      //
+      // CAS トークンに contentLength ではなく updatedAt を使う理由:
+      // contentLength は CHAR_LENGTH(content) の派生値のため、(a) 同じ文字数の別本文に
+      // 差し替えられた場合（ABA問題）と (b) 本文以外（thumbnail 等）だけが更新された
+      // 場合を検出できない。collect-feeds.ts にはサムネイルのみを更新する経路が実在するため
+      // (b) は現実に起こりうる。updatedAt は @updatedAt により任意の更新で必ず変化するので、
+      // 「取得後に誰かが何かを書いた」ことを漏れなく検出できる。
+      //
+      // トレードオフ: 逆に本文と無関係な更新でも CAS が失敗する。特に品質スコア再計算
+      // （manage-quality-scores.ts / quality-score-batch.ts）は raw SQL で
+      // `"updatedAt" = NOW()` を明示セットするため、qualityScore しか変えていなくても
+      // ここで敗北する。安全側に倒れるだけで取りこぼしは起きないため許容する。
       const { count } = await prisma.article.updateMany({
-        where: { id: articleId, contentLength: article.contentLength },
+        where: { id: articleId, updatedAt: article.updatedAt },
         data: {
           content: enrichedData.content,
           ...(enrichedData.thumbnail && { thumbnail: enrichedData.thumbnail })
@@ -67,7 +79,8 @@ async function enrichSingleArticle(articleId: string) {
       });
 
       if (count === 0) {
-        console.error('⏭️  更新スキップ（CAS敗北）: 記事取得後、他プロセスが既に本文を更新済みのため、今回の取得結果は反映しませんでした');
+        console.error('⏭️  更新スキップ（CAS敗北）: 記事取得後に他プロセスがこの記事を更新したため、今回の取得結果は反映しませんでした');
+        console.error('   （本文が更新された場合のほか、品質スコア再計算など本文と無関係な更新でも発生します）');
         console.error('必要であれば記事の最新状態を確認のうえ再実行してください');
         return;
       }
@@ -93,8 +106,13 @@ async function enrichSingleArticle(articleId: string) {
       );
       
       if (result) {
-        await prisma.article.update({
-          where: { id: articleId },
+        // CAS: 要約は enrichedData.content から生成されたものなので、その本文が
+        // まだ記事に残っている場合のみ保存する。要約生成（LLM呼び出し）の間に
+        // 他プロセスが本文を差し替えていた場合、新しい本文に古い要約が結び付くのを防ぐ。
+        // 直前の本文更新で updatedAt は変化済みのため、ここでは自分が書いた本文自体を
+        // CAS トークンとして使う（更新後の updatedAt を取り直す必要がない）。
+        const { count: summaryUpdateCount } = await prisma.article.updateMany({
+          where: { id: articleId, content: enrichedData.content },
           data: {
             summary: result.summary,
             detailedSummary: result.detailedSummary,
@@ -102,7 +120,16 @@ async function enrichSingleArticle(articleId: string) {
             articleType: 'unified'
           }
         });
-        
+
+        if (summaryUpdateCount === 0) {
+          // ここで summary をリセットしないのは意図的。本文を書き換えた側
+          // （collect-feeds.ts の自己修復パス）が summary / detailedSummary /
+          // summaryVersion のリセットまで責務として持つため、こちらでリセットすると
+          // 相手が既に生成した正しい要約を消しかねない。
+          console.error('⏭️  要約更新スキップ（CAS敗北）: 要約生成中に他プロセスが本文を更新したため、生成結果は保存しませんでした');
+          return;
+        }
+
         console.error('✅ 要約再生成成功');
         console.error(`  一覧要約: ${result.summary.length}文字`);
         console.error(`  詳細要約: ${result.detailedSummary.length}文字`);
@@ -134,8 +161,11 @@ async function enrichSingleArticle(articleId: string) {
         );
         
         if (result) {
-          await prisma.article.update({
-            where: { id: articleId },
+          // CAS: 要約は取得時点の article.content から生成したものなので、その本文が
+          // まだ残っている場合のみ保存する。要約生成（LLM呼び出し）中に他プロセスが
+          // 本文を更新していた場合、新しい本文に古い要約が結び付くのを防ぐ。
+          const { count: summaryUpdateCount } = await prisma.article.updateMany({
+            where: { id: articleId, content: article.content },
             data: {
               summary: result.summary,
               detailedSummary: result.detailedSummary,
@@ -143,7 +173,12 @@ async function enrichSingleArticle(articleId: string) {
               articleType: 'unified'
             }
           });
-          
+
+          if (summaryUpdateCount === 0) {
+            console.error('⏭️  要約更新スキップ（CAS敗北）: 要約生成中に他プロセスが本文を更新したため、生成結果は保存しませんでした');
+            return;
+          }
+
           console.error('✅ 要約再生成成功（既存コンテンツ使用）');
           console.error(`  詳細要約: ${result.detailedSummary.length}文字`);
         }

--- a/scripts/maintenance/enrich-single-article.ts
+++ b/scripts/maintenance/enrich-single-article.ts
@@ -98,6 +98,11 @@ async function enrichSingleArticle(articleId: string) {
         where: { id: articleId, updatedAt: article.updatedAt },
         data: {
           content: enrichedData.content,
+          // 本文を更新する他の全経路（collect-feeds.ts、re-enrich-*.ts）と同様に
+          // contentUpdatedAt を進める。manage-quality-scores.ts は contentUpdatedAt の
+          // 差分で品質スコア再計算の対象を抽出するため、更新しないと本文が変わったのに
+          // 品質スコアが古いまま残る。
+          contentUpdatedAt: new Date(),
           ...(enrichedData.thumbnail && { thumbnail: enrichedData.thumbnail }),
           ...(isSummaryEligible && {
             summary: null,

--- a/scripts/maintenance/enrich-single-article.ts
+++ b/scripts/maintenance/enrich-single-article.ts
@@ -53,18 +53,27 @@ async function enrichSingleArticle(articleId: string) {
     if (enrichedData && enrichedData.content) {
       const newLength = enrichedData.content.length;
       console.error(`✅ エンリッチメント成功: ${newLength}文字`);
-      
-      // データベース更新
-      await prisma.article.update({
-        where: { id: articleId },
+
+      // CAS: 記事取得時に観測した contentLength と現在値が一致する場合のみ更新する。
+      // enrich() のネットワークI/O中に他プロセス（例: hourly の collect-feeds.ts）が
+      // 先に本文を更新している可能性があるため、古いスナップショット基準で
+      // 上書きしないための保護（Issue #629 項目6、collect-feeds.ts の自己修復パスと同一方針）。
+      const { count } = await prisma.article.updateMany({
+        where: { id: articleId, contentLength: article.contentLength },
         data: {
           content: enrichedData.content,
           ...(enrichedData.thumbnail && { thumbnail: enrichedData.thumbnail })
         }
       });
-      
+
+      if (count === 0) {
+        console.error('⏭️  更新スキップ（CAS敗北）: 記事取得後、他プロセスが既に本文を更新済みのため、今回の取得結果は反映しませんでした');
+        console.error('必要であれば記事の最新状態を確認のうえ再実行してください');
+        return;
+      }
+
       console.error('データベース更新完了');
-      
+
       // 要約再生成
       console.error('\n=== 要約再生成 ===');
       

--- a/scripts/maintenance/enrich-single-article.ts
+++ b/scripts/maintenance/enrich-single-article.ts
@@ -7,6 +7,7 @@ import { createPrismaClient } from '@/lib/prisma/create-client';
 import { GoogleAIEnricher } from '../../lib/enrichers/google-ai';
 import { UnifiedSummaryService } from '../../lib/ai/unified-summary-service';
 import { isEnrichmentSkipped } from '../../lib/fetchers/generic-foreign-rss';
+import { isHighQuality } from '../../lib/enrichers/strategies/quality';
 
 const prisma = createPrismaClient();
 const enricher = new GoogleAIEnricher();
@@ -80,17 +81,32 @@ async function enrichSingleArticle(articleId: string) {
       const isSummaryEligible =
         article.skipReason !== 'PDF' && article.skipReason !== 'SLIDE';
 
+      // skipReason / summaryError のクリアは、collect-feeds.ts / enrich-thin-content.ts
+      // と同一の受入基準（500文字以上は無条件、250-499文字は isHighQuality 必須）を
+      // 満たす場合に限る。GoogleAIEnricher は300文字未満でも本文を返しうるため、
+      // 基準なしでクリアすると、要約生成の対象になったものの本文が短すぎて
+      // THIN_CONTENT が再設定される、という無駄な往復が発生する。
+      //
+      // 一方、summary / detailedSummary / summaryVersion のリセットは基準に関わらず
+      // 行う。本文が差し替わった時点で旧本文由来の要約は無効であり、残すと
+      // 「新本文 + 旧要約」の不整合になるため。
+      const meetsSummaryQualityBar =
+        enrichedData.content.length >= 500 ||
+        (enrichedData.content.length >= 250 && isHighQuality(enrichedData.content));
+
       const { count } = await prisma.article.updateMany({
         where: { id: articleId, updatedAt: article.updatedAt },
         data: {
           content: enrichedData.content,
           ...(enrichedData.thumbnail && { thumbnail: enrichedData.thumbnail }),
           ...(isSummaryEligible && {
-            skipReason: null,
-            summaryError: null,
             summary: null,
             detailedSummary: null,
             summaryVersion: 0
+          }),
+          ...(isSummaryEligible && meetsSummaryQualityBar && {
+            skipReason: null,
+            summaryError: null
           })
         }
       });

--- a/scripts/manual/__tests__/enrich-thin-content.test.ts
+++ b/scripts/manual/__tests__/enrich-thin-content.test.ts
@@ -1,0 +1,91 @@
+import { isThinContentCandidate } from '../enrich-thin-content';
+
+function makeArticle(overrides: {
+  content?: string | null;
+  thumbnail?: string | null;
+  sourceName?: string;
+}) {
+  return {
+    content: overrides.content ?? null,
+    thumbnail: overrides.thumbnail ?? null,
+    source: { name: overrides.sourceName ?? 'Some Source' },
+  };
+}
+
+describe('isThinContentCandidate', () => {
+  describe('本文が完全に空（Issue #629 項目5）', () => {
+    it('content が null かつサムネイルなしの場合は対象に含める', () => {
+      const article = makeArticle({ content: null, thumbnail: null });
+      expect(isThinContentCandidate(article)).toBe(true);
+    });
+
+    it('content が空文字かつサムネイルなしの場合は対象に含める', () => {
+      const article = makeArticle({ content: '', thumbnail: null });
+      expect(isThinContentCandidate(article)).toBe(true);
+    });
+
+    it('content が null でもサムネイルが既にある場合は対象に含める（旧ロジックからの変更点）', () => {
+      const article = makeArticle({
+        content: null,
+        thumbnail: 'https://example.com/thumb.png',
+        sourceName: 'Some Source',
+      });
+      expect(isThinContentCandidate(article)).toBe(true);
+    });
+
+    it('content が空文字でもサムネイルが既にある場合は対象に含める（旧ロジックからの変更点）', () => {
+      const article = makeArticle({
+        content: '',
+        thumbnail: 'https://example.com/thumb.png',
+        sourceName: 'Some Source',
+      });
+      expect(isThinContentCandidate(article)).toBe(true);
+    });
+  });
+
+  describe('本文はあるが薄い（1〜499文字）', () => {
+    it('サムネイルがない場合は対象に含める', () => {
+      const article = makeArticle({ content: 'x'.repeat(200), thumbnail: null });
+      expect(isThinContentCandidate(article)).toBe(true);
+    });
+
+    it('サムネイルが既にあり Speaker Deck 以外の場合は処理済みとみなし除外する', () => {
+      const article = makeArticle({
+        content: 'x'.repeat(200),
+        thumbnail: 'https://example.com/thumb.png',
+        sourceName: 'Some Source',
+      });
+      expect(isThinContentCandidate(article)).toBe(false);
+    });
+
+    it('サムネイルが既にあっても Speaker Deck の場合は対象に含める（従来の例外を維持）', () => {
+      const article = makeArticle({
+        content: 'x'.repeat(200),
+        thumbnail: 'https://example.com/thumb.png',
+        sourceName: 'Speaker Deck',
+      });
+      expect(isThinContentCandidate(article)).toBe(true);
+    });
+
+    it('境界値: 499文字は薄いコンテンツとして扱う', () => {
+      const article = makeArticle({ content: 'x'.repeat(499), thumbnail: null });
+      expect(isThinContentCandidate(article)).toBe(true);
+    });
+  });
+
+  describe('本文が十分にある（500文字以上）', () => {
+    it('境界値: 500文字は対象外', () => {
+      const article = makeArticle({ content: 'x'.repeat(500), thumbnail: null });
+      expect(isThinContentCandidate(article)).toBe(false);
+    });
+
+    it('サムネイルの有無に関わらず対象外', () => {
+      const article = makeArticle({
+        content: 'x'.repeat(600),
+        thumbnail: 'https://example.com/thumb.png',
+        sourceName: 'Some Source',
+      });
+      expect(isThinContentCandidate(article)).toBe(false);
+    });
+  });
+});

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -30,6 +30,41 @@ interface Options {
   skipSummary: boolean;
 }
 
+interface ThinContentCandidateArticle {
+  content: string | null;
+  thumbnail: string | null;
+  source: { name: string };
+}
+
+/**
+ * 薄いコンテンツ（本文が空、または500文字未満）の記事のうち、
+ * エンリッチメント処理の対象とすべきものを判定する。
+ *
+ * - 本文が完全に空（null または空文字）の記事は、サムネイルの有無に関わらず対象に含める。
+ *   GenericContentEnricherは本文抽出に失敗してもサムネイルのみ返すことがあり、
+ *   collect-feeds.ts はサムネイルのみでも記事を保存する。従来ロジックは
+ *   「サムネイルあり = 処理済み」とみなして除外していたため、
+ *   「本文なし・サムネイルあり」の記事が恒久的に回復対象から漏れていた（Issue #629 項目5）。
+ * - 本文はあるが500文字未満の記事は、既にサムネイルを取得済み（Speaker Deck除く）であれば
+ *   ContentEnricherによる処理済みとみなし、従来通り除外する。
+ */
+export function isThinContentCandidate(article: ThinContentCandidateArticle): boolean {
+  const content = article.content;
+
+  if (!content) {
+    // 本文が完全に空: サムネイル有無に関わらず対象
+    return true;
+  }
+
+  if (content.length >= 500) {
+    return false;
+  }
+
+  // 本文はあるが薄い（1〜499文字）: サムネイル取得済みなら処理済みとみなす
+  const hasEnrichedThumbnail = Boolean(article.thumbnail) && article.source.name !== 'Speaker Deck';
+  return !hasEnrichedThumbnail;
+}
+
 function parseArgs(): Options {
   const args = process.argv.slice(2);
   const options: Options = {
@@ -114,13 +149,7 @@ async function main() {
     });
 
     // 500文字未満の記事を抽出（既に処理済みの記事は除外）
-    let thinArticles = allThinArticles.filter(article => {
-      // コンテンツが空または500文字未満
-      const isThin = !article.content || article.content.length < 500;
-      // サムネイルが既に存在する場合は処理済みとみなす（ContentEnricherで取得済み）
-      const hasEnrichedThumbnail = article.thumbnail && article.source.name !== 'Speaker Deck';
-      return isThin && !hasEnrichedThumbnail;
-    });
+    let thinArticles = allThinArticles.filter(isThinContentCandidate);
 
     // skipを適用
     if (options.skip && options.skip > 0) {
@@ -147,6 +176,7 @@ async function main() {
     let skipCount = 0;
     let thumbnailCount = 0;
     let skipEnrichmentCount = 0;
+    let concurrentUpdateSkipCount = 0;
 
     for (let i = 0; i < thinArticles.length; i++) {
       const article = thinArticles[i];
@@ -240,15 +270,31 @@ async function main() {
             updateData.thumbnail = enrichedData.thumbnail;
           }
 
-          await prisma.article.update({
-            where: { id: article.id },
+          // CAS: 記事読み込み時に観測した contentLength と現在値が一致する場合のみ更新する。
+          // hourly の collect-feeds.ts 等、他プロセスがこの間により良い本文を書き込んで
+          // いた場合に、古いスナップショット基準で上書きしないための保護（Issue #629 項目6）。
+          // 本スクリプトは薄い本文（1〜499文字）も対象にするため、null/0判定ではなく
+          // 読み込み時点の contentLength との厳密一致を条件にする（collect-feeds.ts の
+          // 自己修復パスは対象が空本文のみのため null/0 判定で足りるが、本スクリプトは
+          // 「1〜499文字→さらに別プロセスが伸長」というケースも検出する必要があるため）。
+          const { count } = await prisma.article.updateMany({
+            where: {
+              id: article.id,
+              contentLength: article.contentLength,
+            },
             data: updateData,
           });
-          
-          console.error(`  💾 データベース更新完了`);
+
+          if (count === 0) {
+            console.error(`  ⏭️  スキップ（CAS敗北）: 他プロセスが本文を更新済みのためスキップしました`);
+            concurrentUpdateSkipCount++;
+          } else {
+            console.error(`  💾 データベース更新完了`);
+            successCount++;
+          }
+        } else {
+          successCount++;
         }
-        
-        successCount++;
 
         // レート制限対策
         await new Promise(resolve => setTimeout(resolve, 1500));
@@ -267,6 +313,7 @@ async function main() {
     console.error(`❌ 失敗: ${failCount}件`);
     console.error(`⏭️  スキップ: ${skipCount}件`);
     console.error(`⏭️  スキップ（対象外ソース）: ${skipEnrichmentCount}件`);
+    console.error(`⏭️  スキップ（並行更新でCAS敗北）: ${concurrentUpdateSkipCount}件`);
     console.error(`🖼️  サムネイル取得: ${thumbnailCount}件`);
     console.error(`📊 合計: ${thinArticles.length}件`);
 
@@ -286,4 +333,6 @@ async function main() {
   }
 }
 
-main().catch(console.error);
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -329,22 +329,50 @@ async function main() {
               include: { source: true },
             });
 
-            if (!fresh || !isThinContentCandidate(fresh)) {
-              // 他プロセスが十分な本文を書き込んだ（または記事が消えた）ため、
-              // こちらの結果を書く必要がなくなった
+            // 再試行は「updatedAt 以外は何も変わっていない」場合に限る。
+            //
+            // isThinContentCandidate() だけでは不十分。本文が 1〜499 文字なら候補判定は
+            // true を返すため、他プロセスが「新しいが短い本文」を書いた場合や
+            // サムネイルだけを更新した場合でも再試行が通ってしまい、読み込み時点の
+            // スナップショットから作った updateData でそれらを上書きしてしまう。
+            // それは本スクリプトが CAS を導入した目的そのものに反する。
+            //
+            // updateData が触るフィールド（content / thumbnail / skipReason /
+            // summaryError）と、候補判定に使うフィールド（content / thumbnail /
+            // source）のいずれかが変化していたら、他プロセスが意味のある更新を
+            // 行ったとみなして再試行せず終了する。逆に updatedAt だけが動いている
+            // ケース（品質スコア再計算など本文と無関係な更新）は再試行で回収する。
+            const enrichmentInputChanged =
+              !fresh ||
+              fresh.content !== article.content ||
+              fresh.thumbnail !== article.thumbnail ||
+              fresh.skipReason !== article.skipReason ||
+              fresh.sourceId !== article.sourceId;
+
+            if (enrichmentInputChanged) {
+              supersededByOtherProcess = true;
+              break;
+            }
+
+            // ここに到達する時点で content / thumbnail / source は不変のため候補判定の
+            // 結果も変わらないはずだが、判定ロジックの前提が崩れた場合の保険として残す。
+            if (!isThinContentCandidate(fresh)) {
               supersededByOtherProcess = true;
               break;
             }
 
             casTargetUpdatedAt = fresh.updatedAt;
-            console.error(`  🔁 CAS敗北（${attempt}/${MAX_CAS_ATTEMPTS}回目）: 記事を再取得して再試行します`);
+            console.error(
+              `  🔁 CAS敗北（${attempt}/${MAX_CAS_ATTEMPTS}回目）: ` +
+              `本文・サムネイル・スキップ状態は不変のため再試行します`
+            );
           }
 
           if (casUpdated) {
             console.error(`  💾 データベース更新完了`);
             successCount++;
           } else if (supersededByOtherProcess) {
-            console.error(`  ⏭️  スキップ: 他プロセスが先に本文を補完したか記事が削除されたため、この記事は対象外になりました`);
+            console.error(`  ⏭️  スキップ: 読み込み後に他プロセスが本文・サムネイル等を更新した（または記事が削除された）ため、今回の取得結果は反映しません`);
             skipCount++;
           } else {
             console.error(`  ⏭️  スキップ（CAS敗北）: ${MAX_CAS_ATTEMPTS}回試行しましたが、他プロセスの更新と競合し続けたためスキップしました`);

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -337,11 +337,20 @@ async function main() {
             // スナップショットから作った updateData でそれらを上書きしてしまう。
             // それは本スクリプトが CAS を導入した目的そのものに反する。
             //
-            // updateData が触るフィールド（content / thumbnail / skipReason /
-            // summaryError）と、候補判定に使うフィールド（content / thumbnail /
-            // source）のいずれかが変化していたら、他プロセスが意味のある更新を
-            // 行ったとみなして再試行せず終了する。逆に updatedAt だけが動いている
-            // ケース（品質スコア再計算など本文と無関係な更新）は再試行で回収する。
+            // 読み込み時点と比べて content / thumbnail / skipReason / sourceId の
+            // いずれかが変化していたら、他プロセスが意味のある更新を行ったとみなして
+            // 再試行せず終了する。逆に updatedAt だけが動いているケース
+            // （品質スコア再計算など本文と無関係な更新）は再試行で回収する。
+            //
+            // summary / detailedSummary / summaryVersion / summaryError を比較対象に
+            // 含めないのは、これらが「新しい本文が確定したら旧要約は無効」という理由で
+            // 無条件にリセットする値であり、他プロセスの現在値を見て判断する余地が
+            // ないため。実際の書き込みは updatedAt の CAS が最終的に守る。
+            //
+            // source は name ではなく sourceId で比較している。sourceId が同じまま
+            // Source.name だけがリネームされた場合はここを通過するが、直後の
+            // isThinContentCandidate() が最新の source.name を見るため
+            // （Speaker Deck 例外の判定に影響する変化なら）そちらで検出される。
             const enrichmentInputChanged =
               !fresh ||
               fresh.content !== article.content ||

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -246,7 +246,21 @@ async function main() {
           
           if (hasNewContent) {
             updateData.content = enrichedData.content;
-            if (!options.skipSummary) {
+            // 本文を更新する他の全経路（collect-feeds.ts の5箇所、
+            // re-enrich-moneyforward-articles.ts、re-enrich-publickey-nulls.ts）と同様に
+            // contentUpdatedAt を進める。manage-quality-scores.ts は
+            // contentUpdatedAt の差分で品質スコア再計算の対象を抽出するため
+            // （scripts/scheduled/manage-quality-scores.ts:117-122）、更新しないと
+            // 本文が変わったのに品質スコアが古いまま残る。
+            updateData.contentUpdatedAt = new Date();
+            // PDF / SLIDE は本文の有無と無関係な恒久スキップ理由のため、要約リセットも
+            // 行わない。リセットすると要約が消えたまま、恒久スキップにより再生成もされず
+            // 復旧しなくなる（collect-feeds.ts の自己修復パス・enrich-single-article.ts と
+            // 同じ扱い）。
+            const isSummaryEligible =
+              article.skipReason !== 'PDF' && article.skipReason !== 'SLIDE';
+
+            if (!options.skipSummary && isSummaryEligible) {
               // 要約をリセット（再生成が必要）
               updateData.summary = null;
               updateData.detailedSummary = null;
@@ -264,10 +278,9 @@ async function main() {
             // 250-499文字は isHighQuality 必須）にし、わずかな伸びでの
             // クリアを防ぐ
             if (
+              isSummaryEligible &&
               (enrichedData.content.length >= 500 ||
-                (enrichedData.content.length >= 250 && isHighQuality(enrichedData.content))) &&
-              article.skipReason !== 'PDF' &&
-              article.skipReason !== 'SLIDE'
+                (enrichedData.content.length >= 250 && isHighQuality(enrichedData.content)))
             ) {
               updateData.skipReason = null;
               updateData.summaryError = null;

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -238,7 +238,6 @@ async function main() {
         }
         if (hasNewThumbnail) {
           console.error(`    - サムネイル: 取得成功`);
-          thumbnailCount++;
         }
 
         if (!options.dryRun) {
@@ -380,6 +379,10 @@ async function main() {
           if (casUpdated) {
             console.error(`  💾 データベース更新完了`);
             successCount++;
+            // CAS 敗北時はサムネイルも保存されないため、加算は更新成功後に行う
+            if (hasNewThumbnail) {
+              thumbnailCount++;
+            }
           } else if (supersededByOtherProcess) {
             console.error(`  ⏭️  スキップ: 読み込み後に他プロセスが本文・サムネイル等を更新した（または記事が削除された）ため、今回の取得結果は反映しません`);
             skipCount++;
@@ -388,7 +391,11 @@ async function main() {
             concurrentUpdateSkipCount++;
           }
         } else {
+          // ドライラン: DB は更新しないが、取得できた件数として計上する
           successCount++;
+          if (hasNewThumbnail) {
+            thumbnailCount++;
+          }
         }
 
         // レート制限対策

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -30,6 +30,15 @@ interface Options {
   skipSummary: boolean;
 }
 
+/**
+ * CAS（Compare-And-Swap）更新の最大試行回数。
+ *
+ * updatedAt を CAS トークンに使うため、本文と無関係な更新（品質スコア再計算など）
+ * でも敗北しうる。1回で諦めると取りこぼしが増えるので、記事を再取得して数回まで
+ * 再試行する。
+ */
+const MAX_CAS_ATTEMPTS = 3;
+
 interface ThinContentCandidateArticle {
   content: string | null;
   thumbnail: string | null;
@@ -285,22 +294,61 @@ async function main() {
           // トレードオフ: 逆に本文と無関係な更新でも CAS が失敗する。特に品質スコア再計算
           // （manage-quality-scores.ts / quality-score-batch.ts）は raw SQL で
           // `"updatedAt" = NOW()` を明示セットするため、qualityScore しか変えていなくても
-          // ここで敗北する。本スクリプトは長時間ループするため割り込みを受けやすいが、
-          // 安全側に倒れるだけで取りこぼしは起きず、再実行で回収できるため許容する。
-          const { count } = await prisma.article.updateMany({
-            where: {
-              id: article.id,
-              updatedAt: article.updatedAt,
-            },
-            data: updateData,
-          });
+          // ここで敗北する。この誤失敗による取りこぼしを避けるため、敗北時は記事を
+          // 再取得して上限付きで再試行する。
+          //
+          // 再試行時に enrich をやり直さないのは意図的。再取得後に
+          // isThinContentCandidate で「まだ薄いまま」であることを確認しており、
+          // その場合エンリッチ結果は依然として有効なため、外部への再フェッチは
+          // レート制限とレイテンシのコストに見合わない。逆に他プロセスが十分な本文を
+          // 書き込んでいた場合は候補判定で弾かれ、こちらの結果で上書きすることはない。
+          let casUpdated = false;
+          let supersededByOtherProcess = false;
+          let casTargetUpdatedAt: Date = article.updatedAt;
 
-          if (count === 0) {
-            console.error(`  ⏭️  スキップ（CAS敗北）: 読み込み後に他プロセスがこの記事を更新したためスキップしました`);
-            concurrentUpdateSkipCount++;
-          } else {
+          for (let attempt = 1; attempt <= MAX_CAS_ATTEMPTS; attempt++) {
+            const { count } = await prisma.article.updateMany({
+              where: {
+                id: article.id,
+                updatedAt: casTargetUpdatedAt,
+              },
+              data: updateData,
+            });
+
+            if (count > 0) {
+              casUpdated = true;
+              break;
+            }
+
+            if (attempt === MAX_CAS_ATTEMPTS) break;
+
+            await new Promise(resolve => setTimeout(resolve, 500 * attempt));
+
+            const fresh = await prisma.article.findUnique({
+              where: { id: article.id },
+              include: { source: true },
+            });
+
+            if (!fresh || !isThinContentCandidate(fresh)) {
+              // 他プロセスが十分な本文を書き込んだ（または記事が消えた）ため、
+              // こちらの結果を書く必要がなくなった
+              supersededByOtherProcess = true;
+              break;
+            }
+
+            casTargetUpdatedAt = fresh.updatedAt;
+            console.error(`  🔁 CAS敗北（${attempt}/${MAX_CAS_ATTEMPTS}回目）: 記事を再取得して再試行します`);
+          }
+
+          if (casUpdated) {
             console.error(`  💾 データベース更新完了`);
             successCount++;
+          } else if (supersededByOtherProcess) {
+            console.error(`  ⏭️  スキップ: 他プロセスが先に本文を補完したか記事が削除されたため、この記事は対象外になりました`);
+            skipCount++;
+          } else {
+            console.error(`  ⏭️  スキップ（CAS敗北）: ${MAX_CAS_ATTEMPTS}回試行しましたが、他プロセスの更新と競合し続けたためスキップしました`);
+            concurrentUpdateSkipCount++;
           }
         } else {
           successCount++;

--- a/scripts/manual/enrich-thin-content.ts
+++ b/scripts/manual/enrich-thin-content.ts
@@ -270,23 +270,33 @@ async function main() {
             updateData.thumbnail = enrichedData.thumbnail;
           }
 
-          // CAS: 記事読み込み時に観測した contentLength と現在値が一致する場合のみ更新する。
+          // CAS: 記事読み込み時に観測した updatedAt と現在値が一致する場合のみ更新する。
           // hourly の collect-feeds.ts 等、他プロセスがこの間により良い本文を書き込んで
           // いた場合に、古いスナップショット基準で上書きしないための保護（Issue #629 項目6）。
-          // 本スクリプトは薄い本文（1〜499文字）も対象にするため、null/0判定ではなく
-          // 読み込み時点の contentLength との厳密一致を条件にする（collect-feeds.ts の
-          // 自己修復パスは対象が空本文のみのため null/0 判定で足りるが、本スクリプトは
-          // 「1〜499文字→さらに別プロセスが伸長」というケースも検出する必要があるため）。
+          //
+          // CAS トークンに contentLength ではなく updatedAt を使う理由:
+          // contentLength は CHAR_LENGTH(content) の派生値のため、(a) 同じ文字数の別本文に
+          // 差し替えられた場合（ABA問題）と (b) 本文以外だけが更新された場合を検出できない。
+          // 本スクリプトの updateData は thumbnail も含みうるうえ、collect-feeds.ts には
+          // サムネイルのみを更新する経路が実在するため (b) は現実に起こりうる。
+          // updatedAt は @updatedAt により任意の更新で必ず変化するので、「読み込み後に
+          // 誰かが何かを書いた」ことを漏れなく検出できる。
+          //
+          // トレードオフ: 逆に本文と無関係な更新でも CAS が失敗する。特に品質スコア再計算
+          // （manage-quality-scores.ts / quality-score-batch.ts）は raw SQL で
+          // `"updatedAt" = NOW()` を明示セットするため、qualityScore しか変えていなくても
+          // ここで敗北する。本スクリプトは長時間ループするため割り込みを受けやすいが、
+          // 安全側に倒れるだけで取りこぼしは起きず、再実行で回収できるため許容する。
           const { count } = await prisma.article.updateMany({
             where: {
               id: article.id,
-              contentLength: article.contentLength,
+              updatedAt: article.updatedAt,
             },
             data: updateData,
           });
 
           if (count === 0) {
-            console.error(`  ⏭️  スキップ（CAS敗北）: 他プロセスが本文を更新済みのためスキップしました`);
+            console.error(`  ⏭️  スキップ（CAS敗北）: 読み込み後に他プロセスがこの記事を更新したためスキップしました`);
             concurrentUpdateSkipCount++;
           } else {
             console.error(`  💾 データベース更新完了`);
@@ -314,6 +324,9 @@ async function main() {
     console.error(`⏭️  スキップ: ${skipCount}件`);
     console.error(`⏭️  スキップ（対象外ソース）: ${skipEnrichmentCount}件`);
     console.error(`⏭️  スキップ（並行更新でCAS敗北）: ${concurrentUpdateSkipCount}件`);
+    if (concurrentUpdateSkipCount > 0) {
+      console.error('   ※ 本文更新のほか、品質スコア再計算など本文と無関係な更新でも発生します。再実行で回収できます');
+    }
     console.error(`🖼️  サムネイル取得: ${thumbnailCount}件`);
     console.error(`📊 合計: ${thinArticles.length}件`);
 


### PR DESCRIPTION
## 概要

Issue #629 の項目5・6 に対応します。いずれも PR #634 の cross-review で検出され、当該PRのスコープ外として #629 に追記されていた項目です。

## 項目6: 手動エンリッチスクリプトに並行制御（CAS）がない

### 問題

`scripts/manual/enrich-thin-content.ts` と `scripts/maintenance/enrich-single-article.ts` は、記事を読み込んだ後に外部HTTPフェッチを挟み、最後は ID のみの無条件 `update` で保存していました。この間に hourly の `collect-feeds.ts` がより良い本文を書き込んでも、手動スクリプトが古いスナップショット基準で上書きしうる状態でした。

`collect-feeds.ts` 側は PR #634 で contentLength 条件付き `updateMany`（CAS）に統一済みでしたが、手動スクリプトは未対応のまま残っていました。

### 対応

両スクリプトを `updateMany` + 条件指定の CAS に統一しました。

**CAS 条件に「読み込み時に観測した contentLength と完全一致」を選んだ理由**:
`collect-feeds.ts` の自己修復パスは空本文の記事のみを対象とするため `OR: [{contentLength: null}, {contentLength: 0}]` で足ります。一方 `enrich-thin-content.ts` は 1〜499 文字の薄い本文も対象にするため、競合プロセスが 200→600 文字に更新したケースを null/0 判定では検出できません。完全一致であればこの遷移も検出できます。

CAS 敗北時は更新を破棄し、専用カウンタ（`concurrentUpdateSkipCount`）とログで観測できるようにしました。`enrich-single-article.ts` は単一記事CLIのため、CAS 敗北時はエラー終了ではなく運用者向けメッセージを出して正常終了します。

## 項目5: 「本文空 + サムネイルのみ取得成功」の記事が回復対象から漏れる

### 問題

`GenericContentEnricher` は本文抽出に失敗してもOGPサムネイルのみを返すことがあり、`collect-feeds.ts` は本文なしでもサムネイルを保存します。しかし `enrich-thin-content.ts` は `isThin && !hasEnrichedThumbnail` で「サムネイルあり = 処理済み」とみなして除外していたため、**この状態の記事は恒久的に回復手段から漏れていました**。

### 対応

本文が完全に空（null または空文字）の記事は、サムネイルの有無に関わらず処理対象に含めるよう変更しました。本文はあるが薄い記事に対する従来の除外ルール（Speaker Deck 例外を含む）はそのまま維持しています。

判定ロジックは純粋関数 `isThinContentCandidate()` として切り出し、単体テストを追加しました。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `scripts/manual/enrich-thin-content.ts` | フィルタの純粋関数化 + 空本文の対象化 + CAS化 |
| `scripts/maintenance/enrich-single-article.ts` | CAS化 |
| `scripts/manual/__tests__/enrich-thin-content.test.ts` | 新規。フィルタ判定の単体テスト10件 |

## 検証

- 型チェック: `npx tsc --noEmit` → エラーなし
- テスト: `TEST_FILE=scripts/manual/__tests__/enrich-thin-content.test.ts npm run docker:test:file` → **10 passed**（空本文×サムネイル有無、薄い本文のSpeaker Deck例外、499/500文字の境界値を網羅）
- DB変更なし

## 補足

`enrich-thin-content.ts` に、テストから純粋関数を import できるようにするための `if (require.main === module)` ガードを追加しています（`scripts/maintenance/normalize-existing-summaries.ts` の既存パターンを踏襲）。

Issue #629 の残り項目（項目2 sourceIdバックフィル / 項目3 fixtureテスト強化 / 項目4 ログ方式統一）は本PRのスコープ外です。項目1（エンリッチメント失敗の恒久化）は PR #634 で解消済みであることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 記事の同時更新を検知し、他の更新内容を誤って上書きしないよう改善しました。
  - 内容が空または短い記事の判定を見直し、サムネイルや配信元に応じて適切に処理するようにしました。
  - 更新競合の発生件数を実行結果に表示するようにしました。

- **テスト**
  - 短い記事の判定ルールに関するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->