### PR TITLE
fix: Issue #636 収集ジョブのソース単位の失敗・フィード0件を可視化

### DIFF
--- a/__tests__/fetchers/fetch-error-propagation.test.ts
+++ b/__tests__/fetchers/fetch-error-propagation.test.ts
@@ -1,0 +1,202 @@
+/**
+ * FetchResult.errors 伝播の単体テスト（Issue #636: 収集失敗・0件の可視化）
+ *
+ * フェッチャー内部のフィード取得・パースエラーは例外を投げず、
+ * FetchResult（{ articles, errors }）の errors 配列に積むだけの設計になっている。
+ * collect-feeds.ts の processSource はこれを ProcessSourceResult.fetchErrorCount
+ * として観測可能にするが、その前提となる「両フェッチャー系統
+ * （generic-foreign-rss / base-corporate-fetcher）が実際に errors を返すこと」を
+ * ここで固定する。
+ *
+ * batch2-sources.test.ts の rss-parser モックパターンを踏襲する。
+ */
+
+import {
+  GenericForeignRssFetcher,
+  FOREIGN_SOURCE_CONFIGS,
+} from '@/lib/fetchers/generic-foreign-rss';
+import { FreeeFetcher } from '@/lib/fetchers/corporate-blogs/freee-fetcher';
+import { Source } from '@/lib/prisma-exports';
+import Parser from 'rss-parser';
+import { normalizeUrl } from '@/lib/utils/url/url-normalizer';
+import { getContentFromItem } from '@/lib/types/rss';
+
+jest.mock('rss-parser', () => {
+  return jest.fn().mockImplementation(() => ({
+    parseURL: jest.fn(),
+  }));
+});
+const MockedParser = jest.mocked(Parser);
+
+jest.mock('@/lib/logger', () => {
+  const noop = { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() };
+  // generic-foreign-rss.ts は named import、base-corporate-fetcher.ts は default import
+  return { __esModule: true, logger: noop, default: noop };
+});
+
+jest.mock('@/lib/utils/duplicate-detection', () => ({
+  isDuplicate: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('@/lib/utils/url/url-normalizer', () => ({
+  normalizeUrl: jest.fn((url: string) => url),
+}));
+
+jest.mock('@/lib/types/rss', () => {
+  const actual = jest.requireActual('@/lib/types/rss');
+  return {
+    ...actual,
+    getContentFromItem: jest.fn(actual.getContentFromItem),
+  };
+});
+
+const mockedNormalizeUrl = jest.mocked(normalizeUrl);
+const mockedGetContentFromItem = jest.mocked(getContentFromItem);
+
+const createMockSource = (overrides?: Partial<Source>): Source => ({
+  id: 'test-source',
+  name: 'Test Source',
+  url: 'https://example.com',
+  type: 'RSS',
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+describe('GenericForeignRssFetcher: errors伝播', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedNormalizeUrl.mockImplementation((url: string) => url);
+  });
+
+  it('フィード取得自体が失敗した場合、例外を投げずerrorsに積んで返す', async () => {
+    const mockParseURL = jest.fn().mockRejectedValue(new Error('network timeout'));
+    MockedParser.mockImplementation(
+      () => ({ parseURL: mockParseURL }) as unknown as Parser
+    );
+
+    const config = FOREIGN_SOURCE_CONFIGS['CNCF Blog'];
+    expect(config).toBeDefined();
+    const fetcher = new GenericForeignRssFetcher(
+      createMockSource({ id: 'cncf', name: 'CNCF Blog' }),
+      config
+    );
+
+    const result = await fetcher.fetch();
+
+    expect(result.articles).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toBeInstanceOf(Error);
+    expect(result.errors[0].message).toContain('CNCF Blog');
+    expect(result.errors[0].message).toContain('network timeout');
+  });
+
+  it('個別itemの処理中エラーはerrorsに積まれ、他のitemの処理は継続する', async () => {
+    const mockParseURL = jest.fn().mockResolvedValue({
+      items: [
+        {
+          title: 'Broken item',
+          link: 'https://example.com/broken',
+          isoDate: '2026-08-02T10:00:00.000Z',
+          content: 'broken item content',
+        },
+        {
+          title: 'Healthy item',
+          link: 'https://example.com/healthy',
+          isoDate: '2026-08-02T11:00:00.000Z',
+          content: 'healthy item content body',
+        },
+      ],
+    });
+    MockedParser.mockImplementation(
+      () => ({ parseURL: mockParseURL }) as unknown as Parser
+    );
+
+    // normalizeUrl は articles ループ内で item ごとに呼ばれる。'broken' を含む
+    // itemUrl のときだけ例外を投げ、当該item単体の処理失敗を再現する
+    mockedNormalizeUrl.mockImplementation((url: string) => {
+      if (url.includes('broken')) {
+        throw new Error('normalize failure');
+      }
+      return url;
+    });
+
+    const config = FOREIGN_SOURCE_CONFIGS['Meta Engineering'];
+    expect(config).toBeDefined();
+    const fetcher = new GenericForeignRssFetcher(
+      createMockSource({ id: 'meta', name: 'Meta Engineering' }),
+      config
+    );
+
+    const result = await fetcher.fetch();
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toContain('Broken item');
+    expect(result.errors[0].message).toContain('normalize failure');
+    expect(result.articles).toHaveLength(1);
+    expect(result.articles[0].title).toBe('Healthy item');
+  });
+});
+
+describe('BaseCorporateFetcher (via FreeeFetcher): errors伝播', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetContentFromItem.mockImplementation(
+      jest.requireActual('@/lib/types/rss').getContentFromItem
+    );
+  });
+
+  it('フィード取得自体が失敗した場合、リトライを使い切っても例外を投げずerrorsに積んで返す', async () => {
+    jest.useFakeTimers();
+    try {
+      const mockParseURL = jest.fn().mockRejectedValue(new Error('DNS resolution failed'));
+      MockedParser.mockImplementation(
+        () => ({ parseURL: mockParseURL }) as unknown as Parser
+      );
+
+      const fetcher = new FreeeFetcher(createMockSource({ id: 'freee', name: 'freee' }));
+      const resultPromise = fetcher.fetch();
+      await jest.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result.articles).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toBeInstanceOf(Error);
+      expect(result.errors[0].message).toContain('freee');
+      expect(result.errors[0].message).toContain('DNS resolution failed');
+      // maxRetries(3) 分のリトライ + 初回実行で計4回呼ばれる
+      expect(mockParseURL).toHaveBeenCalledTimes(4);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('個別itemの処理中エラーはerrorsに積まれる', async () => {
+    mockedGetContentFromItem.mockImplementation(() => {
+      throw new Error('unexpected item shape');
+    });
+
+    const mockParseURL = jest.fn().mockResolvedValue({
+      items: [
+        {
+          title: 'テスト記事',
+          link: 'https://developers.freee.co.jp/entry/test',
+          isoDate: new Date().toISOString(),
+        },
+      ],
+    });
+    MockedParser.mockImplementation(
+      () => ({ parseURL: mockParseURL }) as unknown as Parser
+    );
+
+    const fetcher = new FreeeFetcher(createMockSource({ id: 'freee', name: 'freee' }));
+    const result = await fetcher.fetch();
+
+    expect(result.articles).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toBeInstanceOf(Error);
+    expect(result.errors[0].message).toContain('freee');
+    expect(result.errors[0].message).toContain('unexpected item shape');
+  });
+});

--- a/scripts/scheduled/collect-feeds.ts
+++ b/scripts/scheduled/collect-feeds.ts
@@ -170,6 +170,18 @@ interface ProcessSourceResult {
   updated: number;
   newArticleIds: string[];
   articles: ArticleInfo[];
+  /**
+   * フィードから取得できた生アイテム数（フェッチャーが返した articles 件数）。
+   * 全フェッチャー共有の戻り値型に依存するため、既存フェッチャー全ての変更を
+   * 避けるべくオプショナルとする（Issue #636: 収集失敗・0件の可視化）。
+   */
+  fetchedItemCount?: number;
+  /**
+   * フェッチャー内部（FetchResult.errors）で発生したエラー件数。
+   * フェッチャーは取得・パースエラーを例外にせず errors 配列へ積むだけのため、
+   * ここを経由しないと呼び出し元からは失敗の存在自体が見えない。
+   */
+  fetchErrorCount?: number;
 }
 
 async function runWithTimeout<T>(
@@ -260,6 +272,8 @@ async function processSource({
     }
 
     fetchedArticlesCount = articles?.length ?? 0;
+    result.fetchedItemCount = fetchedArticlesCount;
+    result.fetchErrorCount = errors.length;
 
     if (!articles || articles.length === 0) {
       const duration = Math.round((Date.now() - startTime) / 1000);
@@ -708,6 +722,18 @@ async function processSource({
   }
 }
 
+/**
+ * ソース名一覧をログ出力用に整形する。
+ * 件数が多い場合はログの肥大化を避けるため先頭 maxDisplay 件のみ表示し、
+ * 残数を付記する（Issue #636）。
+ */
+function formatSourceNameSummary(names: string[], maxDisplay = 20): string {
+  if (names.length === 0) return 'なし';
+  const shown = names.slice(0, maxDisplay).join(', ');
+  const suffix = names.length > maxDisplay ? ` 他${names.length - maxDisplay}件` : '';
+  return `${shown}${suffix} (計${names.length}件)`;
+}
+
 async function collectFeeds(sourceTypes?: string[]): Promise<CollectResult> {
   console.error('[INFO] フィード収集を開始します...');
   console.error(`   SKIP_POST_SAVE_ENRICHMENT: ${env.SKIP_POST_SAVE_ENRICHMENT}`);
@@ -762,21 +788,40 @@ async function collectFeeds(sourceTypes?: string[]): Promise<CollectResult> {
     let totalUpdated = 0;
     const newArticleIds: string[] = [];
     const allArticles: ArticleInfo[] = [];
+    // Issue #636: ソース単位の失敗・0件収集を可視化するための観測用リスト
+    const rejectedSourceNames: string[] = [];
+    const fetchErrorSourceSummaries: string[] = [];
+    const zeroFetchedSourceNames: string[] = [];
 
-    settledResults.forEach(result => {
+    settledResults.forEach((result, index) => {
+      const sourceName = sources[index]?.name ?? '(unknown)';
       if (result.status === 'fulfilled') {
         totalNewArticles += result.value.newArticles;
         totalDuplicates += result.value.duplicates;
         totalUpdated += result.value.updated;
         newArticleIds.push(...result.value.newArticleIds);
         allArticles.push(...result.value.articles);
+
+        if (result.value.fetchErrorCount && result.value.fetchErrorCount > 0) {
+          fetchErrorSourceSummaries.push(`${sourceName}(${result.value.fetchErrorCount}件)`);
+        }
+        // フィードからアイテムを1件も取得できなかったソース。
+        // 「新規0件」はフィードに新着がないだけで正常だが、「フィードのアイテム自体が0件」は
+        // フィードURL変更・パース失敗・フィルタ設定ドリフトのいずれかを示す異常シグナル。
+        if (result.value.fetchedItemCount === 0) {
+          zeroFetchedSourceNames.push(sourceName);
+        }
       } else {
-        console.error('[WARN] ソース処理で未処理の例外が発生しました:', result.reason);
+        console.error(`[WARN] ソース処理で未処理の例外が発生しました (${sourceName}):`, result.reason);
+        rejectedSourceNames.push(sourceName);
       }
     });
 
     const duration = Math.round((Date.now() - startTime) / 1000);
     console.error(`\n📊 収集完了: 新規${totalNewArticles}件, 更新${totalUpdated}件, 重複${totalDuplicates}件 (${duration}秒)`);
+    console.error(`   未処理例外ソース: ${formatSourceNameSummary(rejectedSourceNames)}`);
+    console.error(`   フェッチエラーソース: ${formatSourceNameSummary(fetchErrorSourceSummaries)}`);
+    console.error(`   フィード0件ソース(要調査): ${formatSourceNameSummary(zeroFetchedSourceNames)}`);
 
     // 自己修復のみ成功した実行（totalNewArticles === 0）でも要約生成・
     // キャッシュ無効化を起動するため、newArticleIds の件数で判定する


### PR DESCRIPTION
## 概要

Issue #636 に対し、**収集失敗とフィード0件ソースをログに可視化**します。exit code の変更は含みません（理由は後述）。

## 問題の実態

調査の結果、Issue が指摘する「ソース単位の失敗がジョブ成功扱いになる」以上に深刻な経路があることが分かりました。

`FetchResult` は `{ articles, errors }` を返しており、`generic-foreign-rss.ts` と `corporate-blogs/base-corporate-fetcher.ts` の**両系統とも errors を正しく積んでいました**。しかし `processSource` がその errors を一切読まずに捨てていたため、フェッチ失敗は `Promise.allSettled` の rejected にすらならず、**fulfilled として正常集計されていました**。

### 実データ

dev DB で「enabled=true・収集起動リストに登録済み・停止コミットなし」にもかかわらず長期間ゼロ収集のソースが存在します。投稿頻度と沈黙期間を比較すると異常が濃厚なのは以下です。

| ソース | 平均投稿間隔 | 沈黙期間 |
|---|---|---|
| Hugging Face Papers | 0.1 日 | 273 日 |
| Mercari Engineering | — | 記事 0 件（同ドメイン記事11件がはてなブックマーク帰属で存在） |
| CNCF Blog | 4.5 日 | 95 日 |
| Chrome Developers | 3.0 日 | 46 日 |

いずれも GHA・scheduler.ts の両方に有効な行として存在し、意図的な停止ではありません。**失敗しているのに誰も気づけない状態**が実際に発生しています。

## 対応内容

### 1. フェッチ結果の伝播

`ProcessSourceResult` に `fetchedItemCount?: number` / `fetchErrorCount?: number` を追加し、`processSource` が `FetchResult.errors` を拾って載せるようにしました。**オプショナルにしたのは、この型が全フェッチャー共有のため必須フィールドにすると全フェッチャーの変更が必要になるため**です。

フェッチャー側のコード変更は不要でした（両系統とも既に errors を正しく積んでいたため）。

### 2. サマリログの拡張

現在の `📊 収集完了: 新規N件, 更新N件, 重複N件` は全体集計のみでソース名を含みませんでした。以下3行を追加します（20件で打ち切り、超過分は件数表示）。

```
   未処理例外ソース: ...
   フェッチエラーソース: SourceName(N件), ...
   フィード0件ソース(要調査): ...
```

**「フィード0件」を指標に選んだ理由**: 当初は「新規0件かつ更新0件」で実装しましたが、dev DB の実測では毎回 76 ソース中 40〜70 が「新着なし」に該当するため、毎時このリストが埋まって本当の異常が埋もれます。一方「フィードのアイテム自体が0件」はフィードURL変更・パース失敗・フィルタ設定ドリフトのいずれかを示す明確な異常シグナルになります。

### 3. exit code は変更しない

「rejected 何件でジョブを失敗させるか」は運用ポリシー判断であり、本PRでは扱いません。全76ソース中1件の一時的タイムアウトで毎時アラートが飛ぶ運用は避けたいためです。まず可視化のみを入れ、**次回の本番収集ログで実態を観測してから閾値を決める**方針です。したがって `.github/workflows/scheduler-rss-hourly.yml` の変更も含みません。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `scripts/scheduled/collect-feeds.ts` | 型フィールド追加・errors伝播・サマリログ拡張・件数打ち切りヘルパー |
| `__tests__/fetchers/fetch-error-propagation.test.ts` | 新規。両フェッチャー系統でのerrors伝播テスト4件 |

## 検証

- 型チェック: `npx tsc --noEmit` → エラーなし
- テスト: `TEST_FILE=__tests__/fetchers npm run docker:test:file` → **21 suites / 379 passed**（新規4件を含む、既存の回帰なし）
- exit code の挙動は変更なし（`process.exit(0)` のまま）
- DB変更なし

## 残る課題（本PRのスコープ外）

- **exit code / Slack 通知への反映**: 上記の通り閾値決定後に別PR
- **マルチフィード統合フェッチャー内の個別フィード死亡**: `Medium Engineering` のような複数フィードを1ソースに束ねるフェッチャーでは、内部の1フィードが死んでもソース全体としては記事が入り続けるため、この対応でも検出できません（実際に `Uber Engineering` フィードが記事0件）。#636 に追記します
- **停止中ソースの個別復旧**: 本PRを入れた後の収集ログで失敗理由を観測してから対応します

🤖 Generated with [Claude Code](https://claude.com/claude-code)