### PR TITLE
fix(deps): Dependabot アラート 3 件対応（hono 4.12.34）+ nanoid 3.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12975,9 +12975,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -18085,9 +18085,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -283,10 +283,11 @@
     "better-call": {
       "zod": "$zod"
     },
-    "hono": "4.12.27",
+    "hono": "4.12.34",
     "@hono/node-server": "2.0.10",
     "follow-redirects": "1.16.0",
     "postcss": "8.5.23",
+    "nanoid": "3.3.18",
     "uuid": "^14.0.0",
     "esbuild": "0.28.1",
     "ws": "8.21.0",


### PR DESCRIPTION
## 概要

- Dependabot セキュリティアラート 3 件（#182 / #181 / #180、いずれも `hono`）を `overrides` の `hono` を `4.12.27` → `4.12.34` に更新して解消
- 併せて `nanoid` を `overrides` に `3.3.18` として追加し、`npm audit --production --audit-level=high` を通過させた
- 変更は `package.json` の `overrides` 2 箇所と `package-lock.json` のみ。アプリケーションコードの変更なし

## 実装内容

### hono（Dependabot Alert #182 / #181 / #180）

`hono` は `@hono/node-server` 経由の transitive（development）依存のため、`package.json` の `overrides` で patched version を強制する既存方針を踏襲した。

| Alert | GHSA | Severity | 内容 |
| --- | --- | --- | --- |
| #182 | GHSA-f23p-vx2j-j53r | medium | `memo()` が SSR 出力をリクエスト間で保持し、クロスユーザーのデータ漏洩につながる |
| #181 | GHSA-79qm-7rj5-m7r9 | low | Proxy Helper が `Connection` ヘッダに列挙されたレスポンスヘッダを削除しない |
| #180 | GHSA-54fx-42gc-7vw4 | medium | Language Middleware のアルゴリズム的複雑性による DoS |

`@hono/node-server@2.0.10` の peer 要求は `hono: ^4` のため、`4.12.34` は互換範囲内（patch bump）。

### nanoid（GHSA-2v37-7h3g-55p8, high）

Dependabot にはアラート未登録だが、`npm audit` で **production 依存**の high として検出された。

- 依存経路: `critters` / `@tailwindcss/postcss` → `postcss@8.5.23`（override 済み）→ `nanoid@3.3.16`
- 脆弱性: `size` が 0 のときカスタムジェネレータが無限ループする（`<3.3.18`、CWE-835）
- 本 PR 前の `npm audit --production --audit-level=high` は **exit=1**（このアラート単独が原因）で、検証ゲートを塞いでいたため同時に修正した
- 依存ツリー内の `nanoid` は 1 系統（3.3.x）のみのため、トップレベル override で影響範囲は閉じている

### 未対応（別途判断が必要）

**Dependabot Alert #184 `extract-zip`（GHSA-jmr9-qjv8-65gv, high, development）** は `first_patched_version` が未公開（`<= 2.0.1` が全て脆弱）のため、本 PR では対応していない。

- 依存経路: `@lhci/cli` → `lighthouse` → `puppeteer-core` → `@puppeteer/browsers` → `extract-zip`
- npm が提示する `fixAvailable` は `@lhci/cli` の破壊的変更を伴うため、修正版の公開待ち・dismiss・`@lhci/cli` の major 更新のいずれを取るか別途判断が必要

## テスト結果

`/verify` フェーズをすべて実行し、出力を確認済み。

| Step | コマンド | 結果 |
| --- | --- | --- |
| Lint / Type Check | `npm run lint` / `npm run type-check` | 0 errors / 0 warnings |
| Security Audit | `npm audit --production --audit-level=high` | **exit=0**（本 PR 前は exit=1） |
| Build | `npm run docker:build:ci` → `npm run docker:build` | **exit=0** |
| Test | `npm run docker:test` | **exit=0** / 341 suites・5183 tests passed, 0 failed |
| Diff Review | `git diff` | 意図しない変更・機密情報の混入なし |
| Visual | — | SKIP（`.tsx` 変更なし） |

`npm audit` の残存は moderate 3 件（`prisma` / `@prisma/dev` / `valibot`）と、上記 #184 の `extract-zip` 系統（development のみ）。

### 検証時の注意点

`docker-compose.test.yml` の `node-ci` サービスは volume マウントを持たず `node_modules` をイメージに内包しているため、`npm run docker:build:ci` で CI イメージを再ビルドしないと **更新前の依存でビルド・テストが実行される**。本 PR では再ビルド後にイメージ内で `hono@4.12.34` / `nanoid@3.3.18` を確認したうえで build / test を実行し直している。

## チェックリスト

- [x] テスト通過
- [x] ドキュメント更新済み（該当なし）
- [x] 破壊的変更なし（いずれも patch レベルの更新）

Generated with Claude Code
