### PR TITLE
fix(security): Issue #633 エンリッチャーにDNS解決を含むSSRFガードを追加

### DIFF
--- a/jest.setup.node.js
+++ b/jest.setup.node.js
@@ -48,6 +48,26 @@ jest.mock('@/lib/auth/get-session', () => ({
   getRequiredSession: jest.fn().mockRejectedValue(new Error('Unauthorized')),
 }));
 
+// DNS解決のモック（Issue #633 SSRF guard: lib/utils/url/ssrf-guard.ts が
+// dns.promises.lookup を使用する）。多数の enricher テストが実在ドメイン
+// （zenn.dev, speakerdeck.com 等）に対して global.fetch のみをモックしており、
+// 実 DNS 解決に依存すると CI で不安定になる（ネットワーク遮断環境で全滅もありうる）。
+// デフォルトでは安全な公開IP（RFC 5737 TEST-NET-3、実在しないが SSRF guard の
+// 拒否レンジには該当しない）を返す。SSRF guard 自体の拒否ケースを検証するテストは
+// (dns.promises.lookup as jest.Mock).mockResolvedValueOnce(...) 等で個別に上書きする。
+jest.mock('dns', () => {
+  const actual = jest.requireActual('dns');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      lookup: jest
+        .fn()
+        .mockResolvedValue([{ address: '203.0.113.10', family: 4 }]),
+    },
+  };
+});
+
 // テスト環境のDI初期化
 beforeAll(() => {
   initializeTestDI();

--- a/lib/enrichers/__tests__/base.test.ts
+++ b/lib/enrichers/__tests__/base.test.ts
@@ -1,5 +1,8 @@
+import dns from 'dns';
 import { BaseContentEnricher } from '../base';
 import logger from '@/lib/logger';
+
+const mockLookup = dns.promises.lookup as jest.Mock;
 
 // NOTE: fetchの「グローバルモック」は行わない。必要なテスト（例: リトライ）ではケース単位で局所的にstubする。
 
@@ -443,6 +446,96 @@ describe('BaseContentEnricher', () => {
       expect(logged.status).toBe(503);
 
       loggerSpy.mockRestore();
+    });
+  });
+
+  describe('fetchWithRetry - SSRF guard integration (Issue #633)', () => {
+    // TestContentEnricher は fetchWithRetry を override して base.ts の実装を
+    // 迂回するため、ここでは override しない別サブクラスで実装を直接検証する。
+    class RealFetchEnricher extends BaseContentEnricher {
+      canHandle(): boolean {
+        return true;
+      }
+      // protected -> public に公開してテストから直接呼べるようにする
+      public callFetchWithRetry(url: string, signal?: AbortSignal) {
+        return this.fetchWithRetry(url, signal);
+      }
+      // rateLimit(1500ms)分の実待機でテストが遅くならないようにモック
+      protected delay(): Promise<void> {
+        return Promise.resolve();
+      }
+    }
+
+    let originalFetch: typeof global.fetch;
+
+    beforeEach(() => {
+      originalFetch = global.fetch;
+      mockLookup.mockReset();
+      mockLookup.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      jest.restoreAllMocks();
+    });
+
+    it('プライベートIPに解決されるURLはリトライせず即座にthrowする', async () => {
+      mockLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+      const fetchSpy = jest.fn();
+      global.fetch = fetchSpy as unknown as typeof global.fetch;
+
+      const enricher = new RealFetchEnricher();
+      await expect(
+        enricher.callFetchWithRetry('https://attacker-controlled.example/')
+      ).rejects.toThrow();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      // maxRetries=3 だが、SSRFガードで即座にthrowするためDNS lookupは1回のみ
+      expect(mockLookup).toHaveBeenCalledTimes(1);
+    });
+
+    it('enrich() 経由でも拒否時はnullを返し、logEnrichmentErrorで記録される', async () => {
+      mockLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+      const fetchSpy = jest.fn();
+      global.fetch = fetchSpy as unknown as typeof global.fetch;
+      const loggerSpy = jest
+        .spyOn(logger, 'error')
+        .mockImplementation(() => {});
+
+      const enricher = new RealFetchEnricher();
+      const result = await enricher.enrich(
+        'https://attacker-controlled.example/'
+      );
+
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://attacker-controlled.example/',
+          enricher: 'RealFetchEnricher',
+        }),
+        '[Enrichment] failed'
+      );
+
+      loggerSpy.mockRestore();
+    });
+
+    it('公開IPに解決されるURLは通常通りfetchされる', async () => {
+      mockLookup.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+      const fetchSpy = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => '<html><body>ok</body></html>',
+        body: { cancel: jest.fn() },
+      });
+      global.fetch = fetchSpy as unknown as typeof global.fetch;
+
+      const enricher = new RealFetchEnricher();
+      const html = await enricher.callFetchWithRetry('https://public.example/');
+
+      expect(html).toBe('<html><body>ok</body></html>');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/lib/enrichers/__tests__/generic.test.ts
+++ b/lib/enrichers/__tests__/generic.test.ts
@@ -1,0 +1,155 @@
+/**
+ * GenericContentEnricher tests
+ *
+ * Issue #633 (SSRF guard) のリグレッション防止:
+ * GenericContentEnricher は ContentEnricherFactory の最終フォールバックであり、
+ * 未知ドメイン URL（フィード投稿者が持ち込める Hacker News / Lobsters / はてな
+ * ブックマーク経由の記事）が最終的に到達する enricher のため、SSRF guard が
+ * 最も効いていなければならない箇所である。このファイル作成以前、
+ * lib/enrichers/__tests__/ 配下に generic.ts 専用のテストは存在しなかった。
+ *
+ * dns.promises.lookup は jest.setup.node.js でグローバルにモックされている
+ * （デフォルトでは公開IP 203.0.113.10 を返す）。危険なURLを検証するテストのみ
+ * mockResolvedValueOnce で私設/内部IPに上書きする。
+ */
+
+import dns from 'dns';
+import { GenericContentEnricher } from '../generic';
+import logger from '@/lib/logger';
+
+const mockLookup = dns.promises.lookup as jest.Mock;
+
+describe('GenericContentEnricher - SSRF guard integration (Issue #633)', () => {
+  let enricher: GenericContentEnricher;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    enricher = new GenericContentEnricher();
+    originalFetch = global.fetch;
+    mockLookup.mockReset();
+    mockLookup.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  describe('危険なURLの拒否', () => {
+    it('プライベートIP(10.0.0.0/8)に解決されるURLはnullを返し、fetchを一切呼ばない', async () => {
+      mockLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+      const fetchSpy = jest.fn();
+      global.fetch = fetchSpy as unknown as typeof global.fetch;
+
+      const result = await enricher.enrich(
+        'https://attacker-controlled.example/'
+      );
+
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('クラウドメタデータIP(169.254.169.254)に解決されるURLはnullを返し、fetchを一切呼ばない', async () => {
+      mockLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+      const fetchSpy = jest.fn();
+      global.fetch = fetchSpy as unknown as typeof global.fetch;
+
+      const result = await enricher.enrich(
+        'https://attacker-controlled.example/'
+      );
+
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('ループバック(127.0.0.1)に解決されるURLはリトライせずnullを返す', async () => {
+      mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+      const fetchSpy = jest.fn();
+      global.fetch = fetchSpy as unknown as typeof global.fetch;
+
+      const result = await enricher.enrich(
+        'https://attacker-controlled.example/'
+      );
+
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      // maxRetries=2 だが、SSRFガードで即座に失敗するためDNS lookupは1回のみ
+      expect(mockLookup).toHaveBeenCalledTimes(1);
+    });
+
+    it('file: スキームのURLはDNS解決すら行わずnullを返す', async () => {
+      const fetchSpy = jest.fn();
+      global.fetch = fetchSpy as unknown as typeof global.fetch;
+
+      const result = await enricher.enrich('file:///etc/passwd');
+
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+
+    it('拒否時はエラーログを残す', async () => {
+      mockLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+      global.fetch = jest.fn() as unknown as typeof global.fetch;
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+      await enricher.enrich('https://attacker-controlled.example/');
+
+      // ssrf-guard 自身の warn ログ（理由付き）
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: 'forbidden_ip_range',
+          url: 'https://attacker-controlled.example/',
+        }),
+        '[SsrfGuard] Blocked outbound request'
+      );
+      // generic.ts 側のエラーログ
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://attacker-controlled.example/',
+        }),
+        '[GenericEnricher] URL rejected by SSRF guard'
+      );
+
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('正当なURLは通過する（回帰）', () => {
+    const buildHtml = (title: string) => `
+      <!DOCTYPE html>
+      <html>
+        <head><title>${title}</title></head>
+        <body>
+          <article>
+            <h1>${title}</h1>
+            <p>${'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '.repeat(20)}</p>
+          </article>
+        </body>
+      </html>
+    `;
+
+    it.each([
+      'https://zenn.dev/user/articles/sample',
+      'https://github.com/example/repo',
+      'https://aws.amazon.com/blogs/compute/example-article',
+    ])(
+      '%s は公開IPに解決される場合、SSRFガードを通過してコンテンツを取得できる',
+      async (url) => {
+        mockLookup.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+        global.fetch = jest.fn().mockResolvedValue({
+          ok: true,
+          url,
+          text: async () => buildHtml('Representative Domain Article'),
+        }) as unknown as typeof global.fetch;
+
+        const result = await enricher.enrich(url);
+
+        expect(result).not.toBeNull();
+        expect(result?.content).toContain('Representative Domain Article');
+      }
+    );
+  });
+});

--- a/lib/enrichers/base.ts
+++ b/lib/enrichers/base.ts
@@ -6,6 +6,7 @@
 import * as cheerio from 'cheerio';
 import logger from '@/lib/logger';
 import { classifyEnrichmentError } from './error-classifier';
+import { assertPublicHttpUrl } from '@/lib/utils/url/ssrf-guard';
 
 /**
  * エンリッチされたコンテンツのデータ構造
@@ -113,6 +114,11 @@ export abstract class BaseContentEnricher implements IContentEnricher {
     url: string,
     externalSignal?: AbortSignal
   ): Promise<string> {
+    // SSRF ガード: DNS解決を含む検証。拒否時はリトライしても無駄なので、
+    // retry ループに入る前に即座に throw する（呼び出し元 enrich() の catch が
+    // logEnrichmentError で記録し null を返す、既存のエラーハンドリングに乗る）
+    await assertPublicHttpUrl(url, { enricher: this.constructor.name });
+
     let lastError: Error | null = null;
     let previousWas429 = false;
 

--- a/lib/enrichers/generic.ts
+++ b/lib/enrichers/generic.ts
@@ -2,6 +2,7 @@ import { BaseContentEnricher, EnrichmentResult } from './base';
 import * as cheerio from 'cheerio';
 import type { CheerioAPI } from 'cheerio';
 import logger from '@/lib/logger';
+import { assertPublicHttpUrl } from '@/lib/utils/url/ssrf-guard';
 import {
   extractWithReadability,
   extractFromJsonLd,
@@ -27,6 +28,19 @@ export class GenericContentEnricher extends BaseContentEnricher {
     url: string,
     externalSignal?: AbortSignal
   ): Promise<EnrichmentResult | null> {
+    // SSRF ガード: DNS解決を含む検証。拒否時はリトライしても無駄なので、
+    // retry ループに入る前に即座に null を返す（enrich() は既存契約上 throw
+    // しないため、base.ts の fetchWithRetry とは異なりここで catch して吸収する）
+    try {
+      await assertPublicHttpUrl(url, { enricher: this.constructor.name });
+    } catch (error) {
+      logger.error(
+        { err: error, url },
+        '[GenericEnricher] URL rejected by SSRF guard'
+      );
+      return null;
+    }
+
     const maxRetries = 2;
     let previousWas429 = false;
 

--- a/lib/utils/url/__tests__/ssrf-guard.test.ts
+++ b/lib/utils/url/__tests__/ssrf-guard.test.ts
@@ -1,0 +1,179 @@
+/**
+ * ssrf-guard のユニットテスト
+ *
+ * dns.promises.lookup は jest.setup.node.js でグローバルにモックされている
+ * （デフォルトでは公開IP 203.0.113.10 を返す）。このファイルでは各テストケースごとに
+ * mockResolvedValue / mockRejectedValue で戻り値を上書きし、実 DNS には一切依存しない。
+ */
+
+import dns from 'dns';
+import { assertPublicHttpUrl, SsrfGuardError } from '../ssrf-guard';
+
+const mockLookup = dns.promises.lookup as jest.Mock;
+
+describe('assertPublicHttpUrl', () => {
+  beforeEach(() => {
+    mockLookup.mockReset();
+  });
+
+  describe('許可ケース', () => {
+    it('公開IPv4に解決される通常のドメインは許可される', async () => {
+      mockLookup.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+
+      await expect(
+        assertPublicHttpUrl('https://example.com/article')
+      ).resolves.toBeUndefined();
+      expect(mockLookup).toHaveBeenCalledWith('example.com', { all: true });
+    });
+
+    it('公開IPv6に解決される通常のドメインは許可される', async () => {
+      mockLookup.mockResolvedValue([{ address: '2001:db8::1', family: 6 }]);
+
+      await expect(
+        assertPublicHttpUrl('https://example.com/article')
+      ).resolves.toBeUndefined();
+    });
+
+    it('解決された全アドレスが公開範囲であれば許可される（複数レコード）', async () => {
+      mockLookup.mockResolvedValue([
+        { address: '203.0.113.10', family: 4 },
+        { address: '203.0.113.11', family: 4 },
+      ]);
+
+      await expect(
+        assertPublicHttpUrl('https://example.com/article')
+      ).resolves.toBeUndefined();
+    });
+
+    it('公開IPにマップされた IPv4-mapped IPv6 は許可される', async () => {
+      mockLookup.mockResolvedValue([
+        { address: '::ffff:203.0.113.10', family: 6 },
+      ]);
+
+      await expect(
+        assertPublicHttpUrl('https://example.com/article')
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('拒否ケース - スキーム', () => {
+    it.each([
+      'file:///etc/passwd',
+      'ftp://example.com/file',
+      'gopher://example.com/',
+      'data:text/plain;base64,aGVsbG8=',
+    ])('%s のような非 http/https スキームは拒否される', async (url) => {
+      await expect(assertPublicHttpUrl(url)).rejects.toThrow(SsrfGuardError);
+      // スキームチェックはDNS解決の前に行われ、無駄なDNS問い合わせをしない
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+
+    it('パース不能なURL文字列は拒否される', async () => {
+      const error = await assertPublicHttpUrl('not a url').catch((e) => e);
+      expect(error).toBeInstanceOf(SsrfGuardError);
+      expect((error as SsrfGuardError).reason).toBe('invalid_url');
+      expect(mockLookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('拒否ケース - DNS解決失敗 (fail-closed)', () => {
+    it('DNS解決がrejectした場合は拒否される', async () => {
+      mockLookup.mockRejectedValue(new Error('ENOTFOUND nonexistent.example'));
+
+      const error = await assertPublicHttpUrl(
+        'https://nonexistent.example/'
+      ).catch((e) => e);
+      expect(error).toBeInstanceOf(SsrfGuardError);
+      expect((error as SsrfGuardError).reason).toBe('dns_resolution_failed');
+    });
+
+    it('DNS解決結果が空配列の場合は拒否される', async () => {
+      mockLookup.mockResolvedValue([]);
+
+      const error = await assertPublicHttpUrl('https://example.com/').catch(
+        (e) => e
+      );
+      expect(error).toBeInstanceOf(SsrfGuardError);
+      expect((error as SsrfGuardError).reason).toBe('dns_no_addresses');
+    });
+  });
+
+  describe('拒否ケース - 禁止IPレンジ', () => {
+    it.each([
+      ['ループバック 127.0.0.1', '127.0.0.1', 4],
+      ['ループバック ::1', '::1', 6],
+      ['プライベート 10.0.0.0/8', '10.1.2.3', 4],
+      ['プライベート 172.16.0.0/12', '172.20.1.1', 4],
+      ['プライベート 192.168.0.0/16', '192.168.1.1', 4],
+      [
+        'リンクローカル 169.254.0.0/16 (クラウドメタデータ)',
+        '169.254.169.254',
+        4,
+      ],
+      ['リンクローカル fe80::/10', 'fe80::1', 6],
+      ['IPv6 ULA fc00::/7', 'fd12:3456:789a::1', 6],
+      ['未指定 0.0.0.0', '0.0.0.0', 4],
+      ['ブロードキャスト 255.255.255.255', '255.255.255.255', 4],
+      ['未指定 ::', '::', 6],
+    ])('%s に解決される場合は拒否される', async (_label, address, family) => {
+      mockLookup.mockResolvedValue([{ address, family }]);
+
+      const error = await assertPublicHttpUrl('https://evil.example/').catch(
+        (e) => e
+      );
+      expect(error).toBeInstanceOf(SsrfGuardError);
+      expect((error as SsrfGuardError).reason).toBe('forbidden_ip_range');
+    });
+
+    it('IPv4-mapped IPv6（ドット十進表記: ::ffff:10.0.0.5）は内側のIPv4として拒否される', async () => {
+      mockLookup.mockResolvedValue([{ address: '::ffff:10.0.0.5', family: 6 }]);
+
+      await expect(
+        assertPublicHttpUrl('https://evil.example/')
+      ).rejects.toThrow(SsrfGuardError);
+    });
+
+    it('IPv4-mapped IPv6（16進グループ表記: ::ffff:a00:5 = ::ffff:10.0.0.5）も拒否される', async () => {
+      mockLookup.mockResolvedValue([{ address: '::ffff:a00:5', family: 6 }]);
+
+      await expect(
+        assertPublicHttpUrl('https://evil.example/')
+      ).rejects.toThrow(SsrfGuardError);
+    });
+
+    it('複数レコードのうち1件でも禁止レンジに該当すれば拒否される', async () => {
+      mockLookup.mockResolvedValue([
+        { address: '203.0.113.10', family: 4 },
+        { address: '169.254.169.254', family: 4 },
+      ]);
+
+      await expect(
+        assertPublicHttpUrl('https://evil.example/')
+      ).rejects.toThrow(SsrfGuardError);
+    });
+  });
+
+  describe('IPリテラルホスト名', () => {
+    it('http://10.0.0.5/ のようなIPv4リテラルホストも拒否される', async () => {
+      // dns.lookup はIPリテラルに対してもそのまま同じIPを返すため、
+      // 通常ドメインと同じ経路で判定できる（実装コメント参照）
+      mockLookup.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+
+      await expect(assertPublicHttpUrl('http://10.0.0.5/')).rejects.toThrow(
+        SsrfGuardError
+      );
+      expect(mockLookup).toHaveBeenCalledWith('10.0.0.5', { all: true });
+    });
+
+    it('http://[::1]/ のようなIPv6リテラルは brackets を除去してDNS解決される', async () => {
+      mockLookup.mockResolvedValue([{ address: '::1', family: 6 }]);
+
+      await expect(assertPublicHttpUrl('http://[::1]/')).rejects.toThrow(
+        SsrfGuardError
+      );
+      // brackets付きのまま渡すと dns.lookup が ENOTFOUND になるため、
+      // 除去されたホスト名で呼ばれていることを検証する
+      expect(mockLookup).toHaveBeenCalledWith('::1', { all: true });
+    });
+  });
+});

--- a/lib/utils/url/ssrf-guard.ts
+++ b/lib/utils/url/ssrf-guard.ts
@@ -1,0 +1,174 @@
+/**
+ * SSRF Guard
+ *
+ * lib/utils/url/url-validator.ts の関数群は URL 文字列を静的にパースするだけで、
+ * DNS 解決を一切行わない。そのため攻撃者が保有するドメインの A/AAAA レコードを
+ * 内部 IP（例: 10.0.0.5, 169.254.169.254 のクラウドメタデータ等）に向けるだけで
+ * 容易に迂回できてしまい、SSRF 対策としては機能しない。
+ *
+ * このモジュールは実際に DNS 解決を行い、解決された「全ての」IP アドレスを
+ * ループバック/プライベート/リンクローカル等のレンジと突き合わせて拒否する。
+ * IPv4-mapped IPv6（例: ::ffff:10.0.0.5）も Node.js 標準の `net.BlockList` が
+ * 内部で自動的にアンラップして判定するため、追加のパース処理は不要。
+ *
+ * 想定利用箇所（Issue #633）:
+ * - lib/enrichers/base.ts の fetchWithRetry
+ * - lib/enrichers/generic.ts の独自 fetch
+ *
+ * フィード投稿者が任意ドメインの URL を持ち込める経路（Hacker News / Lobsters /
+ * はてなブックマーク由来の記事で、既知ドメイン allowlist を持つ専用 enricher に
+ * 一致しなかったもの）から、内部ネットワークやクラウドメタデータサービスへの
+ * リクエストを防ぐことが目的。
+ *
+ * スコープ外（別 PR で対応）:
+ * - リダイレクト追従時の再検証（fetch の `redirect` オプションは変更しない）
+ * - undici custom dispatcher による TOCTOU / DNS rebinding 対策
+ *
+ * @module ssrf-guard
+ */
+
+import dns from 'dns';
+import { BlockList } from 'net';
+import logger from '@/lib/logger';
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+export type SsrfRejectionReason =
+  | 'invalid_url'
+  | 'disallowed_protocol'
+  | 'dns_resolution_failed'
+  | 'dns_no_addresses'
+  | 'forbidden_ip_range';
+
+/** SSRF ガードによる拒否を表す例外 */
+export class SsrfGuardError extends Error {
+  readonly reason: SsrfRejectionReason;
+
+  constructor(message: string, reason: SsrfRejectionReason) {
+    super(message);
+    this.name = 'SsrfGuardError';
+    this.reason = reason;
+  }
+}
+
+// 拒否対象の IP レンジ（IPv4 / IPv6）。モジュールロード時に一度だけ構築する。
+const forbiddenRanges = new BlockList();
+
+// ループバック
+forbiddenRanges.addSubnet('127.0.0.0', 8, 'ipv4');
+forbiddenRanges.addSubnet('::1', 128, 'ipv6');
+
+// プライベート
+forbiddenRanges.addSubnet('10.0.0.0', 8, 'ipv4');
+forbiddenRanges.addSubnet('172.16.0.0', 12, 'ipv4');
+forbiddenRanges.addSubnet('192.168.0.0', 16, 'ipv4');
+forbiddenRanges.addSubnet('fc00::', 7, 'ipv6'); // IPv6 ULA
+
+// リンクローカル（169.254.169.254 のクラウドメタデータサービスを含む）
+forbiddenRanges.addSubnet('169.254.0.0', 16, 'ipv4');
+forbiddenRanges.addSubnet('fe80::', 10, 'ipv6');
+
+// 未指定・ブロードキャスト
+forbiddenRanges.addAddress('0.0.0.0', 'ipv4');
+forbiddenRanges.addAddress('255.255.255.255', 'ipv4');
+forbiddenRanges.addAddress('::', 'ipv6');
+
+/**
+ * DNS 解決を含む、出力先 URL の SSRF 安全性検証。
+ *
+ * 1. http:/https: 以外のスキームを拒否
+ * 2. ホスト名を `dns.promises.lookup(hostname, { all: true })` で解決し、
+ *    全ての解決先 IP をプライベート/ループバック/リンクローカル等のレンジと照合
+ * 3. DNS 解決に失敗した場合は fail-closed（拒否）
+ *
+ * 検証に成功した場合は何も返さない（void）。失敗した場合は必ず {@link SsrfGuardError}
+ * を throw する。呼び出し側は既存のエラーハンドリング（リトライループ・!response.ok
+ * 判定）と整合する形で catch すること（詳細は base.ts / generic.ts の適用箇所を参照）。
+ *
+ * @param urlString 検証対象の URL
+ * @param context ログに含める追加コンテキスト（呼び出し元の enricher 名等）
+ * @throws {SsrfGuardError} 検証に失敗した場合
+ */
+export async function assertPublicHttpUrl(
+  urlString: string,
+  context?: Record<string, unknown>
+): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    logRejection(urlString, 'invalid_url', context);
+    throw new SsrfGuardError(`Invalid URL: ${urlString}`, 'invalid_url');
+  }
+
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+    logRejection(urlString, 'disallowed_protocol', {
+      protocol: url.protocol,
+      ...context,
+    });
+    throw new SsrfGuardError(
+      `Disallowed protocol "${url.protocol}" for ${urlString}`,
+      'disallowed_protocol'
+    );
+  }
+
+  // IPv6 リテラルは URL.hostname が "[::1]" のように brackets を含むため
+  // dns.lookup に渡す前に除去する（brackets 付きのままだと ENOTFOUND になる）
+  const hostname = stripBrackets(url.hostname);
+
+  let addresses: { address: string; family: number }[];
+  try {
+    addresses = await dns.promises.lookup(hostname, { all: true });
+  } catch (error) {
+    logRejection(urlString, 'dns_resolution_failed', {
+      hostname,
+      errorMessage: error instanceof Error ? error.message : String(error),
+      ...context,
+    });
+    throw new SsrfGuardError(
+      `DNS resolution failed for host "${hostname}"`,
+      'dns_resolution_failed'
+    );
+  }
+
+  if (addresses.length === 0) {
+    logRejection(urlString, 'dns_no_addresses', { hostname, ...context });
+    throw new SsrfGuardError(
+      `DNS resolution returned no addresses for host "${hostname}"`,
+      'dns_no_addresses'
+    );
+  }
+
+  for (const { address, family } of addresses) {
+    const type = family === 6 ? 'ipv6' : 'ipv4';
+    if (forbiddenRanges.check(address, type)) {
+      logRejection(urlString, 'forbidden_ip_range', {
+        hostname,
+        address,
+        ...context,
+      });
+      throw new SsrfGuardError(
+        `Resolved address "${address}" for host "${hostname}" is in a forbidden IP range`,
+        'forbidden_ip_range'
+      );
+    }
+  }
+}
+
+function stripBrackets(hostname: string): string {
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
+}
+
+function logRejection(
+  url: string,
+  reason: SsrfRejectionReason,
+  details?: Record<string, unknown>
+): void {
+  logger.warn(
+    { url, reason, ...details },
+    '[SsrfGuard] Blocked outbound request'
+  );
+}

--- a/lib/utils/url/url-validator.ts
+++ b/lib/utils/url/url-validator.ts
@@ -1,8 +1,17 @@
 /**
  * URL Validator Utility
  *
- * Provides secure URL validation functions to prevent SSRF and open redirect vulnerabilities.
- * Uses URL API for robust domain validation instead of string matching.
+ * Provides string-based URL parsing/validation helpers (domain matching, scheme
+ * checks, format checks). Uses the URL API for robust parsing instead of ad-hoc
+ * string matching, which prevents path-based domain spoofing (e.g. distinguishing
+ * `evil.com/github.com` from an actual `github.com` URL).
+ *
+ * IMPORTANT: These functions do NOT perform DNS resolution and therefore do NOT
+ * prevent SSRF on their own — an attacker-controlled domain can still resolve to
+ * an internal IP (e.g. 10.0.0.5, 169.254.169.254) and pass every check here.
+ * For SSRF-safe validation before making an outbound request, use
+ * `assertPublicHttpUrl` from `./ssrf-guard`, which resolves DNS and checks the
+ * resolved IPs against private/loopback/link-local ranges.
  *
  * @module url-validator
  */
@@ -17,16 +26,21 @@
  * @param expectedDomain - The expected domain (e.g., 'github.com')
  * @returns True if the URL belongs to the expected domain
  */
-export function isUrlFromDomain(urlString: string, expectedDomain: string): boolean {
+export function isUrlFromDomain(
+  urlString: string,
+  expectedDomain: string
+): boolean {
   try {
     const url = new URL(urlString);
     const hostname = url.hostname.toLowerCase();
     const expected = expectedDomain.toLowerCase();
 
     // Check for exact match or with www prefix or as subdomain
-    return hostname === expected ||
-           hostname === `www.${expected}` ||
-           hostname.endsWith(`.${expected}`);
+    return (
+      hostname === expected ||
+      hostname === `www.${expected}` ||
+      hostname.endsWith(`.${expected}`)
+    );
   } catch {
     // Invalid URL
     return false;


### PR DESCRIPTION
## 概要

Issue #633 に対し、コンテンツエンリッチメント経路に **DNS 解決を含む** SSRF ガードを追加します。

## 脅威モデル

| 項目 | 内容 |
|---|---|
| 攻撃者 | フィード投稿者（Hacker News / Lobsters / はてなブックマークの3ソース経由） |
| 到達経路 | cron のみ（`app/api/**` に到達経路がないことを grep で確認済み） |
| 到達先 | `GenericContentEnricher`（`canHandle()` が全URLに true を返す最終フォールバック） |
| 実害 | `GET /api/articles` は無認証公開かつエンリッチャーは fetch 応答本文を記事として保存するため、**内部専用サービスの応答が「公開記事」として持ち出される**情報開示パスが成立 |

## DNS 解決を必須要件とした理由（設計上の要点）

既存の `lib/utils/url/url-validator.ts` は docblock で `prevent SSRF and open redirect vulnerabilities` と主張していますが、**実装は DNS 解決を一切行わない文字列処理のみ**です。

この方式を踏襲すると、攻撃者が**自分が保有するドメインの A レコードを内部 IP（`10.0.0.5` や `169.254.169.254` 等）に向けるだけで迂回でき、防御効果がほぼゼロになります**。これは DNS rebinding のような高度な攻撃ではなく、ドメインを1つ持っていれば誰でも実行できる最も基本的なケースです。

本 PR では `dns.promises.lookup(hostname, { all: true })` で解決した**全ての** IP アドレスを検証します。誤解を招く既存 docblock も併せて修正しました。

## 実装

`lib/utils/url/ssrf-guard.ts` に `assertPublicHttpUrl()` を新設しました。

- **スキーム**: http / https 以外を拒否
- **DNS 解決**: 全解決先 IP を取得し、1つでも禁止レンジに該当すれば拒否
- **禁止レンジ**: ループバック（`127.0.0.0/8`, `::1`）/ プライベート（`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `fc00::/7`）/ リンクローカル（`169.254.0.0/16`, `fe80::/10`）/ 未指定・ブロードキャスト
- **DNS 解決失敗時**: fail-closed（拒否）

### IP レンジ判定に Node 標準の `net.BlockList` を使用

`ipaddr.js` / `ip-address` は transitive 依存としてのみ存在し直接依存ではないため、新規依存の追加を避けました。`net.BlockList` は **IPv4-mapped IPv6 を IPv4 サブネットとして自動判定**するため、迂回経路を塞げます。実地検証結果:

```
ipv4 direct 10.0.0.5            : true
mapped ::ffff:10.0.0.5          : true
mapped hex ::ffff:a00:5         : true
metadata ::ffff:169.254.169.254 : true
loopback ::ffff:127.0.0.1       : true
public 93.184.216.34            : false
```

### その他の実装上の発見

- WHATWG `URL` は 8進数（`0177.0.0.1`）・16進数（`0x7f000001`）・10進数（`2130706433`）の IPv4 難読化表記を正規化するため、追加処理は不要
- IPv6 リテラルの `hostname` は brackets 付き（`"[::1]"`）で返るため、`dns.lookup` 前に除去が必要（しないと ENOTFOUND で fail-closed に倒れるが、意図しない挙動になる）

## 適用範囲を 2 箇所に絞った根拠

`ContentEnricherFactory`（`lib/enrichers/index.ts:78-131`）のディスパッチ順序上、攻撃者由来の未知ドメイン URL は**必ず** `GenericContentEnricher` に到達します。

- `HatenaContentEnricher`: 約10件の固定ドメイン allowlist
- `HackerNewsEnricher`: 13件の allowlist をホスト名の厳密一致/サフィックス一致で判定
- Lobsters 専用 enricher は存在しない

したがって `generic.ts` + 共有 `fetchWithRetry` の 2 箇所で実効的なカバレッジが得られます。独自 fetch を持つ他エンリッチャー（anthropic-blog / aws / cloudflare-blog / github-blog / medium-engineering / mozilla-hacks / speakerdeck / zenn / anthropic-news）はいずれも固定ホストの allowlist でゲート済みで、適用してもリスク低減効果は小さい一方、**誤検知による収集停止の副作用だけが増える**ため意図的に除外しています。

検証はリトライループの**外**で 1 回だけ実行します（拒否は再試行しても結果が変わらないため）。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `lib/utils/url/ssrf-guard.ts` | 新規。`assertPublicHttpUrl()` |
| `lib/utils/url/url-validator.ts` | docblock のみ修正（SSRF 防止の主張を撤回し ssrf-guard.ts を参照） |
| `lib/enrichers/base.ts` | `fetchWithRetry` にガード適用（throw、既存の catch-and-log 契約に整合） |
| `lib/enrichers/generic.ts` | 独自 fetch にガード適用（null 返却、既存の never-throw 契約に整合） |
| `lib/utils/url/__tests__/ssrf-guard.test.ts` | 新規27件 |
| `lib/enrichers/__tests__/generic.test.ts` | **新規8件**（従来このファイル自体が存在せず、最もガードが効くべき enricher が未テストだった） |
| `lib/enrichers/__tests__/base.test.ts` | ガード適用後の `fetchWithRetry` を直接検証するテスト追加 |
| `jest.setup.node.js` | グローバル DNS モック（既存の `global.fetch` モックと同じ方式） |

`jest.setup.node.js` でグローバルにモックしたのは、共有 `fetchWithRetry` を使うエンリッチャーが 3 つの異なるテストディレクトリツリーに散在する約15個に及ぶためです。個別モックだと 10 箇所以上の分散した修正が必要になります。

## 検証

- 型チェック: `npx tsc --noEmit` → エラーなし
- **ビルド: `npm run docker:build` → 成功**
- テスト: `lib/enrichers/__tests__` → **7 suites / 135 passed**
- 全テストスイート → 0 failures（288/291 suites、3件は変更と無関係な既存 skip）
- 回帰テスト: `zenn.dev` / `github.com` / `aws.amazon.com` が通ることを検証
- DB変更なし

## スコープ外（別PRで対応）

- **リダイレクト追従の安全化**: `redirect: 'manual'` 化は `generic.ts:78` の `response.url` 依存（追従後の最終URLを相対パス解決に使用）と `base.ts` の `!response.ok` 判定（3xx がエラー化する）の改修を要し、**影響が攻撃者到達可能な3ソースではなく全76ソースに及ぶ**ため分離しました。ホップ数上限と各ホップでの IP 再検証を伴う手動追従の実装が必要です
- **undici dispatcher による TOCTOU / DNS rebinding 対策**: 到達可能な攻撃主体が cron 経由の3ソースに限られる現状では費用対効果が見合わないと判断しました

🤖 Generated with [Claude Code](https://claude.com/claude-code)