### PR TITLE
fix(security): Basic 認証を署名付き Cookie ゲート化し Safari の再入力を解消

### DIFF
--- a/__tests__/middleware.node.test.ts
+++ b/__tests__/middleware.node.test.ts
@@ -7,9 +7,13 @@ describe('middleware - security headers', () => {
   afterEach(() => {
     process.env.NODE_ENV = originalEnv;
     delete process.env.BASIC_AUTH_ENABLED;
+    delete process.env.BASIC_AUTH_USER;
     delete process.env.BASIC_AUTH_PASS;
+    delete process.env.BASIC_PASSWORD;
+    delete process.env.BASIC_AUTH_GATE_SECRET;
     delete process.env.CRON_TOKEN;
     delete process.env.CRON_SECRET;
+    delete process.env.MAINTENANCE_MODE;
   });
 
   describe('Security headers設定', () => {
@@ -131,6 +135,7 @@ describe('middleware - security headers', () => {
     it('should maintain Basic Auth when enabled', async () => {
       process.env.BASIC_AUTH_ENABLED = 'true';
       process.env.BASIC_AUTH_PASS = 'secret';
+      process.env.BASIC_AUTH_GATE_SECRET = 'f'.repeat(64);
 
       const request = new NextRequest(new URL('http://localhost:3000/'));
       const response = await proxy(request);
@@ -142,6 +147,7 @@ describe('middleware - security headers', () => {
     it('should allow cron requests with valid CRON_SECRET without Basic Auth', async () => {
       process.env.BASIC_AUTH_ENABLED = 'true';
       process.env.BASIC_AUTH_PASS = 'secret';
+      process.env.BASIC_AUTH_GATE_SECRET = 'f'.repeat(64);
       process.env.CRON_TOKEN = 'test-cron-secret';
 
       const request = new NextRequest(new URL('http://localhost:3000/'));
@@ -177,6 +183,221 @@ describe('middleware - security headers', () => {
       // Verify both headers are set
       expect(response.headers.get('content-security-policy')).toBeDefined();
       expect(response.headers.get('x-theme')).toBeDefined();
+    });
+  });
+
+  describe('Basic 認証ゲート（署名付き Cookie）', () => {
+    const GATE_SECRET = 'f'.repeat(64);
+    const USER = 'user';
+    const PASS = 'secret';
+
+    const basicHeader = (user = USER, pass = PASS): string =>
+      `Basic ${Buffer.from(`${user}:${pass}`, 'utf8').toString('base64')}`;
+
+    const enableBasicAuth = (): void => {
+      process.env.BASIC_AUTH_ENABLED = 'true';
+      process.env.BASIC_AUTH_USER = USER;
+      process.env.BASIC_AUTH_PASS = PASS;
+      process.env.BASIC_AUTH_GATE_SECRET = GATE_SECRET;
+    };
+
+    /** レスポンスの Set-Cookie から `name=value` の部分だけを取り出す */
+    const gateCookiePair = (response: Response): string | null => {
+      const setCookie = response.headers.get('set-cookie');
+      return setCookie ? setCookie.split(';')[0] : null;
+    };
+
+    const requestWith = (
+      path: string,
+      headers: Record<string, string> = {},
+      origin = 'http://localhost:3000'
+    ): NextRequest =>
+      new NextRequest(new URL(`${origin}${path}`), { headers });
+
+    it('M1: 認証情報なしなら charset 付き challenge と no-store を返し Cookie は発行しない', async () => {
+      enableBasicAuth();
+
+      const response = await proxy(requestWith('/'));
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get('WWW-Authenticate')).toBe(
+        'Basic realm="Protected", charset="UTF-8"'
+      );
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+      expect(response.headers.get('set-cookie')).toBeNull();
+      expect(response.headers.get('Content-Security-Policy')).toBeTruthy();
+    });
+
+    it('M2: Basic 認証成功でゲート Cookie を発行する', async () => {
+      enableBasicAuth();
+
+      const response = await proxy(
+        requestWith('/', { authorization: basicHeader() })
+      );
+
+      expect(response.status).not.toBe(401);
+      const setCookie = response.headers.get('set-cookie');
+      expect(setCookie).toContain('tt_gate=');
+      expect(setCookie).toContain('HttpOnly');
+      expect(setCookie).toContain('SameSite=Lax');
+      expect(setCookie).toContain('Path=/');
+      expect(setCookie).toContain('Max-Age=604800');
+      expect(setCookie).not.toContain('Domain');
+      // Set-Cookie を含む応答は共有キャッシュに載せない
+      expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    });
+
+    it('M3: 有効なゲート Cookie だけで通り、Cookie は再発行されない', async () => {
+      enableBasicAuth();
+      const issued = await proxy(
+        requestWith('/', { authorization: basicHeader() })
+      );
+      const cookie = gateCookiePair(issued);
+      expect(cookie).toBeTruthy();
+
+      const response = await proxy(requestWith('/', { cookie: cookie! }));
+
+      expect(response.status).not.toBe(401);
+      expect(response.headers.get('set-cookie')).toBeNull();
+    });
+
+    it('M4: 改ざんしたゲート Cookie だけなら 401', async () => {
+      enableBasicAuth();
+
+      const response = await proxy(
+        requestWith('/', { cookie: 'tt_gate=v1.9999999999.tampered' })
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it('M5: 改ざん Cookie でも正しい Basic があれば通り Cookie を上書きする', async () => {
+      enableBasicAuth();
+
+      const response = await proxy(
+        requestWith('/', {
+          cookie: 'tt_gate=v1.9999999999.tampered',
+          authorization: basicHeader(),
+        })
+      );
+
+      expect(response.status).not.toBe(401);
+      expect(response.headers.get('set-cookie')).toContain('tt_gate=');
+    });
+
+    it('M6: cron Bearer ではゲート Cookie を発行しない', async () => {
+      enableBasicAuth();
+      process.env.CRON_TOKEN = 'test-cron-secret';
+
+      const response = await proxy(
+        requestWith('/', { authorization: 'Bearer test-cron-secret' })
+      );
+
+      expect(response.status).not.toBe(401);
+      expect(response.headers.get('set-cookie')).toBeNull();
+    });
+
+    it('M7: メンテナンス 503 の経路でもゲート Cookie を発行する', async () => {
+      enableBasicAuth();
+      process.env.MAINTENANCE_MODE = 'true';
+
+      const response = await proxy(
+        requestWith('/', { authorization: basicHeader() })
+      );
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get('set-cookie')).toContain('tt_gate=');
+    });
+
+    it('M8: ログインリダイレクトの経路でもゲート Cookie を発行する', async () => {
+      enableBasicAuth();
+
+      const response = await proxy(
+        requestWith('/profile', { authorization: basicHeader() })
+      );
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toContain('/auth/login');
+      expect(response.headers.get('set-cookie')).toContain('tt_gate=');
+    });
+
+    it('M9: 保護 API の 401 ではセキュリティヘッダが付き Cookie は発行しない', async () => {
+      enableBasicAuth();
+
+      const response = await proxy(
+        requestWith('/api/favorites', { authorization: basicHeader() })
+      );
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get('Content-Security-Policy')).toBeTruthy();
+      // /api/* は公開キャッシュヘッダを返す経路があるため Cookie を載せない
+      expect(response.headers.get('set-cookie')).toBeNull();
+    });
+
+    it('M10: /api/* にはゲート Cookie を発行しない', async () => {
+      enableBasicAuth();
+
+      const response = await proxy(
+        requestWith('/api/stats', { authorization: basicHeader() })
+      );
+
+      expect(response.status).not.toBe(401);
+      expect(response.headers.get('set-cookie')).toBeNull();
+    });
+
+    it('M11: 有効化されているのにパスワードが未設定なら 503（fail-closed）', async () => {
+      process.env.BASIC_AUTH_ENABLED = 'true';
+      process.env.BASIC_AUTH_GATE_SECRET = GATE_SECRET;
+
+      const response = await proxy(requestWith('/'));
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get('set-cookie')).toBeNull();
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+    });
+
+    it('M12: 署名鍵が未設定なら 503（fail-closed）', async () => {
+      process.env.BASIC_AUTH_ENABLED = 'true';
+      process.env.BASIC_AUTH_PASS = PASS;
+
+      const response = await proxy(requestWith('/'));
+
+      expect(response.status).toBe(503);
+    });
+
+    it('M13: Basic 認証 OFF ならゲート Cookie を一切発行しない', async () => {
+      const response = await proxy(requestWith('/'));
+
+      expect(response.status).not.toBe(401);
+      expect(response.headers.get('set-cookie')).toBeNull();
+    });
+
+    it('M14: production かつ HTTPS では __Host- prefix と Secure が付く', async () => {
+      process.env.NODE_ENV = 'production';
+      enableBasicAuth();
+
+      const response = await proxy(
+        requestWith('/', { authorization: basicHeader() }, 'https://example.com')
+      );
+
+      const setCookie = response.headers.get('set-cookie');
+      expect(setCookie).toContain('__Host-tt_gate=');
+      expect(setCookie).toContain('Secure');
+      expect(setCookie).toContain('Path=/');
+      expect(setCookie).not.toContain('Domain');
+    });
+
+    it('M15: development かつ HTTP では prefix も Secure も付かない', async () => {
+      enableBasicAuth();
+
+      const response = await proxy(
+        requestWith('/', { authorization: basicHeader() })
+      );
+
+      const setCookie = response.headers.get('set-cookie');
+      expect(setCookie).toContain('tt_gate=');
+      expect(setCookie).not.toContain('__Host-');
+      expect(setCookie).not.toContain('Secure');
     });
   });
 });

--- a/__tests__/middleware.node.test.ts
+++ b/__tests__/middleware.node.test.ts
@@ -245,6 +245,9 @@ describe('middleware - security headers', () => {
       expect(setCookie).not.toContain('Domain');
       // Set-Cookie を含む応答は共有キャッシュに載せない
       expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+      expect(response.headers.get('CDN-Cache-Control')).toBeNull();
+      expect(response.headers.get('Vary')).toContain('Cookie');
+      expect(response.headers.get('Vary')).toContain('Authorization');
     });
 
     it('M3: 有効なゲート Cookie だけで通り、Cookie は再発行されない', async () => {
@@ -259,6 +262,10 @@ describe('middleware - security headers', () => {
 
       expect(response.status).not.toBe(401);
       expect(response.headers.get('set-cookie')).toBeNull();
+      // Cookie 通過時もゲート配下のページなので共有キャッシュに載せない
+      expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+      expect(response.headers.get('CDN-Cache-Control')).toBeNull();
+      expect(response.headers.get('Vary')).toContain('Cookie');
     });
 
     it('M4: 改ざんしたゲート Cookie だけなら 401', async () => {
@@ -307,6 +314,9 @@ describe('middleware - security headers', () => {
 
       expect(response.status).toBe(503);
       expect(response.headers.get('set-cookie')).toContain('tt_gate=');
+      // Cookie を含む応答は共有キャッシュ用ヘッダを持たない
+      expect(response.headers.get('CDN-Cache-Control')).toBeNull();
+      expect(response.headers.get('Content-Security-Policy')).toBeTruthy();
     });
 
     it('M8: ログインリダイレクトの経路でもゲート Cookie を発行する', async () => {
@@ -319,6 +329,8 @@ describe('middleware - security headers', () => {
       expect(response.status).toBe(307);
       expect(response.headers.get('location')).toContain('/auth/login');
       expect(response.headers.get('set-cookie')).toContain('tt_gate=');
+      // Cookie を含む応答は共有キャッシュ用ヘッダを持たない
+      expect(response.headers.get('CDN-Cache-Control')).toBeNull();
     });
 
     it('M9: 保護 API の 401 ではセキュリティヘッダが付き Cookie は発行しない', async () => {
@@ -370,6 +382,9 @@ describe('middleware - security headers', () => {
 
       expect(response.status).not.toBe(401);
       expect(response.headers.get('set-cookie')).toBeNull();
+      // ゲート OFF のときはキャッシュ制御に手を加えない（既存挙動の維持）
+      expect(response.headers.get('Cache-Control')).toBeNull();
+      expect(response.headers.get('Vary')).toBeNull();
     });
 
     it('M14: production かつ HTTPS では __Host- prefix と Secure が付く', async () => {

--- a/__tests__/middleware.node.test.ts
+++ b/__tests__/middleware.node.test.ts
@@ -245,7 +245,7 @@ describe('middleware - security headers', () => {
       expect(setCookie).not.toContain('Domain');
       // Set-Cookie を含む応答は共有キャッシュに載せない
       expect(response.headers.get('Cache-Control')).toBe('private, no-store');
-      expect(response.headers.get('CDN-Cache-Control')).toBeNull();
+      expect(response.headers.get('CDN-Cache-Control')).toBe('no-store');
       expect(response.headers.get('Vary')).toContain('Cookie');
       expect(response.headers.get('Vary')).toContain('Authorization');
     });
@@ -264,7 +264,7 @@ describe('middleware - security headers', () => {
       expect(response.headers.get('set-cookie')).toBeNull();
       // Cookie 通過時もゲート配下のページなので共有キャッシュに載せない
       expect(response.headers.get('Cache-Control')).toBe('private, no-store');
-      expect(response.headers.get('CDN-Cache-Control')).toBeNull();
+      expect(response.headers.get('CDN-Cache-Control')).toBe('no-store');
       expect(response.headers.get('Vary')).toContain('Cookie');
     });
 
@@ -302,6 +302,9 @@ describe('middleware - security headers', () => {
 
       expect(response.status).not.toBe(401);
       expect(response.headers.get('set-cookie')).toBeNull();
+      // cron でも任意パスを通過できるため、キャッシュ抑止の対象に含める
+      expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+      expect(response.headers.get('CDN-Cache-Control')).toBe('no-store');
     });
 
     it('M7: メンテナンス 503 の経路でもゲート Cookie を発行する', async () => {
@@ -314,8 +317,8 @@ describe('middleware - security headers', () => {
 
       expect(response.status).toBe(503);
       expect(response.headers.get('set-cookie')).toContain('tt_gate=');
-      // Cookie を含む応答は共有キャッシュ用ヘッダを持たない
-      expect(response.headers.get('CDN-Cache-Control')).toBeNull();
+      // Cookie を含む応答は共有キャッシュに載せない
+      expect(response.headers.get('CDN-Cache-Control')).toBe('no-store');
       expect(response.headers.get('Content-Security-Policy')).toBeTruthy();
     });
 
@@ -329,8 +332,8 @@ describe('middleware - security headers', () => {
       expect(response.status).toBe(307);
       expect(response.headers.get('location')).toContain('/auth/login');
       expect(response.headers.get('set-cookie')).toContain('tt_gate=');
-      // Cookie を含む応答は共有キャッシュ用ヘッダを持たない
-      expect(response.headers.get('CDN-Cache-Control')).toBeNull();
+      // Cookie を含む応答は共有キャッシュに載せない
+      expect(response.headers.get('CDN-Cache-Control')).toBe('no-store');
     });
 
     it('M9: 保護 API の 401 ではセキュリティヘッダが付き Cookie は発行しない', async () => {
@@ -342,11 +345,12 @@ describe('middleware - security headers', () => {
 
       expect(response.status).toBe(401);
       expect(response.headers.get('Content-Security-Policy')).toBeTruthy();
-      // /api/* は公開キャッシュヘッダを返す経路があるため Cookie を載せない
+      // /api/* に Cookie は載せないが、キャッシュ抑止は適用する
       expect(response.headers.get('set-cookie')).toBeNull();
+      expect(response.headers.get('Cache-Control')).toBe('private, no-store');
     });
 
-    it('M10: /api/* にはゲート Cookie を発行しない', async () => {
+    it('M10: /api/* には Cookie を発行しないがキャッシュは抑止する', async () => {
       enableBasicAuth();
 
       const response = await proxy(
@@ -355,6 +359,10 @@ describe('middleware - security headers', () => {
 
       expect(response.status).not.toBe(401);
       expect(response.headers.get('set-cookie')).toBeNull();
+      // ゲート済みの API 応答が下流 CDN に共有キャッシュされるのを防ぐ
+      expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+      expect(response.headers.get('CDN-Cache-Control')).toBe('no-store');
+      expect(response.headers.get('Vary')).toContain('Authorization');
     });
 
     it('M11: 有効化されているのにパスワードが未設定なら 503（fail-closed）', async () => {
@@ -384,6 +392,7 @@ describe('middleware - security headers', () => {
       expect(response.headers.get('set-cookie')).toBeNull();
       // ゲート OFF のときはキャッシュ制御に手を加えない（既存挙動の維持）
       expect(response.headers.get('Cache-Control')).toBeNull();
+      expect(response.headers.get('CDN-Cache-Control')).toBeNull();
       expect(response.headers.get('Vary')).toBeNull();
     });
 

--- a/__tests__/unit/auth/basic-auth-gate.test.ts
+++ b/__tests__/unit/auth/basic-auth-gate.test.ts
@@ -1,0 +1,324 @@
+import { NextRequest } from 'next/server';
+import {
+  BASIC_AUTH_CHALLENGE,
+  buildGateSetCookie,
+  evaluateGate,
+  gateCookieName,
+} from '@/lib/auth/basic-auth-gate';
+
+const SECRET = 'f'.repeat(64);
+const USER = 'tester';
+const PASS = 'correct-horse';
+
+function basicHeader(user: string, pass: string, scheme = 'Basic'): string {
+  return `${scheme} ${Buffer.from(`${user}:${pass}`, 'utf8').toString('base64')}`;
+}
+
+function makeRequest(
+  init: { url?: string; headers?: Record<string, string> } = {}
+): NextRequest {
+  return new NextRequest(new URL(init.url ?? 'http://localhost:3000/'), {
+    headers: init.headers,
+  });
+}
+
+/** buildGateSetCookie が返す Set-Cookie 文字列から Cookie の値だけを取り出す */
+function issueCookieValue(request = makeRequest()): string {
+  const setCookie = buildGateSetCookie(request);
+  const nameValue = setCookie.split(';')[0];
+  return nameValue.slice(nameValue.indexOf('=') + 1);
+}
+
+function requestWithCookie(value: string, authorization?: string): NextRequest {
+  const headers: Record<string, string> = {
+    cookie: `${gateCookieName()}=${value}`,
+  };
+  if (authorization) headers.authorization = authorization;
+  return makeRequest({ headers });
+}
+
+describe('basic-auth-gate', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    process.env.BASIC_AUTH_ENABLED = 'true';
+    process.env.BASIC_AUTH_USER = USER;
+    process.env.BASIC_AUTH_PASS = PASS;
+    process.env.BASIC_AUTH_GATE_SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env.NODE_ENV = originalNodeEnv;
+    delete process.env.BASIC_AUTH_ENABLED;
+    delete process.env.BASIC_AUTH_USER;
+    delete process.env.BASIC_AUTH_PASS;
+    delete process.env.BASIC_PASSWORD;
+    delete process.env.BASIC_AUTH_GATE_SECRET;
+    delete process.env.CRON_TOKEN;
+    delete process.env.CRON_SECRET;
+  });
+
+  describe('ゲート Cookie の署名と検証', () => {
+    it('U1: 署名した Cookie は検証を通る', () => {
+      const outcome = evaluateGate(requestWithCookie(issueCookieValue()));
+      expect(outcome.kind).toBe('cookie');
+    });
+
+    it('U2: 署名を改ざんした Cookie は拒否される', () => {
+      const value = issueCookieValue();
+      const parts = value.split('.');
+      parts[2] = `${parts[2].slice(0, -1)}${parts[2].endsWith('A') ? 'B' : 'A'}`;
+
+      expect(evaluateGate(requestWithCookie(parts.join('.'))).kind).toBe('fail');
+    });
+
+    it('U3: 有効期限を過ぎた Cookie は拒否される', () => {
+      const issuedAt = Date.UTC(2026, 0, 1);
+      jest.spyOn(Date, 'now').mockReturnValue(issuedAt);
+      const value = issueCookieValue();
+
+      // 発行直後は通る
+      expect(evaluateGate(requestWithCookie(value)).kind).toBe('cookie');
+
+      // TTL は 7 日。8 日後には失効している
+      jest.spyOn(Date, 'now').mockReturnValue(issuedAt + 8 * 24 * 60 * 60 * 1000);
+      expect(evaluateGate(requestWithCookie(value)).kind).toBe('fail');
+    });
+
+    it('U4: フォーマットバージョンが異なる Cookie は拒否される', () => {
+      const value = issueCookieValue();
+      const parts = value.split('.');
+      parts[0] = 'v0';
+
+      expect(evaluateGate(requestWithCookie(parts.join('.'))).kind).toBe('fail');
+    });
+
+    it('U5: パスワード変更後は既存 Cookie が失効する', () => {
+      const value = issueCookieValue();
+      process.env.BASIC_AUTH_PASS = 'rotated-password';
+
+      expect(evaluateGate(requestWithCookie(value)).kind).toBe('fail');
+    });
+
+    it('U6: ユーザー名変更後は既存 Cookie が失効する', () => {
+      const value = issueCookieValue();
+      process.env.BASIC_AUTH_USER = 'someone-else';
+
+      expect(evaluateGate(requestWithCookie(value)).kind).toBe('fail');
+    });
+
+    it('U7: 署名鍵のローテーション後は既存 Cookie が失効する', () => {
+      const value = issueCookieValue();
+      process.env.BASIC_AUTH_GATE_SECRET = '0'.repeat(64);
+
+      expect(evaluateGate(requestWithCookie(value)).kind).toBe('fail');
+    });
+
+    it('U8: 有効期限が壊れた Cookie は例外を投げずに拒否される', () => {
+      const signature = issueCookieValue().split('.')[2];
+      const malformed = [
+        `v1..${signature}`,
+        `v1.abc.${signature}`,
+        `v1.-1.${signature}`,
+        `v1.99999999999999999999.${signature}`,
+        `v1.${Math.floor(Date.now() / 1000) + 100}.${signature}.extra`,
+        'v1',
+        '',
+      ];
+
+      for (const value of malformed) {
+        expect(() => evaluateGate(requestWithCookie(value))).not.toThrow();
+        expect(evaluateGate(requestWithCookie(value)).kind).toBe('fail');
+      }
+    });
+  });
+
+  describe('Basic ヘッダのパース', () => {
+    it('U9: 非 ASCII のパスワードで認証できる', () => {
+      process.env.BASIC_AUTH_PASS = 'パスワード🔐';
+      const headers = { authorization: basicHeader(USER, 'パスワード🔐') };
+
+      expect(evaluateGate(makeRequest({ headers })).kind).toBe('basic');
+    });
+
+    it('U10: コロンを含むパスワードで認証できる', () => {
+      process.env.BASIC_AUTH_PASS = 'a:b:c';
+      const headers = { authorization: basicHeader(USER, 'a:b:c') };
+
+      expect(evaluateGate(makeRequest({ headers })).kind).toBe('basic');
+    });
+
+    it('U11: スキーム名は大文字小文字を区別しない', () => {
+      for (const scheme of ['Basic', 'basic', 'BASIC', 'BaSiC']) {
+        const headers = { authorization: basicHeader(USER, PASS, scheme) };
+        expect(evaluateGate(makeRequest({ headers })).kind).toBe('basic');
+      }
+    });
+
+    it('U12: 不正な Authorization ヘッダは拒否される', () => {
+      const invalid = [
+        'Basic',
+        'Basic ',
+        `Basic ${Buffer.from('no-colon-here', 'utf8').toString('base64')}`,
+        `Basic ${Buffer.from(`${USER}:${PASS}`, 'utf8').toString('base64')} extra`,
+        'Basic dXNlcjpwYX!!', // 長さは 4 の倍数だが Base64 の文字種ではない
+        'Basic dXNlcjpwYXNz=', // padding 位置が不正（長さが 4 の倍数でない）
+        'Bearer something',
+      ];
+
+      for (const authorization of invalid) {
+        expect(evaluateGate(makeRequest({ headers: { authorization } })).kind).toBe(
+          'fail'
+        );
+      }
+    });
+
+    it('U13: 不正な UTF-8 バイト列は拒否される', () => {
+      const token = Buffer.from([0x75, 0x3a, 0xff, 0xfe]).toString('base64');
+
+      expect(
+        evaluateGate(makeRequest({ headers: { authorization: `Basic ${token}` } }))
+          .kind
+      ).toBe('fail');
+    });
+
+    it('U14: 制御文字を含む資格情報は拒否される', () => {
+      const passWithControlChar = `pa${String.fromCharCode(0x01)}ss`;
+      process.env.BASIC_AUTH_PASS = passWithControlChar;
+      const headers = { authorization: basicHeader(USER, passWithControlChar) };
+
+      expect(evaluateGate(makeRequest({ headers })).kind).toBe('fail');
+    });
+
+    it('パスワードが違えば拒否される', () => {
+      const headers = { authorization: basicHeader(USER, 'wrong') };
+      expect(evaluateGate(makeRequest({ headers })).kind).toBe('fail');
+    });
+
+    it('ユーザー名が違えば拒否される', () => {
+      const headers = { authorization: basicHeader('wrong', PASS) };
+      expect(evaluateGate(makeRequest({ headers })).kind).toBe('fail');
+    });
+  });
+
+  describe('設定不備（fail-closed）', () => {
+    it('U15: 有効化されているのにパスワードが未設定なら misconfigured', () => {
+      delete process.env.BASIC_AUTH_PASS;
+
+      expect(evaluateGate(makeRequest()).kind).toBe('misconfigured');
+    });
+
+    it('U16: 署名鍵が未設定または短すぎれば misconfigured', () => {
+      delete process.env.BASIC_AUTH_GATE_SECRET;
+      expect(evaluateGate(makeRequest()).kind).toBe('misconfigured');
+
+      process.env.BASIC_AUTH_GATE_SECRET = 'a'.repeat(31);
+      expect(evaluateGate(makeRequest()).kind).toBe('misconfigured');
+
+      process.env.BASIC_AUTH_GATE_SECRET = 'a'.repeat(32);
+      expect(evaluateGate(makeRequest()).kind).toBe('fail');
+    });
+
+    it('BASIC_AUTH_ENABLED が未設定ならゲートは無効', () => {
+      delete process.env.BASIC_AUTH_ENABLED;
+
+      expect(evaluateGate(makeRequest()).kind).toBe('disabled');
+    });
+
+    it('BASIC_PASSWORD（旧名）でも設定済みとみなす', () => {
+      delete process.env.BASIC_AUTH_PASS;
+      process.env.BASIC_PASSWORD = PASS;
+      const headers = { authorization: basicHeader(USER, PASS) };
+
+      expect(evaluateGate(makeRequest({ headers })).kind).toBe('basic');
+    });
+  });
+
+  describe('Cookie 検証失敗は非終端', () => {
+    it('U17: 改ざん Cookie でも正しい Basic があれば basic として通る', () => {
+      const request = requestWithCookie(
+        'v1.9999999999.tampered',
+        basicHeader(USER, PASS)
+      );
+
+      expect(evaluateGate(request).kind).toBe('basic');
+    });
+
+    it('U18: 旧パスワード由来の Cookie でも新しい Basic があれば basic として通る', () => {
+      const staleCookie = issueCookieValue();
+      process.env.BASIC_AUTH_PASS = 'rotated-password';
+      const request = requestWithCookie(
+        staleCookie,
+        basicHeader(USER, 'rotated-password')
+      );
+
+      expect(evaluateGate(request).kind).toBe('basic');
+    });
+  });
+
+  describe('cron Bearer', () => {
+    it('U19: 資格情報が欠落していても cron は通る', () => {
+      delete process.env.BASIC_AUTH_PASS;
+      delete process.env.BASIC_AUTH_GATE_SECRET;
+      process.env.CRON_TOKEN = 'cron-token-value';
+      const headers = { authorization: 'Bearer cron-token-value' };
+
+      expect(evaluateGate(makeRequest({ headers })).kind).toBe('cron');
+    });
+
+    it('CRON_SECRET（旧名）でも通る', () => {
+      process.env.CRON_SECRET = 'legacy-cron-secret';
+      const headers = { authorization: 'bearer legacy-cron-secret' };
+
+      expect(evaluateGate(makeRequest({ headers })).kind).toBe('cron');
+    });
+
+    it('トークンが違えば cron として扱わない', () => {
+      process.env.CRON_TOKEN = 'cron-token-value';
+      const headers = { authorization: 'Bearer wrong-token' };
+
+      expect(evaluateGate(makeRequest({ headers })).kind).toBe('fail');
+    });
+  });
+
+  describe('Cookie 属性', () => {
+    it('development / HTTP では prefix なし・Secure なし', () => {
+      const setCookie = buildGateSetCookie(makeRequest());
+
+      expect(setCookie).toContain('tt_gate=');
+      expect(setCookie).not.toContain('__Host-');
+      expect(setCookie).not.toContain('Secure');
+      expect(setCookie).toContain('HttpOnly');
+      expect(setCookie).toContain('SameSite=Lax');
+      expect(setCookie).toContain('Path=/');
+      expect(setCookie).toContain('Max-Age=604800');
+      expect(setCookie).not.toContain('Domain');
+    });
+
+    it('HTTPS なら Secure が付く', () => {
+      const setCookie = buildGateSetCookie(
+        makeRequest({ url: 'https://example.com/' })
+      );
+
+      expect(setCookie).toContain('Secure');
+    });
+
+    it('production では __Host- prefix が付く', () => {
+      process.env.NODE_ENV = 'production';
+      const setCookie = buildGateSetCookie(
+        makeRequest({ url: 'https://example.com/' })
+      );
+
+      expect(gateCookieName()).toBe('__Host-tt_gate');
+      expect(setCookie).toContain('__Host-tt_gate=');
+      expect(setCookie).toContain('Secure');
+      expect(setCookie).toContain('Path=/');
+      expect(setCookie).not.toContain('Domain');
+    });
+  });
+
+  it('challenge は RFC 7617 の charset を通知する', () => {
+    expect(BASIC_AUTH_CHALLENGE).toBe('Basic realm="Protected", charset="UTF-8"');
+  });
+});

--- a/__tests__/unit/auth/basic-auth-gate.test.ts
+++ b/__tests__/unit/auth/basic-auth-gate.test.ts
@@ -19,6 +19,7 @@ function gateEnv(overrides: Partial<GateEnv> = {}): GateEnv {
     legacyPass: undefined,
     gateSecret: SECRET,
     cronSecret: undefined,
+    isProduction: false,
     ...overrides,
   };
 }
@@ -44,18 +45,15 @@ function issueCookieValue(env: GateEnv = gateEnv()): string {
 
 function requestWithCookie(value: string, authorization?: string): NextRequest {
   const headers: Record<string, string> = {
-    cookie: `${gateCookieName()}=${value}`,
+    cookie: `${gateCookieName(false)}=${value}`,
   };
   if (authorization) headers.authorization = authorization;
   return makeRequest({ headers });
 }
 
 describe('basic-auth-gate', () => {
-  const originalNodeEnv = process.env.NODE_ENV;
-
   afterEach(() => {
     jest.restoreAllMocks();
-    process.env.NODE_ENV = originalNodeEnv;
   });
 
   describe('ゲート Cookie の署名と検証', () => {
@@ -131,19 +129,26 @@ describe('basic-auth-gate', () => {
       ).toBe('fail');
     });
 
-    it('U8: 有効期限が壊れた Cookie は例外を投げずに拒否される', () => {
-      const signature = issueCookieValue().split('.')[2];
-      const malformed = [
-        `v1..${signature}`,
-        `v1.abc.${signature}`,
-        `v1.-1.${signature}`,
-        `v1.99999999999999999999.${signature}`,
-        `v1.${Math.floor(Date.now() / 1000) + 100}.${signature}.extra`,
-        'v1',
-        '',
+    const malformedCookieCases: Array<[string, (signature: string) => string]> =
+      [
+        ['exp が空文字', signature => `v1..${signature}`],
+        ['exp が非数字', signature => `v1.abc.${signature}`],
+        ['exp が負値', signature => `v1.-1.${signature}`],
+        ['exp が安全な整数の範囲外', signature => `v1.99999999999999999999.${signature}`],
+        [
+          '区切りが多い',
+          signature =>
+            `v1.${Math.floor(Date.now() / 1000) + 100}.${signature}.extra`,
+        ],
+        ['要素が足りない', () => 'v1'],
+        ['空文字', () => ''],
       ];
 
-      for (const value of malformed) {
+    it.each(malformedCookieCases)(
+      'U8: 壊れた Cookie は例外を投げずに拒否される (%s)',
+      (_label, build) => {
+        const value = build(issueCookieValue().split('.')[2]);
+
         expect(() =>
           evaluateGate(requestWithCookie(value), gateEnv())
         ).not.toThrow();
@@ -151,7 +156,7 @@ describe('basic-auth-gate', () => {
           'fail'
         );
       }
-    });
+    );
   });
 
   describe('Basic ヘッダのパース', () => {
@@ -173,32 +178,28 @@ describe('basic-auth-gate', () => {
       ).toBe('basic');
     });
 
-    it('U11: スキーム名は大文字小文字を区別しない', () => {
-      for (const scheme of ['Basic', 'basic', 'BASIC', 'BaSiC']) {
+    it.each(['Basic', 'basic', 'BASIC', 'BaSiC'])(
+      'U11: スキーム名は大文字小文字を区別しない (%s)',
+      scheme => {
         const headers = { authorization: basicHeader(USER, PASS, scheme) };
         expect(evaluateGate(makeRequest({ headers }), gateEnv()).kind).toBe(
           'basic'
         );
       }
-    });
+    );
 
-    it('U12: 不正な Authorization ヘッダは拒否される', () => {
-      const invalid = [
-        'Basic',
-        'Basic ',
-        `Basic ${Buffer.from('no-colon-here', 'utf8').toString('base64')}`,
-        `Basic ${Buffer.from(`${USER}:${PASS}`, 'utf8').toString('base64')} extra`,
-        'Basic dXNlcjpwYX!!', // 長さは 4 の倍数だが Base64 の文字種ではない
-        'Basic dXNlcjpwYXNz=', // 長さが 4 の倍数でない
-        'Bearer something',
-      ];
-
-      for (const authorization of invalid) {
-        expect(
-          evaluateGate(makeRequest({ headers: { authorization } }), gateEnv())
-            .kind
-        ).toBe('fail');
-      }
+    it.each([
+      'Basic',
+      'Basic ',
+      `Basic ${Buffer.from('no-colon-here', 'utf8').toString('base64')}`,
+      `Basic ${Buffer.from(`${USER}:${PASS}`, 'utf8').toString('base64')} extra`,
+      'Basic dXNlcjpwYX!!', // 長さは 4 の倍数だが Base64 の文字種ではない
+      'Basic dXNlcjpwYXNz=', // 長さが 4 の倍数でない
+      'Bearer something',
+    ])('U12: 不正な Authorization ヘッダは拒否される (%s)', authorization => {
+      expect(
+        evaluateGate(makeRequest({ headers: { authorization } }), gateEnv()).kind
+      ).toBe('fail');
     });
 
     it('U13: 不正な UTF-8 バイト列は拒否される', () => {
@@ -233,6 +234,17 @@ describe('basic-auth-gate', () => {
       ).toBe('basic');
     });
 
+    it('U24: 設定値が NFC でも NFD で送られた資格情報と一致する', () => {
+      // U20 の逆方向。両側を正規化している契約を固定する
+      const nfdPass = String.fromCharCode(0x30cf, 0x309a);
+      const nfcPass = nfdPass.normalize('NFC');
+      const headers = { authorization: basicHeader(USER, nfdPass) };
+
+      expect(
+        evaluateGate(makeRequest({ headers }), gateEnv({ pass: nfcPass })).kind
+      ).toBe('basic');
+    });
+
     it('パスワードが違えば拒否される', () => {
       const headers = { authorization: basicHeader(USER, 'wrong') };
       expect(evaluateGate(makeRequest({ headers }), gateEnv()).kind).toBe(
@@ -249,29 +261,32 @@ describe('basic-auth-gate', () => {
   });
 
   describe('BASIC_AUTH_ENABLED の解釈', () => {
-    it('U21: 表記揺れでも有効と判定する', () => {
-      for (const enabled of ['true', 'TRUE', ' true ', 'True']) {
+    it.each(['true', 'TRUE', ' true ', 'True'])(
+      'U21: 表記揺れでも有効と判定する (%s)',
+      enabled => {
         expect(evaluateGate(makeRequest(), gateEnv({ enabled })).kind).toBe(
           'fail'
         );
       }
-    });
+    );
 
-    it('U22: 未設定・空文字・false は無効と判定する', () => {
-      for (const enabled of [undefined, '', '  ', 'false', 'FALSE']) {
+    it.each([undefined, '', '  ', 'false', 'FALSE'])(
+      'U22: 未設定・空文字・false は無効と判定する (%s)',
+      enabled => {
         expect(evaluateGate(makeRequest(), gateEnv({ enabled })).kind).toBe(
           'disabled'
         );
       }
-    });
+    );
 
-    it('U23: true/false 以外の値は設定ミスとして fail-closed にする', () => {
-      for (const enabled of ['ture', '1', 'yes', 'on']) {
+    it.each(['ture', '1', 'yes', 'on'])(
+      'U23: true/false 以外の値は設定ミスとして fail-closed にする (%s)',
+      enabled => {
         expect(evaluateGate(makeRequest(), gateEnv({ enabled })).kind).toBe(
           'misconfigured'
         );
       }
-    });
+    );
   });
 
   describe('設定不備（fail-closed）', () => {
@@ -382,6 +397,15 @@ describe('basic-auth-gate', () => {
       expect(setCookie).not.toContain('Domain');
     });
 
+    it('production なら HTTP でも Secure が付く', () => {
+      const setCookie = buildGateSetCookie(
+        makeRequest(),
+        gateEnv({ isProduction: true })
+      );
+
+      expect(setCookie).toContain('Secure');
+    });
+
     it('HTTPS なら Secure が付く', () => {
       const setCookie = buildGateSetCookie(
         makeRequest({ url: 'https://example.com/' }),
@@ -392,13 +416,12 @@ describe('basic-auth-gate', () => {
     });
 
     it('production では __Host- prefix が付く', () => {
-      process.env.NODE_ENV = 'production';
       const setCookie = buildGateSetCookie(
         makeRequest({ url: 'https://example.com/' }),
-        gateEnv()
+        gateEnv({ isProduction: true })
       );
 
-      expect(gateCookieName()).toBe('__Host-tt_gate');
+      expect(gateCookieName(true)).toBe('__Host-tt_gate');
       expect(setCookie).toContain('__Host-tt_gate=');
       expect(setCookie).toContain('Secure');
       expect(setCookie).toContain('Path=/');

--- a/__tests__/unit/auth/basic-auth-gate.test.ts
+++ b/__tests__/unit/auth/basic-auth-gate.test.ts
@@ -4,11 +4,24 @@ import {
   buildGateSetCookie,
   evaluateGate,
   gateCookieName,
+  type GateEnv,
 } from '@/lib/auth/basic-auth-gate';
 
 const SECRET = 'f'.repeat(64);
 const USER = 'tester';
 const PASS = 'correct-horse';
+
+function gateEnv(overrides: Partial<GateEnv> = {}): GateEnv {
+  return {
+    enabled: 'true',
+    user: USER,
+    pass: PASS,
+    legacyPass: undefined,
+    gateSecret: SECRET,
+    cronSecret: undefined,
+    ...overrides,
+  };
+}
 
 function basicHeader(user: string, pass: string, scheme = 'Basic'): string {
   return `${scheme} ${Buffer.from(`${user}:${pass}`, 'utf8').toString('base64')}`;
@@ -23,8 +36,8 @@ function makeRequest(
 }
 
 /** buildGateSetCookie が返す Set-Cookie 文字列から Cookie の値だけを取り出す */
-function issueCookieValue(request = makeRequest()): string {
-  const setCookie = buildGateSetCookie(request);
+function issueCookieValue(env: GateEnv = gateEnv()): string {
+  const setCookie = buildGateSetCookie(makeRequest(), env);
   const nameValue = setCookie.split(';')[0];
   return nameValue.slice(nameValue.indexOf('=') + 1);
 }
@@ -40,37 +53,27 @@ function requestWithCookie(value: string, authorization?: string): NextRequest {
 describe('basic-auth-gate', () => {
   const originalNodeEnv = process.env.NODE_ENV;
 
-  beforeEach(() => {
-    process.env.BASIC_AUTH_ENABLED = 'true';
-    process.env.BASIC_AUTH_USER = USER;
-    process.env.BASIC_AUTH_PASS = PASS;
-    process.env.BASIC_AUTH_GATE_SECRET = SECRET;
-  });
-
   afterEach(() => {
     jest.restoreAllMocks();
     process.env.NODE_ENV = originalNodeEnv;
-    delete process.env.BASIC_AUTH_ENABLED;
-    delete process.env.BASIC_AUTH_USER;
-    delete process.env.BASIC_AUTH_PASS;
-    delete process.env.BASIC_PASSWORD;
-    delete process.env.BASIC_AUTH_GATE_SECRET;
-    delete process.env.CRON_TOKEN;
-    delete process.env.CRON_SECRET;
   });
 
   describe('ゲート Cookie の署名と検証', () => {
     it('U1: 署名した Cookie は検証を通る', () => {
-      const outcome = evaluateGate(requestWithCookie(issueCookieValue()));
+      const outcome = evaluateGate(
+        requestWithCookie(issueCookieValue()),
+        gateEnv()
+      );
       expect(outcome.kind).toBe('cookie');
     });
 
     it('U2: 署名を改ざんした Cookie は拒否される', () => {
-      const value = issueCookieValue();
-      const parts = value.split('.');
+      const parts = issueCookieValue().split('.');
       parts[2] = `${parts[2].slice(0, -1)}${parts[2].endsWith('A') ? 'B' : 'A'}`;
 
-      expect(evaluateGate(requestWithCookie(parts.join('.'))).kind).toBe('fail');
+      expect(
+        evaluateGate(requestWithCookie(parts.join('.')), gateEnv()).kind
+      ).toBe('fail');
     });
 
     it('U3: 有効期限を過ぎた Cookie は拒否される', () => {
@@ -78,41 +81,54 @@ describe('basic-auth-gate', () => {
       jest.spyOn(Date, 'now').mockReturnValue(issuedAt);
       const value = issueCookieValue();
 
-      // 発行直後は通る
-      expect(evaluateGate(requestWithCookie(value)).kind).toBe('cookie');
+      expect(evaluateGate(requestWithCookie(value), gateEnv()).kind).toBe(
+        'cookie'
+      );
 
       // TTL は 7 日。8 日後には失効している
-      jest.spyOn(Date, 'now').mockReturnValue(issuedAt + 8 * 24 * 60 * 60 * 1000);
-      expect(evaluateGate(requestWithCookie(value)).kind).toBe('fail');
+      jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(issuedAt + 8 * 24 * 60 * 60 * 1000);
+      expect(evaluateGate(requestWithCookie(value), gateEnv()).kind).toBe(
+        'fail'
+      );
     });
 
     it('U4: フォーマットバージョンが異なる Cookie は拒否される', () => {
-      const value = issueCookieValue();
-      const parts = value.split('.');
+      const parts = issueCookieValue().split('.');
       parts[0] = 'v0';
 
-      expect(evaluateGate(requestWithCookie(parts.join('.'))).kind).toBe('fail');
+      expect(
+        evaluateGate(requestWithCookie(parts.join('.')), gateEnv()).kind
+      ).toBe('fail');
     });
 
     it('U5: パスワード変更後は既存 Cookie が失効する', () => {
       const value = issueCookieValue();
-      process.env.BASIC_AUTH_PASS = 'rotated-password';
 
-      expect(evaluateGate(requestWithCookie(value)).kind).toBe('fail');
+      expect(
+        evaluateGate(requestWithCookie(value), gateEnv({ pass: 'rotated' })).kind
+      ).toBe('fail');
     });
 
     it('U6: ユーザー名変更後は既存 Cookie が失効する', () => {
       const value = issueCookieValue();
-      process.env.BASIC_AUTH_USER = 'someone-else';
 
-      expect(evaluateGate(requestWithCookie(value)).kind).toBe('fail');
+      expect(
+        evaluateGate(requestWithCookie(value), gateEnv({ user: 'someone-else' }))
+          .kind
+      ).toBe('fail');
     });
 
     it('U7: 署名鍵のローテーション後は既存 Cookie が失効する', () => {
       const value = issueCookieValue();
-      process.env.BASIC_AUTH_GATE_SECRET = '0'.repeat(64);
 
-      expect(evaluateGate(requestWithCookie(value)).kind).toBe('fail');
+      expect(
+        evaluateGate(
+          requestWithCookie(value),
+          gateEnv({ gateSecret: '0'.repeat(64) })
+        ).kind
+      ).toBe('fail');
     });
 
     it('U8: 有効期限が壊れた Cookie は例外を投げずに拒否される', () => {
@@ -128,31 +144,41 @@ describe('basic-auth-gate', () => {
       ];
 
       for (const value of malformed) {
-        expect(() => evaluateGate(requestWithCookie(value))).not.toThrow();
-        expect(evaluateGate(requestWithCookie(value)).kind).toBe('fail');
+        expect(() =>
+          evaluateGate(requestWithCookie(value), gateEnv())
+        ).not.toThrow();
+        expect(evaluateGate(requestWithCookie(value), gateEnv()).kind).toBe(
+          'fail'
+        );
       }
     });
   });
 
   describe('Basic ヘッダのパース', () => {
     it('U9: 非 ASCII のパスワードで認証できる', () => {
-      process.env.BASIC_AUTH_PASS = 'パスワード🔐';
-      const headers = { authorization: basicHeader(USER, 'パスワード🔐') };
+      const pass = 'パスワード🔐';
+      const headers = { authorization: basicHeader(USER, pass) };
 
-      expect(evaluateGate(makeRequest({ headers })).kind).toBe('basic');
+      expect(
+        evaluateGate(makeRequest({ headers }), gateEnv({ pass })).kind
+      ).toBe('basic');
     });
 
     it('U10: コロンを含むパスワードで認証できる', () => {
-      process.env.BASIC_AUTH_PASS = 'a:b:c';
-      const headers = { authorization: basicHeader(USER, 'a:b:c') };
+      const pass = 'a:b:c';
+      const headers = { authorization: basicHeader(USER, pass) };
 
-      expect(evaluateGate(makeRequest({ headers })).kind).toBe('basic');
+      expect(
+        evaluateGate(makeRequest({ headers }), gateEnv({ pass })).kind
+      ).toBe('basic');
     });
 
     it('U11: スキーム名は大文字小文字を区別しない', () => {
       for (const scheme of ['Basic', 'basic', 'BASIC', 'BaSiC']) {
         const headers = { authorization: basicHeader(USER, PASS, scheme) };
-        expect(evaluateGate(makeRequest({ headers })).kind).toBe('basic');
+        expect(evaluateGate(makeRequest({ headers }), gateEnv()).kind).toBe(
+          'basic'
+        );
       }
     });
 
@@ -163,75 +189,132 @@ describe('basic-auth-gate', () => {
         `Basic ${Buffer.from('no-colon-here', 'utf8').toString('base64')}`,
         `Basic ${Buffer.from(`${USER}:${PASS}`, 'utf8').toString('base64')} extra`,
         'Basic dXNlcjpwYX!!', // 長さは 4 の倍数だが Base64 の文字種ではない
-        'Basic dXNlcjpwYXNz=', // padding 位置が不正（長さが 4 の倍数でない）
+        'Basic dXNlcjpwYXNz=', // 長さが 4 の倍数でない
         'Bearer something',
       ];
 
       for (const authorization of invalid) {
-        expect(evaluateGate(makeRequest({ headers: { authorization } })).kind).toBe(
-          'fail'
-        );
+        expect(
+          evaluateGate(makeRequest({ headers: { authorization } }), gateEnv())
+            .kind
+        ).toBe('fail');
       }
     });
 
     it('U13: 不正な UTF-8 バイト列は拒否される', () => {
       const token = Buffer.from([0x75, 0x3a, 0xff, 0xfe]).toString('base64');
+      const headers = { authorization: `Basic ${token}` };
 
-      expect(
-        evaluateGate(makeRequest({ headers: { authorization: `Basic ${token}` } }))
-          .kind
-      ).toBe('fail');
+      expect(evaluateGate(makeRequest({ headers }), gateEnv()).kind).toBe(
+        'fail'
+      );
     });
 
     it('U14: 制御文字を含む資格情報は拒否される', () => {
-      const passWithControlChar = `pa${String.fromCharCode(0x01)}ss`;
-      process.env.BASIC_AUTH_PASS = passWithControlChar;
-      const headers = { authorization: basicHeader(USER, passWithControlChar) };
+      // 設定値と入力値は一致しているが、制御文字を含むためパース段階で拒否される
+      const pass = `pa${String.fromCharCode(0x01)}ss`;
+      const headers = { authorization: basicHeader(USER, pass) };
 
-      expect(evaluateGate(makeRequest({ headers })).kind).toBe('fail');
+      expect(
+        evaluateGate(makeRequest({ headers }), gateEnv({ pass })).kind
+      ).toBe('fail');
+    });
+
+    it('U20: 設定値が NFD でも NFC で送られた資格情報と一致する', () => {
+      // NFD の「パ」（ハ + 半濁点）。RFC 7617 は charset="UTF-8" 時に NFC を期待する
+      const nfdPass = String.fromCharCode(0x30cf, 0x309a);
+      const nfcPass = nfdPass.normalize('NFC');
+      expect(nfdPass).not.toBe(nfcPass);
+
+      const headers = { authorization: basicHeader(USER, nfcPass) };
+
+      expect(
+        evaluateGate(makeRequest({ headers }), gateEnv({ pass: nfdPass })).kind
+      ).toBe('basic');
     });
 
     it('パスワードが違えば拒否される', () => {
       const headers = { authorization: basicHeader(USER, 'wrong') };
-      expect(evaluateGate(makeRequest({ headers })).kind).toBe('fail');
+      expect(evaluateGate(makeRequest({ headers }), gateEnv()).kind).toBe(
+        'fail'
+      );
     });
 
     it('ユーザー名が違えば拒否される', () => {
       const headers = { authorization: basicHeader('wrong', PASS) };
-      expect(evaluateGate(makeRequest({ headers })).kind).toBe('fail');
+      expect(evaluateGate(makeRequest({ headers }), gateEnv()).kind).toBe(
+        'fail'
+      );
+    });
+  });
+
+  describe('BASIC_AUTH_ENABLED の解釈', () => {
+    it('U21: 表記揺れでも有効と判定する', () => {
+      for (const enabled of ['true', 'TRUE', ' true ', 'True']) {
+        expect(evaluateGate(makeRequest(), gateEnv({ enabled })).kind).toBe(
+          'fail'
+        );
+      }
+    });
+
+    it('U22: 未設定・空文字・false は無効と判定する', () => {
+      for (const enabled of [undefined, '', '  ', 'false', 'FALSE']) {
+        expect(evaluateGate(makeRequest(), gateEnv({ enabled })).kind).toBe(
+          'disabled'
+        );
+      }
+    });
+
+    it('U23: true/false 以外の値は設定ミスとして fail-closed にする', () => {
+      for (const enabled of ['ture', '1', 'yes', 'on']) {
+        expect(evaluateGate(makeRequest(), gateEnv({ enabled })).kind).toBe(
+          'misconfigured'
+        );
+      }
     });
   });
 
   describe('設定不備（fail-closed）', () => {
     it('U15: 有効化されているのにパスワードが未設定なら misconfigured', () => {
-      delete process.env.BASIC_AUTH_PASS;
+      const outcome = evaluateGate(
+        makeRequest(),
+        gateEnv({ pass: undefined, legacyPass: undefined })
+      );
 
-      expect(evaluateGate(makeRequest()).kind).toBe('misconfigured');
+      expect(outcome.kind).toBe('misconfigured');
+      expect(outcome.kind === 'misconfigured' && outcome.reason).toContain(
+        'BASIC_AUTH_PASS'
+      );
     });
 
     it('U16: 署名鍵が未設定または短すぎれば misconfigured', () => {
-      delete process.env.BASIC_AUTH_GATE_SECRET;
-      expect(evaluateGate(makeRequest()).kind).toBe('misconfigured');
+      const missing = evaluateGate(
+        makeRequest(),
+        gateEnv({ gateSecret: undefined })
+      );
+      expect(missing.kind).toBe('misconfigured');
+      expect(missing.kind === 'misconfigured' && missing.reason).toContain(
+        'BASIC_AUTH_GATE_SECRET'
+      );
 
-      process.env.BASIC_AUTH_GATE_SECRET = 'a'.repeat(31);
-      expect(evaluateGate(makeRequest()).kind).toBe('misconfigured');
+      expect(
+        evaluateGate(makeRequest(), gateEnv({ gateSecret: 'a'.repeat(31) })).kind
+      ).toBe('misconfigured');
 
-      process.env.BASIC_AUTH_GATE_SECRET = 'a'.repeat(32);
-      expect(evaluateGate(makeRequest()).kind).toBe('fail');
-    });
-
-    it('BASIC_AUTH_ENABLED が未設定ならゲートは無効', () => {
-      delete process.env.BASIC_AUTH_ENABLED;
-
-      expect(evaluateGate(makeRequest()).kind).toBe('disabled');
+      expect(
+        evaluateGate(makeRequest(), gateEnv({ gateSecret: 'a'.repeat(32) })).kind
+      ).toBe('fail');
     });
 
     it('BASIC_PASSWORD（旧名）でも設定済みとみなす', () => {
-      delete process.env.BASIC_AUTH_PASS;
-      process.env.BASIC_PASSWORD = PASS;
       const headers = { authorization: basicHeader(USER, PASS) };
 
-      expect(evaluateGate(makeRequest({ headers })).kind).toBe('basic');
+      expect(
+        evaluateGate(
+          makeRequest({ headers }),
+          gateEnv({ pass: undefined, legacyPass: PASS })
+        ).kind
+      ).toBe('basic');
     });
   });
 
@@ -242,49 +325,52 @@ describe('basic-auth-gate', () => {
         basicHeader(USER, PASS)
       );
 
-      expect(evaluateGate(request).kind).toBe('basic');
+      expect(evaluateGate(request, gateEnv()).kind).toBe('basic');
     });
 
     it('U18: 旧パスワード由来の Cookie でも新しい Basic があれば basic として通る', () => {
       const staleCookie = issueCookieValue();
-      process.env.BASIC_AUTH_PASS = 'rotated-password';
+      const rotated = gateEnv({ pass: 'rotated-password' });
       const request = requestWithCookie(
         staleCookie,
         basicHeader(USER, 'rotated-password')
       );
 
-      expect(evaluateGate(request).kind).toBe('basic');
+      expect(evaluateGate(request, rotated).kind).toBe('basic');
     });
   });
 
   describe('cron Bearer', () => {
     it('U19: 資格情報が欠落していても cron は通る', () => {
-      delete process.env.BASIC_AUTH_PASS;
-      delete process.env.BASIC_AUTH_GATE_SECRET;
-      process.env.CRON_TOKEN = 'cron-token-value';
       const headers = { authorization: 'Bearer cron-token-value' };
+      const env = gateEnv({
+        pass: undefined,
+        legacyPass: undefined,
+        gateSecret: undefined,
+        cronSecret: 'cron-token-value',
+      });
 
-      expect(evaluateGate(makeRequest({ headers })).kind).toBe('cron');
+      expect(evaluateGate(makeRequest({ headers }), env).kind).toBe('cron');
     });
 
-    it('CRON_SECRET（旧名）でも通る', () => {
-      process.env.CRON_SECRET = 'legacy-cron-secret';
+    it('スキーム名は大文字小文字を区別しない', () => {
       const headers = { authorization: 'bearer legacy-cron-secret' };
+      const env = gateEnv({ cronSecret: 'legacy-cron-secret' });
 
-      expect(evaluateGate(makeRequest({ headers })).kind).toBe('cron');
+      expect(evaluateGate(makeRequest({ headers }), env).kind).toBe('cron');
     });
 
     it('トークンが違えば cron として扱わない', () => {
-      process.env.CRON_TOKEN = 'cron-token-value';
       const headers = { authorization: 'Bearer wrong-token' };
+      const env = gateEnv({ cronSecret: 'cron-token-value' });
 
-      expect(evaluateGate(makeRequest({ headers })).kind).toBe('fail');
+      expect(evaluateGate(makeRequest({ headers }), env).kind).toBe('fail');
     });
   });
 
   describe('Cookie 属性', () => {
     it('development / HTTP では prefix なし・Secure なし', () => {
-      const setCookie = buildGateSetCookie(makeRequest());
+      const setCookie = buildGateSetCookie(makeRequest(), gateEnv());
 
       expect(setCookie).toContain('tt_gate=');
       expect(setCookie).not.toContain('__Host-');
@@ -298,7 +384,8 @@ describe('basic-auth-gate', () => {
 
     it('HTTPS なら Secure が付く', () => {
       const setCookie = buildGateSetCookie(
-        makeRequest({ url: 'https://example.com/' })
+        makeRequest({ url: 'https://example.com/' }),
+        gateEnv()
       );
 
       expect(setCookie).toContain('Secure');
@@ -307,7 +394,8 @@ describe('basic-auth-gate', () => {
     it('production では __Host- prefix が付く', () => {
       process.env.NODE_ENV = 'production';
       const setCookie = buildGateSetCookie(
-        makeRequest({ url: 'https://example.com/' })
+        makeRequest({ url: 'https://example.com/' }),
+        gateEnv()
       );
 
       expect(gateCookieName()).toBe('__Host-tt_gate');
@@ -319,6 +407,8 @@ describe('basic-auth-gate', () => {
   });
 
   it('challenge は RFC 7617 の charset を通知する', () => {
-    expect(BASIC_AUTH_CHALLENGE).toBe('Basic realm="Protected", charset="UTF-8"');
+    expect(BASIC_AUTH_CHALLENGE).toBe(
+      'Basic realm="Protected", charset="UTF-8"'
+    );
   });
 });

--- a/lib/auth/basic-auth-gate.ts
+++ b/lib/auth/basic-auth-gate.ts
@@ -42,6 +42,8 @@ export interface GateEnv {
   gateSecret: string | undefined;
   /** CRON_TOKEN または CRON_SECRET */
   cronSecret: string | undefined;
+  /** NODE_ENV === 'production'。Cookie の prefix と Secure 属性の判定に使う */
+  isProduction: boolean;
 }
 
 export type GateOutcome =
@@ -102,11 +104,11 @@ function missingSettings(config: ResolvedConfig): string[] {
 }
 
 /**
- * Cookie 名は関数内で都度決定する。モジュールロード時に確定させると
+ * Cookie 名は呼び出し時に決定する。モジュールロード時に確定させると
  * production 属性（__Host- prefix）をテストで検証できなくなる。
  */
-export function gateCookieName(): string {
-  return process.env.NODE_ENV === 'production'
+export function gateCookieName(isProduction: boolean): string {
+  return isProduction
     ? `__Host-${GATE_COOKIE_BASE_NAME}`
     : GATE_COOKIE_BASE_NAME;
 }
@@ -150,11 +152,8 @@ function verifyGateCookie(
   return compareSecrets(signature, sign(exp, config));
 }
 
-function isSecureRequest(request: NextRequest): boolean {
-  return (
-    process.env.NODE_ENV === 'production' ||
-    request.nextUrl.protocol === 'https:'
-  );
+function isSecureRequest(request: NextRequest, isProduction: boolean): boolean {
+  return isProduction || request.nextUrl.protocol === 'https:';
 }
 
 /**
@@ -173,7 +172,7 @@ export function buildGateSetCookie(
   const value = `${GATE_COOKIE_VERSION}.${exp}.${sign(exp, config)}`;
 
   const attributes = [
-    `${gateCookieName()}=${value}`,
+    `${gateCookieName(gateEnv.isProduction)}=${value}`,
     'Path=/',
     `Max-Age=${GATE_TTL_SEC}`,
     'HttpOnly',
@@ -181,7 +180,7 @@ export function buildGateSetCookie(
   ];
 
   // __Host- prefix は Secure を要求する。ローカルの http 開発を壊さないため条件付きにする。
-  if (isSecureRequest(request)) {
+  if (isSecureRequest(request, gateEnv.isProduction)) {
     attributes.push('Secure');
   }
 
@@ -220,20 +219,39 @@ interface BasicCredentials {
   pass: string;
 }
 
+const BASIC_SCHEME_PATTERN = /^Basic[ \t]+([^ \t]+)[ \t]*$/i;
+const BEARER_SCHEME_PATTERN = /^Bearer[ \t]+([^ \t]+)[ \t]*$/i;
+
+/**
+ * Authorization ヘッダから token を取り出す共通パーサー。
+ * Basic / Bearer で同じ形式・同じ検証（scheme は RFC 7235 上 case-insensitive、
+ * token は単一、制御文字を含まない）を適用するために 1 箇所に集約している。
+ */
+function extractAuthToken(
+  header: string | null,
+  schemePattern: RegExp
+): string | null {
+  if (!header) return null;
+
+  const match = schemePattern.exec(header);
+  if (!match) return null;
+
+  const token = match[1];
+  if (CONTROL_CHAR_PATTERN.test(token)) return null;
+
+  return token;
+}
+
 /**
  * RFC 7617 に従って Authorization: Basic をパースする。
- * - スキーム名は case-insensitive
- * - token は単一（余分なトークンがあれば不正）
  * - 最初の ':' より後ろが全て password。user-id に ':' は含められない
  * - charset="UTF-8" を通知しているため NFC に正規化する
  */
 function parseBasicHeader(header: string | null): BasicCredentials | null {
-  if (!header) return null;
+  const token = extractAuthToken(header, BASIC_SCHEME_PATTERN);
+  if (token === null) return null;
 
-  const match = /^Basic[ \t]+([^ \t]+)[ \t]*$/i.exec(header);
-  if (!match) return null;
-
-  const decoded = decodeBase64Strict(match[1]);
+  const decoded = decodeBase64Strict(token);
   if (decoded === null) return null;
 
   const separator = decoded.indexOf(':');
@@ -268,10 +286,10 @@ function matchesCronBearer(
 ): boolean {
   if (!cronSecret) return false;
 
-  const match = /^Bearer[ \t]+([^ \t]+)[ \t]*$/i.exec(header ?? '');
-  if (!match) return false;
+  const token = extractAuthToken(header, BEARER_SCHEME_PATTERN);
+  if (token === null) return false;
 
-  return compareSecrets(match[1], cronSecret);
+  return compareSecrets(token, cronSecret);
 }
 
 /**
@@ -314,7 +332,10 @@ export function evaluateGate(
     };
   }
 
-  if (verifyGateCookie(request.cookies.get(gateCookieName())?.value, config)) {
+  const cookieValue = request.cookies.get(
+    gateCookieName(gateEnv.isProduction)
+  )?.value;
+  if (verifyGateCookie(cookieValue, config)) {
     return { kind: 'cookie' };
   }
 

--- a/lib/auth/basic-auth-gate.ts
+++ b/lib/auth/basic-auth-gate.ts
@@ -1,0 +1,262 @@
+import { createHash, createHmac } from 'crypto';
+import type { NextRequest } from 'next/server';
+import { compareSecrets } from '@/lib/utils/compare-secrets';
+
+/**
+ * サイト全体の Basic 認証ゲート。
+ *
+ * Basic 認証は「一度入力したら次から出ない」動作をブラウザの HTTP authentication entry に
+ * 委ねており、その挙動は実装依存で環境差が大きい（Safari ではページ遷移毎にダイアログが
+ * 再表示される事象が発生）。そこで認証成功時に HMAC 署名付き Cookie を発行し、以降は
+ * Cookie で通すことでブラウザ実装差への依存をなくす。
+ *
+ * 設定値は proxy.ts と同様に process.env から都度読む。lib/config/env.ts はモジュール
+ * ロード時に一度だけ parse するため、テストが実行時に process.env を書き換える方式と
+ * 両立しない。
+ */
+
+/** Cookie フォーマットのバージョン。値の意味を変えたらインクリメントして旧 Cookie を一括失効させる */
+const GATE_COOKIE_VERSION = 'v1';
+const GATE_COOKIE_BASE_NAME = 'tt_gate';
+
+/** 絶対 TTL（7日）。スライディング更新は行わない（更新し続けると実質無期限になるため） */
+const GATE_TTL_SEC = 60 * 60 * 24 * 7;
+
+/** 署名鍵の最低長。Cookie を入手した攻撃者によるオフライン総当たりを非現実的にするため */
+const MIN_GATE_SECRET_LENGTH = 32;
+
+/** RFC 7617: charset を通知しないと非 ASCII 資格情報の相互運用性が保証されない */
+export const BASIC_AUTH_CHALLENGE = 'Basic realm="Protected", charset="UTF-8"';
+
+export type GateOutcome =
+  /** Basic 認証 OFF。ゲートは何もしない */
+  | { kind: 'disabled' }
+  /** cron Bearer 一致。通すが Cookie は発行しない */
+  | { kind: 'cron' }
+  /** 有効化されているのに資格情報 or 署名鍵が欠落。fail-closed で 503 */
+  | { kind: 'misconfigured' }
+  /** 有効なゲート Cookie。通すが Cookie は再発行しない */
+  | { kind: 'cookie' }
+  /** Basic 認証成功。通してゲート Cookie を発行（＝旧 Cookie を上書き）する */
+  | { kind: 'basic' }
+  /** 401 challenge を返す */
+  | { kind: 'fail' };
+
+interface GateConfig {
+  user: string;
+  pass: string;
+  secret: string;
+}
+
+function readConfig(): GateConfig {
+  return {
+    user: process.env.BASIC_AUTH_USER || 'user',
+    pass: process.env.BASIC_AUTH_PASS || process.env.BASIC_PASSWORD || '',
+    secret: process.env.BASIC_AUTH_GATE_SECRET || '',
+  };
+}
+
+function isConfigured(config: GateConfig): boolean {
+  return (
+    config.pass.length > 0 && config.secret.length >= MIN_GATE_SECRET_LENGTH
+  );
+}
+
+/**
+ * Cookie 名は関数内で都度決定する。モジュールロード時に確定させると
+ * production 属性（__Host- prefix）をテストで検証できなくなる。
+ */
+export function gateCookieName(): string {
+  return process.env.NODE_ENV === 'production'
+    ? `__Host-${GATE_COOKIE_BASE_NAME}`
+    : GATE_COOKIE_BASE_NAME;
+}
+
+/**
+ * 現行の資格情報の指紋。署名対象に含めることで、user/pass を変更するだけで
+ * 既存の全 Cookie が検証に失敗するようになる（＝即時失効手段になる）。
+ *
+ * user の長さを前置して user="a:b", pass="c" と user="a", pass="b:c" を区別する。
+ */
+function credentialFingerprint(config: GateConfig): string {
+  return createHash('sha256')
+    .update(`${config.user.length}:${config.user}:${config.pass}`, 'utf8')
+    .digest('hex');
+}
+
+function sign(exp: number, config: GateConfig): string {
+  const message = `${GATE_COOKIE_VERSION}.${exp}.${credentialFingerprint(config)}`;
+  return createHmac('sha256', config.secret)
+    .update(message, 'utf8')
+    .digest('base64url');
+}
+
+function verifyGateCookie(
+  value: string | undefined,
+  config: GateConfig
+): boolean {
+  if (!value) return false;
+
+  const parts = value.split('.');
+  if (parts.length !== 3) return false;
+
+  const [version, expRaw, signature] = parts;
+  if (version !== GATE_COOKIE_VERSION) return false;
+  if (!/^\d+$/.test(expRaw)) return false;
+
+  const exp = Number(expRaw);
+  if (!Number.isSafeInteger(exp)) return false;
+  if (exp * 1000 <= Date.now()) return false;
+
+  return compareSecrets(signature, sign(exp, config));
+}
+
+function isSecureRequest(request: NextRequest): boolean {
+  return (
+    process.env.NODE_ENV === 'production' ||
+    request.nextUrl.protocol === 'https:'
+  );
+}
+
+/**
+ * Set-Cookie の値を組み立てる。
+ *
+ * NextResponse.cookies.set() は使わない。__mocks__/next/server.ts の NextResponse には
+ * cookies API が実装されておらず、テストが実行時エラーになるため。
+ * 自前でシリアライズすることで __Host- prefix の要件（Domain を出力しない）も確実に守れる。
+ */
+export function buildGateSetCookie(request: NextRequest): string {
+  const config = readConfig();
+  const exp = Math.floor(Date.now() / 1000) + GATE_TTL_SEC;
+  const value = `${GATE_COOKIE_VERSION}.${exp}.${sign(exp, config)}`;
+
+  const attributes = [
+    `${gateCookieName()}=${value}`,
+    'Path=/',
+    `Max-Age=${GATE_TTL_SEC}`,
+    'HttpOnly',
+    'SameSite=Lax',
+  ];
+
+  // __Host- prefix は Secure を要求する。ローカルの http 開発を壊さないため条件付きにする。
+  if (isSecureRequest(request)) {
+    attributes.push('Secure');
+  }
+
+  // Domain は出力しない（__Host- prefix の要件であり、サブドメインへの漏出も防ぐ）
+  return attributes.join('; ');
+}
+
+/** 標準 Base64（padding 込み）のみを許容する */
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/;
+
+/**
+ * Base64 をバイト列として厳密にデコードし、UTF-8 として解釈する。
+ *
+ * Buffer.from(x, 'base64') は不正な入力を黙って受理する（不正文字を読み飛ばす）ため、
+ * 文字種・padding を検証したうえで往復比較する。
+ */
+function decodeBase64Strict(token: string): string | null {
+  if (token.length === 0 || token.length % 4 !== 0) return null;
+  if (!BASE64_PATTERN.test(token)) return null;
+
+  const buffer = Buffer.from(token, 'base64');
+  if (buffer.toString('base64') !== token) return null;
+
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+  } catch {
+    // 不正な UTF-8 バイト列
+    return null;
+  }
+}
+
+interface BasicCredentials {
+  user: string;
+  pass: string;
+}
+
+/**
+ * RFC 7617 に従って Authorization: Basic をパースする。
+ * - スキーム名は case-insensitive
+ * - token は単一（余分なトークンがあれば不正）
+ * - 最初の ':' より後ろが全て password。user-id に ':' は含められない
+ */
+function parseBasicHeader(header: string | null): BasicCredentials | null {
+  if (!header) return null;
+
+  const match = /^Basic[ \t]+([^ \t]+)[ \t]*$/i.exec(header);
+  if (!match) return null;
+
+  const decoded = decodeBase64Strict(match[1]);
+  if (decoded === null) return null;
+
+  const separator = decoded.indexOf(':');
+  if (separator < 0) return null;
+
+  const user = decoded.slice(0, separator);
+  const pass = decoded.slice(separator + 1);
+
+  if (CONTROL_CHAR_PATTERN.test(user) || CONTROL_CHAR_PATTERN.test(pass))
+    return null;
+
+  return { user, pass };
+}
+
+function matchesBasicCredentials(
+  header: string | null,
+  config: GateConfig
+): boolean {
+  const parsed = parseBasicHeader(header);
+  if (!parsed) return false;
+
+  // 短絡評価を避け、user 側の一致有無が応答時間から観測できないようにする
+  const userMatches = compareSecrets(parsed.user, config.user);
+  const passMatches = compareSecrets(parsed.pass, config.pass);
+  return userMatches && passMatches;
+}
+
+function matchesCronBearer(header: string | null): boolean {
+  const cronSecret = process.env.CRON_TOKEN || process.env.CRON_SECRET;
+  if (!cronSecret) return false;
+
+  const match = /^Bearer[ \t]+([^ \t]+)[ \t]*$/i.exec(header ?? '');
+  if (!match) return false;
+
+  return compareSecrets(match[1], cronSecret);
+}
+
+/**
+ * ゲートの判定。評価順序は以下の通り。
+ *
+ * 1. Basic 認証 OFF → disabled
+ * 2. cron Bearer → cron（設定不備チェックより前。ゲートの設定ミスでバッチを止めないため）
+ * 3. 資格情報 or 署名鍵の欠落 → misconfigured（fail-closed）
+ * 4. 有効なゲート Cookie → cookie
+ * 5. 正しい Basic ヘッダ → basic
+ * 6. → fail
+ *
+ * 4 が失敗しても打ち切らずに 5 へ進むのが重要。ここで終端すると、不正・失効した Cookie を
+ * 持つ利用者が正しい資格情報を入力しても Cookie を上書きできず 401 ループに陥る。
+ */
+export function evaluateGate(request: NextRequest): GateOutcome {
+  if (process.env.BASIC_AUTH_ENABLED !== 'true') return { kind: 'disabled' };
+
+  const authHeader = request.headers.get('authorization');
+
+  if (matchesCronBearer(authHeader)) return { kind: 'cron' };
+
+  const config = readConfig();
+  if (!isConfigured(config)) return { kind: 'misconfigured' };
+
+  if (verifyGateCookie(request.cookies.get(gateCookieName())?.value, config)) {
+    return { kind: 'cookie' };
+  }
+
+  if (matchesBasicCredentials(authHeader, config)) return { kind: 'basic' };
+
+  return { kind: 'fail' };
+}

--- a/lib/auth/basic-auth-gate.ts
+++ b/lib/auth/basic-auth-gate.ts
@@ -10,9 +10,9 @@ import { compareSecrets } from '@/lib/utils/compare-secrets';
  * 再表示される事象が発生）。そこで認証成功時に HMAC 署名付き Cookie を発行し、以降は
  * Cookie で通すことでブラウザ実装差への依存をなくす。
  *
- * 設定値は proxy.ts と同様に process.env から都度読む。lib/config/env.ts はモジュール
- * ロード時に一度だけ parse するため、テストが実行時に process.env を書き換える方式と
- * 両立しない。
+ * 環境変数はこのモジュールでは読まず、呼び出し元（proxy.ts）が GateEnv として渡す。
+ * lib/config/env.ts はモジュールロード時に一度だけ parse するためテストの実行時書き換えと
+ * 両立せず、かつ lib/ 配下は process.env の直接参照を ESLint で禁止しているため。
  */
 
 /** Cookie フォーマットのバージョン。値の意味を変えたらインクリメントして旧 Cookie を一括失効させる */
@@ -28,13 +28,29 @@ const MIN_GATE_SECRET_LENGTH = 32;
 /** RFC 7617: charset を通知しないと非 ASCII 資格情報の相互運用性が保証されない */
 export const BASIC_AUTH_CHALLENGE = 'Basic realm="Protected", charset="UTF-8"';
 
+/** 呼び出し元が読み出して渡す環境変数の生値 */
+export interface GateEnv {
+  /** BASIC_AUTH_ENABLED */
+  enabled: string | undefined;
+  /** BASIC_AUTH_USER */
+  user: string | undefined;
+  /** BASIC_AUTH_PASS */
+  pass: string | undefined;
+  /** BASIC_PASSWORD（旧名） */
+  legacyPass: string | undefined;
+  /** BASIC_AUTH_GATE_SECRET */
+  gateSecret: string | undefined;
+  /** CRON_TOKEN または CRON_SECRET */
+  cronSecret: string | undefined;
+}
+
 export type GateOutcome =
   /** Basic 認証 OFF。ゲートは何もしない */
   | { kind: 'disabled' }
   /** cron Bearer 一致。通すが Cookie は発行しない */
   | { kind: 'cron' }
-  /** 有効化されているのに資格情報 or 署名鍵が欠落。fail-closed で 503 */
-  | { kind: 'misconfigured' }
+  /** 有効化されているのに設定が不完全。fail-closed で 503 */
+  | { kind: 'misconfigured'; reason: string }
   /** 有効なゲート Cookie。通すが Cookie は再発行しない */
   | { kind: 'cookie' }
   /** Basic 認証成功。通してゲート Cookie を発行（＝旧 Cookie を上書き）する */
@@ -42,24 +58,47 @@ export type GateOutcome =
   /** 401 challenge を返す */
   | { kind: 'fail' };
 
-interface GateConfig {
+interface ResolvedConfig {
   user: string;
   pass: string;
   secret: string;
 }
 
-function readConfig(): GateConfig {
+/**
+ * RFC 7617 は charset="UTF-8" を通知した場合に NFC を期待する。設定値と受信値の双方を
+ * NFC に揃えないと、見た目が同じ資格情報でも合成形/分解形の違いで認証に失敗する。
+ */
+function resolveConfig(gateEnv: GateEnv): ResolvedConfig {
   return {
-    user: process.env.BASIC_AUTH_USER || 'user',
-    pass: process.env.BASIC_AUTH_PASS || process.env.BASIC_PASSWORD || '',
-    secret: process.env.BASIC_AUTH_GATE_SECRET || '',
+    user: (gateEnv.user || 'user').normalize('NFC'),
+    pass: (gateEnv.pass || gateEnv.legacyPass || '').normalize('NFC'),
+    secret: gateEnv.gateSecret || '',
   };
 }
 
-function isConfigured(config: GateConfig): boolean {
-  return (
-    config.pass.length > 0 && config.secret.length >= MIN_GATE_SECRET_LENGTH
-  );
+type EnabledState = 'on' | 'off' | 'invalid';
+
+/**
+ * env.ts の booleanEnum と同じく trim + lowercase で判定する。
+ * 'TRUE' や ' true ' を OFF と誤判定してサイトが全公開になるのを防ぐ。
+ * true/false 以外の値は設定ミスとして fail-closed 側に倒す。
+ */
+function readEnabledState(raw: string | undefined): EnabledState {
+  if (raw === undefined) return 'off';
+
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === '' || normalized === 'false') return 'off';
+  if (normalized === 'true') return 'on';
+  return 'invalid';
+}
+
+function missingSettings(config: ResolvedConfig): string[] {
+  const missing: string[] = [];
+  if (config.pass.length === 0) missing.push('BASIC_AUTH_PASS');
+  if (config.secret.length < MIN_GATE_SECRET_LENGTH) {
+    missing.push(`BASIC_AUTH_GATE_SECRET (${MIN_GATE_SECRET_LENGTH}文字以上)`);
+  }
+  return missing;
 }
 
 /**
@@ -78,13 +117,13 @@ export function gateCookieName(): string {
  *
  * user の長さを前置して user="a:b", pass="c" と user="a", pass="b:c" を区別する。
  */
-function credentialFingerprint(config: GateConfig): string {
+function credentialFingerprint(config: ResolvedConfig): string {
   return createHash('sha256')
     .update(`${config.user.length}:${config.user}:${config.pass}`, 'utf8')
     .digest('hex');
 }
 
-function sign(exp: number, config: GateConfig): string {
+function sign(exp: number, config: ResolvedConfig): string {
   const message = `${GATE_COOKIE_VERSION}.${exp}.${credentialFingerprint(config)}`;
   return createHmac('sha256', config.secret)
     .update(message, 'utf8')
@@ -93,7 +132,7 @@ function sign(exp: number, config: GateConfig): string {
 
 function verifyGateCookie(
   value: string | undefined,
-  config: GateConfig
+  config: ResolvedConfig
 ): boolean {
   if (!value) return false;
 
@@ -125,8 +164,11 @@ function isSecureRequest(request: NextRequest): boolean {
  * cookies API が実装されておらず、テストが実行時エラーになるため。
  * 自前でシリアライズすることで __Host- prefix の要件（Domain を出力しない）も確実に守れる。
  */
-export function buildGateSetCookie(request: NextRequest): string {
-  const config = readConfig();
+export function buildGateSetCookie(
+  request: NextRequest,
+  gateEnv: GateEnv
+): string {
+  const config = resolveConfig(gateEnv);
   const exp = Math.floor(Date.now() / 1000) + GATE_TTL_SEC;
   const value = `${GATE_COOKIE_VERSION}.${exp}.${sign(exp, config)}`;
 
@@ -150,7 +192,6 @@ export function buildGateSetCookie(request: NextRequest): string {
 /** 標準 Base64（padding 込み）のみを許容する */
 const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
 
-// eslint-disable-next-line no-control-regex
 const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/;
 
 /**
@@ -184,6 +225,7 @@ interface BasicCredentials {
  * - スキーム名は case-insensitive
  * - token は単一（余分なトークンがあれば不正）
  * - 最初の ':' より後ろが全て password。user-id に ':' は含められない
+ * - charset="UTF-8" を通知しているため NFC に正規化する
  */
 function parseBasicHeader(header: string | null): BasicCredentials | null {
   if (!header) return null;
@@ -200,15 +242,16 @@ function parseBasicHeader(header: string | null): BasicCredentials | null {
   const user = decoded.slice(0, separator);
   const pass = decoded.slice(separator + 1);
 
-  if (CONTROL_CHAR_PATTERN.test(user) || CONTROL_CHAR_PATTERN.test(pass))
+  if (CONTROL_CHAR_PATTERN.test(user) || CONTROL_CHAR_PATTERN.test(pass)) {
     return null;
+  }
 
-  return { user, pass };
+  return { user: user.normalize('NFC'), pass: pass.normalize('NFC') };
 }
 
 function matchesBasicCredentials(
   header: string | null,
-  config: GateConfig
+  config: ResolvedConfig
 ): boolean {
   const parsed = parseBasicHeader(header);
   if (!parsed) return false;
@@ -219,8 +262,10 @@ function matchesBasicCredentials(
   return userMatches && passMatches;
 }
 
-function matchesCronBearer(header: string | null): boolean {
-  const cronSecret = process.env.CRON_TOKEN || process.env.CRON_SECRET;
+function matchesCronBearer(
+  header: string | null,
+  cronSecret: string | undefined
+): boolean {
   if (!cronSecret) return false;
 
   const match = /^Bearer[ \t]+([^ \t]+)[ \t]*$/i.exec(header ?? '');
@@ -234,7 +279,7 @@ function matchesCronBearer(header: string | null): boolean {
  *
  * 1. Basic 認証 OFF → disabled
  * 2. cron Bearer → cron（設定不備チェックより前。ゲートの設定ミスでバッチを止めないため）
- * 3. 資格情報 or 署名鍵の欠落 → misconfigured（fail-closed）
+ * 3. 設定が不完全 → misconfigured（fail-closed）
  * 4. 有効なゲート Cookie → cookie
  * 5. 正しい Basic ヘッダ → basic
  * 6. → fail
@@ -242,15 +287,32 @@ function matchesCronBearer(header: string | null): boolean {
  * 4 が失敗しても打ち切らずに 5 へ進むのが重要。ここで終端すると、不正・失効した Cookie を
  * 持つ利用者が正しい資格情報を入力しても Cookie を上書きできず 401 ループに陥る。
  */
-export function evaluateGate(request: NextRequest): GateOutcome {
-  if (process.env.BASIC_AUTH_ENABLED !== 'true') return { kind: 'disabled' };
+export function evaluateGate(
+  request: NextRequest,
+  gateEnv: GateEnv
+): GateOutcome {
+  const enabled = readEnabledState(gateEnv.enabled);
+  if (enabled === 'off') return { kind: 'disabled' };
 
   const authHeader = request.headers.get('authorization');
+  if (matchesCronBearer(authHeader, gateEnv.cronSecret))
+    return { kind: 'cron' };
 
-  if (matchesCronBearer(authHeader)) return { kind: 'cron' };
+  if (enabled === 'invalid') {
+    return {
+      kind: 'misconfigured',
+      reason: 'BASIC_AUTH_ENABLED には true または false のみ指定できます',
+    };
+  }
 
-  const config = readConfig();
-  if (!isConfigured(config)) return { kind: 'misconfigured' };
+  const config = resolveConfig(gateEnv);
+  const missing = missingSettings(config);
+  if (missing.length > 0) {
+    return {
+      kind: 'misconfigured',
+      reason: `未設定または不正な環境変数: ${missing.join(', ')}`,
+    };
+  }
 
   if (verifyGateCookie(request.cookies.get(gateCookieName())?.value, config)) {
     return { kind: 'cookie' };

--- a/proxy.ts
+++ b/proxy.ts
@@ -24,6 +24,7 @@ function readGateEnv(): GateEnv {
     legacyPass: process.env.BASIC_PASSWORD,
     gateSecret: process.env.BASIC_AUTH_GATE_SECRET,
     cronSecret: process.env.CRON_TOKEN || process.env.CRON_SECRET,
+    isProduction: process.env.NODE_ENV === 'production',
   };
 }
 
@@ -106,14 +107,37 @@ export async function proxy(request: NextRequest) {
   // Cookie を最後の NextResponse.next() にだけ付けると、初回アクセスがメンテナンス 503 や
   // ログインリダイレクトに落ちた場合に発行されず、再入力の症状がそのまま残る。
   const finalize = <T extends NextResponse>(response: T): T => {
-    if (gate.kind === 'basic' && !pathname.startsWith('/api/')) {
-      response.headers.append('Set-Cookie', buildGateSetCookie(request, gateEnv));
-      // Set-Cookie を含む応答が共有キャッシュに載らないようにする
-      // （app/api/stats 等が public, s-maxage と CDN-Cache-Control を返すため、
-      //   API を除外したうえでさらに二重に防ぐ）
+    // ゲート配下のページ応答は共有キャッシュに載せない。
+    // Cookie 発行時（basic）だけでなく Cookie 通過時（cookie）も対象にしないと、
+    // 2 回目以降のリクエストがキャッシュ制御なしで通ってしまう。
+    // /api/ は app/api/stats 等が public, s-maxage と CDN-Cache-Control を返すため除外する。
+    const isGatedPage =
+      !pathname.startsWith('/api/') &&
+      (gate.kind === 'basic' || gate.kind === 'cookie');
+
+    if (isGatedPage) {
+      if (gate.kind === 'basic') {
+        response.headers.append(
+          'Set-Cookie',
+          buildGateSetCookie(request, gateEnv)
+        );
+      }
+
       response.headers.set('Cache-Control', 'private, no-store');
       response.headers.delete('CDN-Cache-Control');
+
+      // 既存の Vary を保持したうえで認証に影響するヘッダを追加する
+      const vary = new Set(
+        (response.headers.get('Vary') ?? '')
+          .split(',')
+          .map(value => value.trim())
+          .filter(Boolean)
+      );
+      vary.add('Cookie');
+      vary.add('Authorization');
+      response.headers.set('Vary', [...vary].join(', '));
     }
+
     setSecurityHeaders(response, request);
     return response;
   };
@@ -142,9 +166,8 @@ export async function proxy(request: NextRequest) {
         const { createMaintenanceResponse } = await import(
           '@/lib/maintenance/maintenance-response'
         );
-        const maintenanceRes = createMaintenanceResponse();
-        setSecurityHeaders(maintenanceRes, request);
-        return maintenanceRes;
+        // セキュリティヘッダは呼び出し元の finalize が一括で適用する
+        return createMaintenanceResponse();
       } catch {
         // 最終フォールバック: メンテ画面モジュールの取得すら失敗しても 503 を返す。
         return new NextResponse('Service Unavailable', {

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { compareSecrets } from '@/lib/utils/compare-secrets';
+import {
+  BASIC_AUTH_CHALLENGE,
+  buildGateSetCookie,
+  evaluateGate,
+} from '@/lib/auth/basic-auth-gate';
 import { getThemeFromCookie } from '@/lib/cookies/theme-cookie';
 import { setSecurityHeaders } from '@/config/security-headers';
 import {
@@ -8,38 +12,6 @@ import {
   requiresCSRFProtection,
 } from '@/lib/middleware/csrf-protection';
 import { AUTH_COOKIES } from '@/lib/config/auth-cookies';
-
-// Optional Basic Auth (enabled when env is set)
-function needsBasicAuth(): boolean {
-  const enabled = process.env.BASIC_AUTH_ENABLED === 'true';
-  const hasCreds = !!(process.env.BASIC_AUTH_PASS || process.env.BASIC_PASSWORD);
-  return enabled && hasCreds;
-}
-
-function checkBasicAuth(request: NextRequest): boolean {
-  // Allow cron requests with valid CRON_SECRET Bearer token
-  const cronSecret = process.env.CRON_TOKEN || process.env.CRON_SECRET;
-  if (cronSecret) {
-    const authHeader = request.headers.get('authorization');
-    const token = authHeader?.startsWith('Bearer ') ? authHeader.substring('Bearer '.length) : undefined;
-    if (token && compareSecrets(token, cronSecret)) return true;
-  }
-
-  const user = process.env.BASIC_AUTH_USER || 'user';
-  const pass = process.env.BASIC_AUTH_PASS || process.env.BASIC_PASSWORD || '';
-
-  const header = request.headers.get('authorization');
-  if (!header || !header.startsWith('Basic ')) return false;
-
-  try {
-    const base64 = header.split(' ')[1] || '';
-    const decoded = atob(base64);
-    const [u, p] = decoded.split(':');
-    return u === user && p === pass;
-  } catch {
-    return false;
-  }
-}
 
 // メンテナンスモードの除外パス判定
 // メンテ中でも通常応答するパス: API・管理者ログイン・メンテ画面自身・静的アセット。
@@ -87,16 +59,47 @@ export async function proxy(request: NextRequest) {
     }
   }
 
-  // Site-wide Basic Auth
-  if (needsBasicAuth()) {
-    const ok = checkBasicAuth(request);
-    if (!ok) {
-      return new NextResponse('Unauthorized', {
-        status: 401,
-        headers: { 'WWW-Authenticate': 'Basic realm="Protected"' },
-      });
-    }
+  // Site-wide Basic Auth（認証済み状態は署名付きゲート Cookie で保持する）
+  const gate = evaluateGate(request);
+
+  if (gate.kind === 'misconfigured') {
+    // fail-closed: BASIC_AUTH_ENABLED=true なのに資格情報 or 署名鍵が欠けている設定ミス。
+    // 認証を黙って無効化してサイトが全公開になるより、明示的に止める方が安全。
+    const misconfiguredRes = new NextResponse('Service Unavailable', {
+      status: 503,
+      headers: { 'Cache-Control': 'no-store' },
+    });
+    setSecurityHeaders(misconfiguredRes, request);
+    return misconfiguredRes;
   }
+
+  if (gate.kind === 'fail') {
+    const challengeRes = new NextResponse('Unauthorized', {
+      status: 401,
+      headers: {
+        'WWW-Authenticate': BASIC_AUTH_CHALLENGE,
+        'Cache-Control': 'no-store',
+      },
+    });
+    setSecurityHeaders(challengeRes, request);
+    return challengeRes;
+  }
+
+  // ゲート通過後の全 return をここに通す。
+  // Cookie を最後の NextResponse.next() にだけ付けると、初回アクセスがメンテナンス 503 や
+  // ログインリダイレクトに落ちた場合に発行されず、再入力の症状がそのまま残る。
+  const finalize = <T extends NextResponse>(response: T): T => {
+    if (gate.kind === 'basic' && !pathname.startsWith('/api/')) {
+      response.headers.append('Set-Cookie', buildGateSetCookie(request));
+      // Set-Cookie を含む応答が共有キャッシュに載らないようにする
+      // （app/api/stats 等が public, s-maxage と CDN-Cache-Control を返すため、
+      //   API を除外したうえでさらに二重に防ぐ）
+      response.headers.set('Cache-Control', 'private, no-store');
+      response.headers.delete('CDN-Cache-Control');
+    }
+    setSecurityHeaders(response, request);
+    return response;
+  };
 
   // Maintenance Mode: 管理者以外をメンテナンス画面（HTTP 503）に切り替える。
   // OFF（未設定 or 'true' 以外）のときは getSession を呼ばず既存フローを維持する。
@@ -127,7 +130,7 @@ export async function proxy(request: NextRequest) {
     // セッション Cookie が無ければ未認証＝非管理者確定。getSession/DB を呼ばず即 503 に倒す
     // （メンテ中の未認証アクセスで毎回 DB セッション検索が走るのを防ぐ）。
     if (!request.cookies.get(AUTH_COOKIES.sessionToken)) {
-      return await respondMaintenance();
+      return finalize(await respondMaintenance());
     }
 
     try {
@@ -148,12 +151,12 @@ export async function proxy(request: NextRequest) {
       }
 
       if (!isAdmin) {
-        return await respondMaintenance();
+        return finalize(await respondMaintenance());
       }
     } catch {
       // フェイルセーフ: session/DB 取得失敗時は 500 ではなくメンテ画面（503）に倒す。
       // （getUserAuthData は Redis 失敗は握るが DB query 例外は握らないため、ここで捕捉する）
-      return await respondMaintenance();
+      return finalize(await respondMaintenance());
     }
   }
 
@@ -173,23 +176,19 @@ export async function proxy(request: NextRequest) {
     if (!sessionCookie) {
       // APIルートの場合は401を返す
       if (isProtectedApiPath) {
-        return NextResponse.json(
-          { error: 'Unauthorized' },
-          { status: 401 }
+        return finalize(
+          NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
         );
       }
 
       // ページの場合はログインページにリダイレクト
       const url = new URL('/auth/login', request.url);
       url.searchParams.set('callbackUrl', pathname);
-      return NextResponse.redirect(url);
+      return finalize(NextResponse.redirect(url));
     }
   }
 
   const response = NextResponse.next();
-
-  // セキュリティヘッダ設定（Phase 2: 並行運用検証）
-  setSecurityHeaders(response, request);
 
   // テーマCookieの処理
   const theme = getThemeFromCookie(request);
@@ -197,7 +196,8 @@ export async function proxy(request: NextRequest) {
   // レスポンスヘッダーにテーマ情報を追加（デバッグ用）
   response.headers.set('x-theme', theme);
 
-  return response;
+  // セキュリティヘッダ設定とゲート Cookie 発行は finalize がまとめて行う
+  return finalize(response);
 }
 
 export const config = {

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,6 +3,7 @@ import {
   BASIC_AUTH_CHALLENGE,
   buildGateSetCookie,
   evaluateGate,
+  type GateEnv,
 } from '@/lib/auth/basic-auth-gate';
 import { getThemeFromCookie } from '@/lib/cookies/theme-cookie';
 import { setSecurityHeaders } from '@/config/security-headers';
@@ -12,6 +13,23 @@ import {
   requiresCSRFProtection,
 } from '@/lib/middleware/csrf-protection';
 import { AUTH_COOKIES } from '@/lib/config/auth-cookies';
+
+// Basic 認証ゲートの設定値。lib/ 配下は process.env の直接参照を ESLint で禁止しており、
+// env.ts はモジュールロード時に一度だけ parse するため、ここ（proxy.ts）で都度読んで渡す。
+function readGateEnv(): GateEnv {
+  return {
+    enabled: process.env.BASIC_AUTH_ENABLED,
+    user: process.env.BASIC_AUTH_USER,
+    pass: process.env.BASIC_AUTH_PASS,
+    legacyPass: process.env.BASIC_PASSWORD,
+    gateSecret: process.env.BASIC_AUTH_GATE_SECRET,
+    cronSecret: process.env.CRON_TOKEN || process.env.CRON_SECRET,
+  };
+}
+
+// 設定不備は全リクエストが 503 になる重大事象なので必ず気づけるようにする。
+// ただしリクエスト毎に出すとログが溢れるため、プロセスにつき一度だけ出力する。
+let gateMisconfigurationLogged = false;
 
 // メンテナンスモードの除外パス判定
 // メンテ中でも通常応答するパス: API・管理者ログイン・メンテ画面自身・静的アセット。
@@ -49,22 +67,21 @@ const protectedApiPaths = [
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
-  // CSRF Protection for API routes
-  if (pathname.startsWith('/api/')) {
-    if (requiresCSRFProtection(request.method) && !isCSRFExemptPath(pathname)) {
-      const csrfResponse = await csrfProtection(request);
-      if (csrfResponse) {
-        return csrfResponse;
-      }
-    }
-  }
-
   // Site-wide Basic Auth（認証済み状態は署名付きゲート Cookie で保持する）
-  const gate = evaluateGate(request);
+  // サイト全体のゲートなので CSRF より外側で評価する。未認証リクエストのために
+  // CSRF 側のセッション照会（DB アクセス）を走らせないためでもある。
+  const gateEnv = readGateEnv();
+  const gate = evaluateGate(request, gateEnv);
 
   if (gate.kind === 'misconfigured') {
-    // fail-closed: BASIC_AUTH_ENABLED=true なのに資格情報 or 署名鍵が欠けている設定ミス。
+    // fail-closed: Basic 認証が有効なのに設定が不完全。
     // 認証を黙って無効化してサイトが全公開になるより、明示的に止める方が安全。
+    if (!gateMisconfigurationLogged) {
+      gateMisconfigurationLogged = true;
+      console.error(
+        `[proxy] Basic 認証が有効ですが設定が不完全なため全リクエストを 503 にしています: ${gate.reason}`
+      );
+    }
     const misconfiguredRes = new NextResponse('Service Unavailable', {
       status: 503,
       headers: { 'Cache-Control': 'no-store' },
@@ -90,7 +107,7 @@ export async function proxy(request: NextRequest) {
   // ログインリダイレクトに落ちた場合に発行されず、再入力の症状がそのまま残る。
   const finalize = <T extends NextResponse>(response: T): T => {
     if (gate.kind === 'basic' && !pathname.startsWith('/api/')) {
-      response.headers.append('Set-Cookie', buildGateSetCookie(request));
+      response.headers.append('Set-Cookie', buildGateSetCookie(request, gateEnv));
       // Set-Cookie を含む応答が共有キャッシュに載らないようにする
       // （app/api/stats 等が public, s-maxage と CDN-Cache-Control を返すため、
       //   API を除外したうえでさらに二重に防ぐ）
@@ -100,6 +117,16 @@ export async function proxy(request: NextRequest) {
     setSecurityHeaders(response, request);
     return response;
   };
+
+  // CSRF Protection for API routes
+  if (pathname.startsWith('/api/')) {
+    if (requiresCSRFProtection(request.method) && !isCSRFExemptPath(pathname)) {
+      const csrfResponse = await csrfProtection(request);
+      if (csrfResponse) {
+        return finalize(csrfResponse);
+      }
+    }
+  }
 
   // Maintenance Mode: 管理者以外をメンテナンス画面（HTTP 503）に切り替える。
   // OFF（未設定 or 'true' 以外）のときは getSession を呼ばず既存フローを維持する。

--- a/proxy.ts
+++ b/proxy.ts
@@ -107,16 +107,17 @@ export async function proxy(request: NextRequest) {
   // Cookie を最後の NextResponse.next() にだけ付けると、初回アクセスがメンテナンス 503 や
   // ログインリダイレクトに落ちた場合に発行されず、再入力の症状がそのまま残る。
   const finalize = <T extends NextResponse>(response: T): T => {
-    // ゲート配下のページ応答は共有キャッシュに載せない。
-    // Cookie 発行時（basic）だけでなく Cookie 通過時（cookie）も対象にしないと、
-    // 2 回目以降のリクエストがキャッシュ制御なしで通ってしまう。
-    // /api/ は app/api/stats 等が public, s-maxage と CDN-Cache-Control を返すため除外する。
-    const isGatedPage =
-      !pathname.startsWith('/api/') &&
-      (gate.kind === 'basic' || gate.kind === 'cookie');
+    // ゲートを通過した応答は共有キャッシュに載せない。
+    // basic だけでなく cookie（2 回目以降）と cron も対象にする必要がある。
+    // また /api/ も除外できない: app/api/stats 等が public, s-maxage と
+    // CDN-Cache-Control を返しており、これは「ゲート済みコンテンツを下流 CDN が
+    // 共有キャッシュしてよい」という宣言になってしまうため。
+    const passedGate =
+      gate.kind === 'basic' || gate.kind === 'cookie' || gate.kind === 'cron';
 
-    if (isGatedPage) {
-      if (gate.kind === 'basic') {
+    if (passedGate) {
+      // Cookie はドキュメント遷移でのみ発行する。API 応答（beacon 含む）には載せない。
+      if (gate.kind === 'basic' && !pathname.startsWith('/api/')) {
         response.headers.append(
           'Set-Cookie',
           buildGateSetCookie(request, gateEnv)
@@ -124,7 +125,8 @@ export async function proxy(request: NextRequest) {
       }
 
       response.headers.set('Cache-Control', 'private, no-store');
-      response.headers.delete('CDN-Cache-Control');
+      // 下流 CDN 向けの指定も明示的に打ち消す（delete だけでは後段が再設定しうる）
+      response.headers.set('CDN-Cache-Control', 'no-store');
 
       // 既存の Vary を保持したうえで認証に影響するヘッダを追加する
       const vary = new Set(


### PR DESCRIPTION
## 概要

- Safari でページ遷移のたびに Basic 認証ダイアログが再表示される問題に対処する
- Basic 認証成功時に HMAC 署名付き HttpOnly Cookie を発行し、以降は Cookie で通す「ゲート化」を行う
- 併せて Basic 認証のパースを RFC 7617 準拠に修正し、資格情報欠落時の fail-open を fail-closed に変える

> [!IMPORTANT]
> **デプロイ前に `BASIC_AUTH_GATE_SECRET` の設定が必須です。** 未設定のスコープは全リクエストが 503 になります。詳細は「デプロイ手順」を参照してください。

## 背景

`proxy.ts` の Basic 認証は認証済み状態をサーバ側に一切保持しておらず、「一度入力したら次から出ない」動作をクライアントの HTTP authentication entry（資格情報キャッシュ）に完全に委ねていました。

App Router のクライアント遷移は RSC を `fetch()` で取得し（`next/dist/client/components/router-reducer/fetch-server-response.js` の `credentials: 'same-origin'`）、その URL は pathname が同じなので matcher に必ずマッチして Basic 認証の対象になります。そのため entry が未生成・スコープ外・消去済みになる環境では、遷移のたびに 401 → ダイアログが発生します。

サーバ側に状態を持たせることで、ブラウザ実装差への依存をなくします。

なお **根本原因は実機 HAR 未採取のため未確定です**。401 が Vercel の Deployment Protection 由来だった場合はリクエストが `proxy()` に到達しないため本 PR では解消しません（デプロイ後の確認項目に含めています）。ただし Cookie ゲート化はどの下位原因でも有効なため、HAR を待たずに実装しています。

調査・計画の詳細は `.workflow/docs/investigate/investigate_20260814_234500_vercel_basic_auth_prompt.md` および `.workflow/docs/plan/plan_20260815_000312_basic_auth_cookie_gate.md` を参照してください。

## 実装内容

### ゲート Cookie（`lib/auth/basic-auth-gate.ts` 新規）

```
<version>.<expEpochSec>.<base64url(HMAC-SHA256)>
```

- HMAC のメッセージに **現行 user/pass の指紋** `sha256(<user.length>:<user>:<pass>)` を含める。これにより `BASIC_AUTH_PASS` / `BASIC_AUTH_USER` を変更するだけで既存 Cookie が一斉に失効する（＝即時失効手段）
- 署名鍵は `BASIC_AUTH_GATE_SECRET`（32文字以上、必須）。資格情報からの鍵導出は、Cookie を入手した攻撃者にオフライン辞書攻撃を許すため採用していない
- 絶対 7 日 TTL。スライディング更新は行わない（更新し続けると実質無期限になるため）
- 属性: `Path=/; Max-Age=604800; HttpOnly; SameSite=Lax`、HTTPS/production では `Secure`、production では `__Host-` prefix、`Domain` は出力しない

### 判定順序

1. `BASIC_AUTH_ENABLED` が off → `disabled`
2. cron Bearer 一致 → `cron`（Cookie は発行しない。設定不備チェックより前に置き、ゲートの設定ミスでバッチを止めない）
3. 設定が不完全 → `misconfigured`（fail-closed、503）
4. 有効なゲート Cookie → `cookie`（再発行しない）
5. 正しい Basic ヘッダ → `basic`（Cookie を発行＝旧 Cookie を上書き）
6. → `fail`（401 challenge）

**4 が失敗しても終端しない**のが要点です。ここで打ち切ると、失効・改ざんされた Cookie を持つ利用者が正しい資格情報を入力しても Cookie を上書きできず、401 ループに陥ります。

### finalizer 化（`proxy.ts`）

ゲート通過後の **7 箇所の return すべて**（CSRF 403・メンテナンス 503 × 3・保護 API 401・ログインリダイレクト・通常応答）を `finalize()` に通します。Cookie を最後の `NextResponse.next()` だけに付けると、初回アクセスがメンテナンスやログインリダイレクトに落ちた場合に Cookie が発行されず、症状がそのまま残るためです。

Cookie は `/api/` 以外にのみ発行し、発行レスポンスには `Cache-Control: private, no-store` を設定して `CDN-Cache-Control` を削除します。`app/api/stats/route.ts` などが `public, s-maxage=300` + `CDN-Cache-Control` を返すため、共有キャッシュに認証 Cookie が載るのを防ぐ意図です。

また、サイト全体のゲートである以上 CSRF より外側で評価すべきなので、ゲート評価を CSRF ブロックの前に移動しました。未認証リクエストのために CSRF 側のセッション照会（DB アクセス）が走らなくなる副次効果もあります。

### 挙動変更（fail-open の修正）

`BASIC_AUTH_ENABLED=true` でも資格情報が未設定なら、従来は**認証ごと無効化されてサイトが全公開**になっていました。これを設定ミスとして 503 で止めます（fail-closed）。

`BASIC_AUTH_ENABLED` の判定も `=== 'true'` から trim + lowercase に変更しました。従来は `TRUE` や ` true ` が OFF と解釈され、503 にもならず全公開になっていました（`lib/config/env.ts` の `booleanEnum` と同じ規則に揃えています）。`true`/`false` 以外の値は設定ミス扱いです。

### Basic 認証パースの修正（RFC 7617 準拠）

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| スキーム名 | `startsWith('Basic ')` で大小文字を区別 | case-insensitive |
| デコード | `atob`（Latin-1）→ 非 ASCII が常に不一致 | Base64 の文字種・padding 検証 + `TextDecoder('utf-8', { fatal: true })` |
| 分割 | `split(':')` → パスワード中の `:` で切り詰め | 最初の `:` のみで分割 |
| 制御文字 | 素通り | 拒否 |
| 比較 | `u === user && p === pass`（非定数時間） | `compareSecrets`（timing safe）で非短絡比較 |
| 正規化 | なし | 設定値・受信値の双方を NFC に正規化 |
| challenge | `Basic realm="Protected"` | `Basic realm="Protected", charset="UTF-8"` |
| 401 のキャッシュ制御 | なし | `Cache-Control: no-store` |

## テスト結果

test.md は作成していないため、VERIFY フェーズの結果を記載します。

| Step | 結果 | 内容 |
|------|------|------|
| Lint + Type Check | PASS | ESLint 0 errors / 0 warnings、`tsc --noEmit` エラーなし |
| Security Audit | FAIL | 本変更と無関係の既存問題（「既知事項」参照） |
| Build | PASS | `npm run docker:build` exit 0 |
| Test | PASS | 5 suites / 119 tests、すべて exit 0 |
| Diff Review | PASS | 機密ファイル・デバッグコードの混入なし |
| Visual | SKIP | `.tsx` の変更なし |

### テスト内訳

| ファイル | 件数 |
|---------|------|
| `__tests__/unit/auth/basic-auth-gate.test.ts`（新規） | 32 |
| `__tests__/middleware.node.test.ts` | 33 |
| `__tests__/middleware-maintenance.node.test.ts`（回帰） | 14 |
| `__tests__/api/middleware-order.test.ts`（回帰） | 15 |
| `__tests__/lib/middleware/csrf-protection.test.ts`（回帰） | 25 |

回帰3ファイルは CSRF の処理順を変更したため追加で実行しています。

主なカバー範囲: 署名・検証の往復、改ざん／期限切れ／資格情報・署名鍵ローテーションによる失効、Cookie 検証の非終端性（改ざん Cookie + 正しい Basic からの復旧）、fail-closed の 503、`/api/` への Cookie 非発行、メンテナンス 503・ログインリダイレクト経路での Cookie 発行、`__Host-` prefix、非 ASCII／コロン含み／NFD 設定値／不正 Base64／不正 UTF-8／制御文字。

### レビュー

Codex + Devil's Advocate による cross-review（Full Tier、盲検化）を PLAN 時と IMPLEMENT 時の 2 回実施し、指摘は以下のとおり反映済みです。

- `BASIC_AUTH_ENABLED` の表記揺れによる fail-open（Critical）
- `lib/` 配下の `process.env` 直接参照による ESLint エラー 7 件（環境変数の読み出しを `proxy.ts` へ移し `GateEnv` として渡す構造に変更）
- CSRF の early return がゲート評価と `finalize()` を迂回
- `charset="UTF-8"` を宣言しながら NFC 正規化していなかった点
- 設定不備が黙って 503 になり原因が分かりにくい点（不足環境変数名をプロセスにつき一度だけログ出力）

## デプロイ手順

### 1. `BASIC_AUTH_GATE_SECRET` を設定する（必須）

```bash
openssl rand -hex 32
```

生成した値を Vercel の **Production / Preview / Development の全スコープ**に設定してください。

**現在 Basic 認証を有効にしている環境にこの変更をそのままデプロイすると、鍵が未設定のスコープは正しい資格情報を送っても全リクエストが 503 になります。** これは意図した fail-closed 挙動です（設定漏れでサイトが全公開になるより安全側に倒す判断）。cron Bearer は設定不備チェックより前に評価されるため、バッチ処理は停止しません。

### 2. デプロイ後の確認

- [ ] Safari で初回入力後、通常遷移・RSC 遷移で再入力が発生しないこと
- [ ] `Set-Cookie`（production では `__Host-tt_gate`）が保存されていること
- [ ] 再発した場合: 401 の本文・`x-vercel-id`・`Authorization`/`Cookie` の有無を HAR で確認し、Vercel Dashboard の Deployment Protection を点検する（アプリ側の修正では解消しないケース）
- [ ] `/api/articles/read-status` と `/api/telemetry/vitals` の beacon が 200 で通るようになったか（Basic 認証 ON 時にサイレントに 401 で失われていた可能性がある）

## 既知事項

### `.env.example` が未更新

権限設定により本セッションからは `.env.example` を読み書きできなかったため、以下を手動で追記する必要があります。

```
# Basic 認証ゲートの Cookie 署名鍵（BASIC_AUTH_ENABLED=true のとき必須、32文字以上）
# 未設定だと全リクエストが 503 になります（fail-closed）
# 生成例: openssl rand -hex 32
BASIC_AUTH_GATE_SECRET=
```

### npm audit の high（別 PR 対応）

```
nanoid <3.3.18  Severity: high  GHSA-2v37-7h3g-55p8
経路: @tailwindcss/postcss (devDependency) → postcss@8.5.23 (overridden) → nanoid@3.3.16
```

本 PR は `package.json` / `package-lock.json` を一切変更しておらず、main でも同じ結果になります。devDependency 経由のビルド時依存で本番ランタイムには載らず、脆弱性も `nanoid(0)` 呼び出しが前提のため PostCSS 経路からは到達しません。`overrides` への追加で別 PR 対応とします。

## スコープ外

- CSRF と cron Bearer の処理順（`lib/middleware/csrf-protection.ts` が Bearer 単体では通らずセッションを要求する）。現行 cron 経路は GET のため実害なし
- `proxy.ts` matcher の拡張子除外リストの見直し（`.json` / `.xml` / `.webmanifest` / `.avif` が未除外。該当ファイルが存在せず実害なし）
- Basic 認証へのレート制限追加（既存の課題）

## チェックリスト

- [x] テスト通過（119 件、回帰3ファイル含む）
- [x] Lint / 型チェック通過
- [x] 本番ビルド通過
- [ ] ドキュメント更新済み（`.env.example` が権限制約により未更新。上記「既知事項」参照）
- [ ] 破壊的変更なし（**デプロイ設定に破壊的変更あり**: `BASIC_AUTH_GATE_SECRET` が必須。また `BASIC_AUTH_ENABLED=true` かつ資格情報未設定の環境は従来「全公開」だったものが 503 になる）

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Basic認証によるアクセス保護を追加しました。
  - 認証成功後は署名付きCookieで一定期間アクセスを維持できます。
  - Cron向けのBearer認証にも対応しました。
  - 本番環境では安全なCookie属性を適用します。

- **セキュリティ改善**
  - Cookieの改ざんや期限切れ、認証情報変更を検知して拒否します。
  - 認証設定に不備がある場合は安全側に倒してアクセスを停止します。
  - API、メンテナンス、リダイレクト時の認証制御を統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->