### PR TITLE
refactor(auth): Issue #647 Bearer パース規則を共有ヘルパーへ集約

### DIFF
--- a/__tests__/api/feeds/collect/with-feed-collect-auth.test.ts
+++ b/__tests__/api/feeds/collect/with-feed-collect-auth.test.ts
@@ -1,0 +1,188 @@
+/**
+ * withFeedCollectTokenAuth（feeds/collect の GET 専用ラッパー）のテスト。
+ *
+ * このラッパーは withCronOrAdminAuth に委譲せず独自に Bearer を抽出するため、
+ * 共有パーサー化（issue #647 項目3）で実際に挙動が変わる経路の 1 つである。
+ * GET は CSRF 保護の対象外（CSRF_PROTECTED_METHODS に含まれない）なので、
+ * サーバ間の Bearer 呼び出しがエンドツーエンドで到達しうる数少ない経路でもある。
+ *
+ * 本ファイル追加前はこのラッパーのテストが 1 件も存在しなかった。
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { NextRequest, NextResponse } from 'next/server';
+
+import {
+  withFeedCollectTokenAuth,
+  withFeedCollectAuth,
+} from '@/app/api/feeds/collect/with-feed-collect-auth';
+import { resetEnvCache } from '@/lib/config/env';
+
+const SECRET = 'valid-feed-collect-secret';
+
+describe('withFeedCollectTokenAuth (GET)', () => {
+  const mockHandler = jest.fn(async () => NextResponse.json({ success: true }));
+
+  const buildRequest = (init?: { authorization?: string; token?: string }) => {
+    const url = init?.token
+      ? `http://localhost:3000/api/feeds/collect?token=${encodeURIComponent(init.token)}`
+      : 'http://localhost:3000/api/feeds/collect';
+
+    return new NextRequest(url, {
+      headers: init?.authorization
+        ? { Authorization: init.authorization }
+        : undefined,
+    });
+  };
+
+  beforeEach(() => {
+    mockHandler.mockClear();
+    delete process.env.CRON_SECRET;
+    delete process.env.CRON_TOKEN;
+    resetEnvCache();
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    delete process.env.CRON_TOKEN;
+    resetEnvCache();
+  });
+
+  describe('Bearer 認証', () => {
+    it.each(['CRON_SECRET', 'CRON_TOKEN'] as const)(
+      '正しい Bearer トークンで通す (%s)',
+      async (envVar) => {
+        process.env[envVar] = SECRET;
+        resetEnvCache();
+
+        const response = await withFeedCollectTokenAuth(mockHandler)(
+          buildRequest({ authorization: `Bearer ${SECRET}` })
+        );
+
+        expect(response.status).toBe(200);
+        expect(mockHandler).toHaveBeenCalled();
+      }
+    );
+
+    // Basic 認証ゲート（lib/auth/basic-auth-gate.ts）と同一の受理判定になることを固定する。
+    // ゲートは通るが API 側で 401 になる不整合が issue #647 項目3 の原因だった。
+    it.each([
+      ['小文字スキーム', `bearer ${SECRET}`],
+      ['大文字スキーム', `BEARER ${SECRET}`],
+      ['タブ区切り', `Bearer\t${SECRET}`],
+      ['複数空白区切り', `Bearer   ${SECRET}`],
+      ['末尾に空白', `Bearer ${SECRET}  `],
+    ])('%s でも通す（ゲートと同一の受理判定）', async (_label, authorization) => {
+      process.env.CRON_SECRET = SECRET;
+      resetEnvCache();
+
+      const response = await withFeedCollectTokenAuth(mockHandler)(
+        buildRequest({ authorization })
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockHandler).toHaveBeenCalled();
+    });
+
+    it.each([
+      ['トークンが違う', 'Bearer wrong-secret'],
+      ['複数トークン', `Bearer ${SECRET} extra`],
+      ['スキームが Basic', `Basic ${SECRET}`],
+      ['トークンなし', 'Bearer'],
+      ['制御文字を含む', `Bearer ${SECRET}\u0001`],
+    ])('%s は 401 にする', async (_label, authorization) => {
+      process.env.CRON_SECRET = SECRET;
+      resetEnvCache();
+
+      const response = await withFeedCollectTokenAuth(mockHandler)(
+        buildRequest({ authorization })
+      );
+
+      expect(response.status).toBe(401);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    it('Authorization ヘッダがなければ 401 にする', async () => {
+      process.env.CRON_SECRET = SECRET;
+      resetEnvCache();
+
+      const response = await withFeedCollectTokenAuth(mockHandler)(
+        buildRequest()
+      );
+
+      expect(response.status).toBe(401);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+
+    it('シークレット未設定なら正しい形式でも 401 にする（fail-closed）', async () => {
+      const response = await withFeedCollectTokenAuth(mockHandler)(
+        buildRequest({ authorization: `Bearer ${SECRET}` })
+      );
+
+      expect(response.status).toBe(401);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('?token= クエリパラメータ（後方互換）', () => {
+    it('正しい token で通す', async () => {
+      process.env.CRON_SECRET = SECRET;
+      resetEnvCache();
+
+      const response = await withFeedCollectTokenAuth(mockHandler)(
+        buildRequest({ token: SECRET })
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockHandler).toHaveBeenCalled();
+    });
+
+    it('不正な token は Bearer にフォールスルーせず即 401 にする', async () => {
+      process.env.CRON_SECRET = SECRET;
+      resetEnvCache();
+
+      // 正しい Bearer を同時に付けても、?token= が不正なら 401 で終端する
+      const response = await withFeedCollectTokenAuth(mockHandler)(
+        buildRequest({ token: 'wrong-token', authorization: `Bearer ${SECRET}` })
+      );
+
+      expect(response.status).toBe(401);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('withFeedCollectAuth (POST) の Bearer 経路', () => {
+  const mockHandler = jest.fn(async () => NextResponse.json({ success: true }));
+
+  beforeEach(() => {
+    mockHandler.mockClear();
+    delete process.env.CRON_SECRET;
+    delete process.env.CRON_TOKEN;
+    resetEnvCache();
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    delete process.env.CRON_TOKEN;
+    resetEnvCache();
+  });
+
+  // POST は withCronOrAdminAuth へ委譲する。ラッパー単体では小文字スキームも
+  // 受理されることを確認する（proxy 経路では CSRF が先に効くため、
+  // エンドツーエンドでの到達性とは別の話である点に注意）。
+  it('小文字スキームでも委譲先が受理する', async () => {
+    process.env.CRON_SECRET = SECRET;
+    resetEnvCache();
+
+    const request = new NextRequest('http://localhost:3000/api/feeds/collect', {
+      method: 'POST',
+      headers: { Authorization: `bearer ${SECRET}` },
+    });
+
+    const response = await withFeedCollectAuth(mockHandler)(request);
+
+    expect(response.status).toBe(200);
+    expect(mockHandler).toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/workers/embedding.test.ts
+++ b/__tests__/api/workers/embedding.test.ts
@@ -315,6 +315,41 @@ describe('withEmbeddingWorkerAuth', () => {
     }
   );
 
+  // ゲート（lib/auth/basic-auth-gate.ts）と同一の受理判定であることを固定する（issue #647 項目3）
+  it.each([
+    ['小文字スキーム', 'bearer valid-embedding-secret'],
+    ['タブ区切り', 'Bearer\tvalid-embedding-secret'],
+    ['複数空白区切り', 'Bearer   valid-embedding-secret'],
+  ])('should return 200 with %s (ゲートと同一の受理判定)', async (_label, authorization) => {
+    process.env.CRON_SECRET = 'valid-embedding-secret';
+    resetEnvCache();
+
+    const handler = realWithEmbeddingWorkerAuth(mockHandler);
+    const request = new NextRequest('http://localhost:3000/api/workers/embedding', {
+      headers: { Authorization: authorization },
+    });
+
+    const response = await handler(request);
+
+    expect(response.status).toBe(200);
+    expect(mockHandler).toHaveBeenCalled();
+  });
+
+  it('should return 401 with a Bearer header carrying multiple tokens', async () => {
+    process.env.CRON_SECRET = 'valid-embedding-secret';
+    resetEnvCache();
+
+    const handler = realWithEmbeddingWorkerAuth(mockHandler);
+    const request = new NextRequest('http://localhost:3000/api/workers/embedding', {
+      headers: { Authorization: 'Bearer valid-embedding-secret extra' },
+    });
+
+    const response = await handler(request);
+
+    expect(response.status).toBe(401);
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
   it('should return 401 (fail-closed) with a Bearer token when neither CRON_SECRET nor CRON_TOKEN is set', async () => {
     // Both env vars are deleted in beforeEach; do not set either here.
     resetEnvCache();

--- a/__tests__/lib/config/env.test.ts
+++ b/__tests__/lib/config/env.test.ts
@@ -690,8 +690,8 @@ describe('Environment Configuration - CRON_TOKEN / CRON_SECRET の形式検証',
       ['英数字', 'abc123'],
       ['記号を含む', 'a-b_c.d~e'],
       ['16進文字列（openssl rand -hex 32 相当）', 'a'.repeat(64)],
-      ['非 ASCII', 'トークン'],
-      ['NBSP を含む（共有パーサーも token として受理するため）', 'a\u00a0b'],
+      ['base64url 相当', 'aB3-_x.~+/='],
+      ['可視 ASCII の両端', '!~'],
     ])('CRON_TOKEN: %s は受理される', (_label, value) => {
       process.env.CRON_TOKEN = value;
       resetEnvCache();
@@ -713,6 +713,11 @@ describe('Environment Configuration - CRON_TOKEN / CRON_SECRET の形式検証',
       ['タブを含む', 'a\tb'],
       ['改行を含む（コピペ事故の典型）', 'abc\n'],
       ['制御文字を含む', 'abc\u0001'],
+      ['DEL を含む', 'abc\u007F'],
+      // 以下は「設定はできるが Authorization ヘッダとして送出できない／
+      // 途中で壊れる」値。cross-review で検出した実際の欠陥に対応する。
+      ['非 ASCII（ByteString に変換できず送出不可）', 'トークン'],
+      ['NBSP を含む（obs-text であり proxy/CDN での扱いが保証されない）', 'a\u00a0b'],
     ])('CRON_TOKEN: %s は検証エラーになる', (_label, value) => {
       process.env.CRON_TOKEN = value;
       resetEnvCache();
@@ -744,6 +749,26 @@ describe('Environment Configuration - CRON_TOKEN / CRON_SECRET の形式検証',
       resetEnvCache();
       expect(() => getEnv()).not.toThrow();
       expect(getEnv().CRON_TOKEN).toBeUndefined();
+    });
+  });
+
+  describe('受理された値は Authorization ヘッダとして送出できる', () => {
+    // 検証の目的は「設定はできるが認証には使えない値」を弾くこと。
+    // HTTP ヘッダ値は ByteString のため U+00FF を超える文字は載せられない。
+    it('受理される値は Headers に設定でき、値が保持される', () => {
+      const value = 'a'.repeat(64);
+      process.env.CRON_TOKEN = value;
+      resetEnvCache();
+
+      expect(getEnv().CRON_TOKEN).toBe(value);
+      const headers = new Headers({ authorization: `Bearer ${value}` });
+      expect(headers.get('authorization')).toBe(`Bearer ${value}`);
+    });
+
+    it('拒否される非 ASCII 値は Headers に設定しようとすると TypeError になる', () => {
+      expect(
+        () => new Headers({ authorization: 'Bearer トークン' })
+      ).toThrow(TypeError);
     });
   });
 });

--- a/__tests__/lib/config/env.test.ts
+++ b/__tests__/lib/config/env.test.ts
@@ -765,10 +765,12 @@ describe('Environment Configuration - CRON_TOKEN / CRON_SECRET の形式検証',
       expect(headers.get('authorization')).toBe(`Bearer ${value}`);
     });
 
-    it('拒否される非 ASCII 値は Headers に設定しようとすると TypeError になる', () => {
-      expect(
-        () => new Headers({ authorization: 'Bearer トークン' })
-      ).toThrow(TypeError);
+    it('拒否される非 ASCII 値は Headers に設定できない', () => {
+      // TypeError のコンストラクタ同一性は jest の realm 差で一致しないため
+      // メッセージで検証する（ByteString 変換に失敗することが確認できればよい）。
+      expect(() => new Headers({ authorization: 'Bearer トークン' })).toThrow(
+        /ByteString/
+      );
     });
   });
 });

--- a/__tests__/lib/config/env.test.ts
+++ b/__tests__/lib/config/env.test.ts
@@ -662,3 +662,88 @@ describe('Environment Configuration - Config Helpers', () => {
     expect(config.app.url()).toBe('https://example.com');
   });
 });
+
+describe('Environment Configuration - CRON_TOKEN / CRON_SECRET の形式検証', () => {
+  // lib/auth/authorization-header.ts の受理規則（token は [^ \t]+、制御文字は拒否）と
+  // 1 対 1 で対応することを固定する。ここを緩めると「設定はできるが認証には使えない」
+  // シークレットが本番に入り、cron 認証がサイレントに壊れる。
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeAll(() => {
+    originalEnv = { ...process.env };
+  });
+
+  beforeEach(() => {
+    resetEnvCache();
+    process.env = { ...originalEnv };
+    delete process.env.CRON_TOKEN;
+    delete process.env.CRON_SECRET;
+  });
+
+  afterAll(() => {
+    resetEnvCache();
+    process.env = originalEnv;
+  });
+
+  describe('受理される値', () => {
+    it.each([
+      ['英数字', 'abc123'],
+      ['記号を含む', 'a-b_c.d~e'],
+      ['16進文字列（openssl rand -hex 32 相当）', 'a'.repeat(64)],
+      ['非 ASCII', 'トークン'],
+      ['NBSP を含む（共有パーサーも token として受理するため）', 'a\u00a0b'],
+    ])('CRON_TOKEN: %s は受理される', (_label, value) => {
+      process.env.CRON_TOKEN = value;
+      resetEnvCache();
+      expect(getEnv().CRON_TOKEN).toBe(value);
+    });
+
+    it('CRON_SECRET も同じ規則で受理される', () => {
+      process.env.CRON_SECRET = 'valid-secret-value';
+      resetEnvCache();
+      expect(getEnv().CRON_SECRET).toBe('valid-secret-value');
+    });
+  });
+
+  describe('拒否される値', () => {
+    it.each([
+      ['内部に空白', 'a b'],
+      ['末尾に空白', 'abc '],
+      ['先頭に空白', ' abc'],
+      ['タブを含む', 'a\tb'],
+      ['改行を含む（コピペ事故の典型）', 'abc\n'],
+      ['制御文字を含む', 'abc\u0001'],
+    ])('CRON_TOKEN: %s は検証エラーになる', (_label, value) => {
+      process.env.CRON_TOKEN = value;
+      resetEnvCache();
+      expect(() => getEnv()).toThrow(/CRON_TOKEN/);
+    });
+
+    it('CRON_SECRET も同じ規則で拒否される', () => {
+      process.env.CRON_SECRET = 'a b';
+      resetEnvCache();
+      expect(() => getEnv()).toThrow(/CRON_SECRET/);
+    });
+  });
+
+  describe('sanitizeEnv による前処理（空白のみは未設定扱い）', () => {
+    // sanitizeEnv() が空白のみの文字列を undefined へ変換するため regex に到達しない。
+    // 「空白を含む値はエラー」と単純化すると誤りになるので、この挙動を固定しておく。
+    it.each([
+      ['空文字列', ''],
+      ['空白のみ', '   '],
+      ['タブのみ', '\t'],
+    ])('CRON_TOKEN: %s はエラーにならず undefined になる', (_label, value) => {
+      process.env.CRON_TOKEN = value;
+      resetEnvCache();
+      expect(() => getEnv()).not.toThrow();
+      expect(getEnv().CRON_TOKEN).toBeUndefined();
+    });
+
+    it('未設定でもエラーにならない', () => {
+      resetEnvCache();
+      expect(() => getEnv()).not.toThrow();
+      expect(getEnv().CRON_TOKEN).toBeUndefined();
+    });
+  });
+});

--- a/__tests__/lib/config/env.test.ts
+++ b/__tests__/lib/config/env.test.ts
@@ -664,9 +664,13 @@ describe('Environment Configuration - Config Helpers', () => {
 });
 
 describe('Environment Configuration - CRON_TOKEN / CRON_SECRET の形式検証', () => {
-  // lib/auth/authorization-header.ts の受理規則（token は [^ \t]+、制御文字は拒否）と
-  // 1 対 1 で対応することを固定する。ここを緩めると「設定はできるが認証には使えない」
-  // シークレットが本番に入り、cron 認証がサイレントに壊れる。
+  // 受理範囲は lib/auth/cron-secret.ts の CRON_SECRET_PATTERN（可視 ASCII）と共有する。
+  // ここを緩めると「設定はできるが認証には使えない」シークレットが本番に入り、
+  // cron 認証がサイレントに壊れる。
+  //
+  // 注: lib/auth/authorization-header.ts のトークン抽出規則とは一致しない。
+  // パーサーはワイヤから届いた値の受理規則で非 ASCII も通すが、こちらは
+  // 「設定してよい値」のポリシーであり、HTTP ヘッダとして送出できない値を弾くぶん厳しい。
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeAll(() => {
@@ -717,7 +721,10 @@ describe('Environment Configuration - CRON_TOKEN / CRON_SECRET の形式検証',
       // 以下は「設定はできるが Authorization ヘッダとして送出できない／
       // 途中で壊れる」値。cross-review で検出した実際の欠陥に対応する。
       ['非 ASCII（ByteString に変換できず送出不可）', 'トークン'],
-      ['NBSP を含む（obs-text であり proxy/CDN での扱いが保証されない）', 'a\u00a0b'],
+      [
+        'NBSP を含む（obs-text であり proxy/CDN での扱いが保証されない）',
+        'a\u00a0b',
+      ],
     ])('CRON_TOKEN: %s は検証エラーになる', (_label, value) => {
       process.env.CRON_TOKEN = value;
       resetEnvCache();

--- a/__tests__/lib/middleware/csrf-protection.test.ts
+++ b/__tests__/lib/middleware/csrf-protection.test.ts
@@ -382,6 +382,56 @@ describe('csrf-protection', () => {
     });
   });
 
+  // issue #647 項目3: Bearer のスキーム判定を hasBearerScheme（case-insensitive）へ
+  // 置き換えたことで、CSRF 免除の入口が広がっていないことを固定する。
+  //
+  // この分岐の認可の実体は Cookie セッション（auth.api.getSession）であり、
+  // Authorization ヘッダの値そのものはセッションを確立しない。lib/auth/auth.ts の
+  // plugins に Better Auth の bearer プラグインを追加すると、この前提が崩れる。
+  describe('Bearer スキーム判定の受理範囲（issue #647）', () => {
+    const buildRequest = (authorization: string) =>
+      new NextRequest(new URL('http://localhost:3000/api/test'), {
+        method: 'POST',
+        headers: { origin: 'http://evil.com', authorization },
+      });
+
+    it.each([
+      ['小文字スキーム', 'bearer some-token'],
+      ['大文字スキーム', 'BEARER some-token'],
+      ['タブ区切り', 'Bearer\tsome-token'],
+    ])(
+      '%s でもセッションがなければ拒否する（スキーム緩和で免除が広がらない）',
+      async (_label, authorization) => {
+        getAuthApiGetSession().mockResolvedValue(null);
+
+        const request = buildRequest(authorization);
+        const ctx = extendWithSessionContext(undefined, request.headers);
+
+        await expect(validateOrigin(request, ctx)).resolves.toBe(false);
+      }
+    );
+
+    it('小文字スキームでも有効なセッションがあれば通す（判定が case-insensitive になっている）', async () => {
+      getAuthApiGetSession().mockResolvedValue({ user: { id: 'user-1' } });
+
+      const request = buildRequest('bearer some-token');
+      const ctx = extendWithSessionContext(undefined, request.headers);
+
+      await expect(validateOrigin(request, ctx)).resolves.toBe(true);
+    });
+
+    it('proxy 経路（context なし）ではセッションを解決できないため拒否する', async () => {
+      // proxy.ts は csrfProtection(request) を context なしで呼ぶため、
+      // resolveSession は常に null を返す。Bearer の形式に関わらず通らない。
+      getAuthApiGetSession().mockResolvedValue({ user: { id: 'user-1' } });
+
+      const request = buildRequest('Bearer some-token');
+
+      await expect(validateOrigin(request)).resolves.toBe(false);
+      expect(getAuthApiGetSession()).not.toHaveBeenCalled();
+    });
+  });
+
   describe('constants', () => {
     it('should have expected exempt paths', () => {
       expect(CSRF_EXEMPT_PATHS).toContain('/api/auth');

--- a/__tests__/lib/middleware/with-cron-or-admin-auth.test.ts
+++ b/__tests__/lib/middleware/with-cron-or-admin-auth.test.ts
@@ -75,6 +75,49 @@ describe('withCronOrAdminAuth', () => {
       expect(getAuthApiGetSession()).not.toHaveBeenCalled();
     });
 
+    // Basic 認証ゲート（lib/auth/basic-auth-gate.ts）と同じ受理判定になることを固定する。
+    // ゲートは通るが API 側で 401 になる、という不整合が issue #647 項目3 の原因だった。
+    it.each([
+      ['小文字スキーム', 'bearer valid-secret-token-12345'],
+      ['大文字スキーム', 'BEARER valid-secret-token-12345'],
+      ['タブ区切り', 'Bearer\tvalid-secret-token-12345'],
+      ['複数空白区切り', 'Bearer   valid-secret-token-12345'],
+      ['末尾に空白', 'Bearer valid-secret-token-12345  '],
+    ])(
+      'should authenticate with %s (ゲートと同一の受理判定)',
+      async (_label, authorization) => {
+        process.env.CRON_SECRET = 'valid-secret-token-12345';
+        resetEnvCache();
+
+        const handler = withCronOrAdminAuth(mockHandler);
+        const request = new NextRequest('http://localhost/api/test', {
+          method: 'POST',
+          headers: { Authorization: authorization },
+        });
+
+        const response = await handler(request);
+
+        expect(response.status).toBe(200);
+        expect(mockHandler).toHaveBeenCalled();
+      }
+    );
+
+    it('should reject a Bearer header carrying multiple tokens', async () => {
+      process.env.CRON_SECRET = 'valid-secret-token-12345';
+      resetEnvCache();
+
+      const handler = withCronOrAdminAuth(mockHandler);
+      const request = new NextRequest('http://localhost/api/test', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-secret-token-12345 extra' },
+      });
+
+      const response = await handler(request);
+
+      expect(response.status).toBe(401);
+      expect(mockHandler).not.toHaveBeenCalled();
+    });
+
     it('should authenticate with valid Bearer token (CRON_TOKEN)', async () => {
       process.env.CRON_TOKEN = 'valid-cron-token-67890';
       resetEnvCache();

--- a/__tests__/middleware.node.test.ts
+++ b/__tests__/middleware.node.test.ts
@@ -156,6 +156,10 @@ describe('middleware - security headers', () => {
 
       expect(response.status).not.toBe(401);
       expect(response.headers.get('Content-Security-Policy')).toBeDefined();
+      // not.toBe(401) だけでは設定不備の 503 も成功として通ってしまうため、
+      // ゲートを通過したときだけ finalize が付与するヘッダで確認する。
+      expect(response.headers.get('CDN-Cache-Control')).toBe('no-store');
+      expect(response.headers.get('Vary')).toContain('Authorization');
     });
 
     // ゲートと API 側でシークレットの選択規則が一致していることを固定する。
@@ -174,6 +178,8 @@ describe('middleware - security headers', () => {
       const response = await proxy(request);
 
       expect(response.status).not.toBe(401);
+      expect(response.headers.get('CDN-Cache-Control')).toBe('no-store');
+      expect(response.headers.get('Vary')).toContain('Authorization');
     });
 
     it('should accept a lowercase bearer scheme for cron requests', async () => {
@@ -187,6 +193,8 @@ describe('middleware - security headers', () => {
       const response = await proxy(request);
 
       expect(response.status).not.toBe(401);
+      expect(response.headers.get('CDN-Cache-Control')).toBe('no-store');
+      expect(response.headers.get('Vary')).toContain('Authorization');
     });
 
     it('should redirect to login for protected paths without session', async () => {

--- a/__tests__/middleware.node.test.ts
+++ b/__tests__/middleware.node.test.ts
@@ -158,6 +158,37 @@ describe('middleware - security headers', () => {
       expect(response.headers.get('Content-Security-Policy')).toBeDefined();
     });
 
+    // ゲートと API 側でシークレットの選択規則が一致していることを固定する。
+    // proxy.ts が生の process.env を使っていた頃は、空白のみの CRON_TOKEN を
+    // truthy として選び、API 側（sanitizeEnv 済み）が CRON_SECRET を選ぶという
+    // 不一致があった。ゲートだけが 401 を返す原因になる。
+    it('should fall back to CRON_SECRET when CRON_TOKEN is whitespace-only', async () => {
+      process.env.BASIC_AUTH_ENABLED = 'true';
+      process.env.BASIC_AUTH_PASS = 'secret';
+      process.env.BASIC_AUTH_GATE_SECRET = 'f'.repeat(64);
+      process.env.CRON_TOKEN = '   ';
+      process.env.CRON_SECRET = 'valid-cron-secret';
+
+      const request = new NextRequest(new URL('http://localhost:3000/'));
+      request.headers.set('authorization', 'Bearer valid-cron-secret');
+      const response = await proxy(request);
+
+      expect(response.status).not.toBe(401);
+    });
+
+    it('should accept a lowercase bearer scheme for cron requests', async () => {
+      process.env.BASIC_AUTH_ENABLED = 'true';
+      process.env.BASIC_AUTH_PASS = 'secret';
+      process.env.BASIC_AUTH_GATE_SECRET = 'f'.repeat(64);
+      process.env.CRON_TOKEN = 'test-cron-secret';
+
+      const request = new NextRequest(new URL('http://localhost:3000/'));
+      request.headers.set('authorization', 'bearer test-cron-secret');
+      const response = await proxy(request);
+
+      expect(response.status).not.toBe(401);
+    });
+
     it('should redirect to login for protected paths without session', async () => {
       const request = new NextRequest(new URL('http://localhost:3000/profile'));
       const response = await proxy(request);

--- a/__tests__/unit/auth/authorization-header.test.ts
+++ b/__tests__/unit/auth/authorization-header.test.ts
@@ -1,0 +1,190 @@
+/**
+ * lib/auth/authorization-header.ts の単体テスト。
+ *
+ * 純関数のみで構成されるモジュールのため NextRequest 等のモックは不要。
+ * ゲート（basic-auth-gate）と cron 認証ラッパーが同じ受理判定になることを
+ * 保証するのがこのモジュールの目的なので、受理・拒否の境界を網羅する。
+ */
+
+import {
+  CONTROL_CHAR_PATTERN,
+  extractBasicToken,
+  extractBearerToken,
+  hasBearerScheme,
+} from '@/lib/auth/authorization-header';
+
+const CTL = '\u0001';
+const DEL = '\u007F';
+
+describe('authorization-header', () => {
+  describe('extractBearerToken', () => {
+    it('通常形式の token を取り出す', () => {
+      expect(extractBearerToken('Bearer abc')).toBe('abc');
+    });
+
+    it.each(['bearer abc', 'BEARER abc', 'BeArEr abc'])(
+      'スキーム名は大文字小文字を区別しない: %s',
+      (header) => {
+        expect(extractBearerToken(header)).toBe('abc');
+      }
+    );
+
+    it('タブ区切りを受理する', () => {
+      expect(extractBearerToken('Bearer\tabc')).toBe('abc');
+    });
+
+    it('複数の空白区切りを受理する', () => {
+      expect(extractBearerToken('Bearer   abc')).toBe('abc');
+    });
+
+    it('空白とタブが混在する区切りを受理する', () => {
+      expect(extractBearerToken('Bearer \t abc')).toBe('abc');
+    });
+
+    it('末尾の空白・タブを無視する', () => {
+      expect(extractBearerToken('Bearer abc  ')).toBe('abc');
+      expect(extractBearerToken('Bearer abc\t')).toBe('abc');
+    });
+
+    it('token が複数語なら拒否する', () => {
+      expect(extractBearerToken('Bearer abc def')).toBeNull();
+    });
+
+    it.each([
+      ['制御文字(U+0001)', `Bearer abc${CTL}`],
+      ['DEL(U+007F)', `Bearer abc${DEL}`],
+    ])('token に %s を含む場合は拒否する', (_label, header) => {
+      expect(extractBearerToken(header)).toBeNull();
+    });
+
+    it.each([
+      ['token なし', 'Bearer'],
+      ['区切りのみで token なし', 'Bearer '],
+      ['空文字列', ''],
+      ['スキーム不一致(Basic)', 'Basic abc'],
+      ['前置文字あり', 'XBearer abc'],
+    ])('%s は拒否する', (_label, header) => {
+      expect(extractBearerToken(header)).toBeNull();
+    });
+
+    it('null を渡しても例外にならず null を返す', () => {
+      expect(extractBearerToken(null)).toBeNull();
+    });
+
+    it('空白を含むシークレット相当の値は取り出せない（env 側で禁止している前提）', () => {
+      // lib/config/env.ts の CRON_TOKEN / CRON_SECRET は空白を禁止しており、
+      // このケースが本番で発生しないことを検証で担保している。
+      expect(extractBearerToken('Bearer a b')).toBeNull();
+    });
+  });
+
+  describe('extractBasicToken', () => {
+    const token = 'dXNlcjpwYXNz'; // "user:pass"
+
+    it('通常形式の token を取り出す', () => {
+      expect(extractBasicToken(`Basic ${token}`)).toBe(token);
+    });
+
+    it.each(['basic', 'BASIC', 'BaSiC'])(
+      'スキーム名は大文字小文字を区別しない: %s',
+      (scheme) => {
+        expect(extractBasicToken(`${scheme} ${token}`)).toBe(token);
+      }
+    );
+
+    it('タブ区切りを受理する', () => {
+      expect(extractBasicToken(`Basic\t${token}`)).toBe(token);
+    });
+
+    it('複数の空白区切りを受理する', () => {
+      expect(extractBasicToken(`Basic   ${token}`)).toBe(token);
+    });
+
+    it('末尾の空白・タブを無視する', () => {
+      expect(extractBasicToken(`Basic ${token}  `)).toBe(token);
+    });
+
+    it('token が複数語なら拒否する', () => {
+      expect(extractBasicToken(`Basic ${token} extra`)).toBeNull();
+    });
+
+    it('token に制御文字を含む場合は拒否する', () => {
+      expect(extractBasicToken(`Basic ${token}${CTL}`)).toBeNull();
+    });
+
+    it.each([
+      ['token なし', 'Basic'],
+      ['区切りのみで token なし', 'Basic '],
+      ['空文字列', ''],
+      ['スキーム不一致(Bearer)', 'Bearer abc'],
+    ])('%s は拒否する', (_label, header) => {
+      expect(extractBasicToken(header)).toBeNull();
+    });
+
+    it('null を渡しても例外にならず null を返す', () => {
+      expect(extractBasicToken(null)).toBeNull();
+    });
+
+    it('base64 として不正な値でも抽出はする（デコードは呼び出し元の責務）', () => {
+      // 責務境界の明示: base64 妥当性検証は basic-auth-gate.ts の
+      // decodeBase64Strict が担当し、このモジュールはスキーム抽出のみを担う。
+      expect(extractBasicToken('Basic !!!!')).toBe('!!!!');
+    });
+  });
+
+  describe('hasBearerScheme', () => {
+    it.each(['Bearer abc', 'bearer abc', 'BEARER abc', 'Bearer\tabc'])(
+      'Bearer スキームなら true: %s',
+      (header) => {
+        expect(hasBearerScheme(header)).toBe(true);
+      }
+    );
+
+    it.each([
+      ['Basic', 'Basic abc'],
+      ['token なし', 'Bearer'],
+      ['区切りのみ', 'Bearer '],
+      ['複数語', 'Bearer abc def'],
+      ['空文字列', ''],
+    ])('%s なら false', (_label, header) => {
+      expect(hasBearerScheme(header)).toBe(false);
+    });
+
+    it('null なら false', () => {
+      expect(hasBearerScheme(null)).toBe(false);
+    });
+
+    it('制御文字を含む token でも true を返す（extractBearerToken とは判定が異なる）', () => {
+      // hasBearerScheme は「スキームが Bearer か」だけを判定する述語であり、
+      // token の妥当性は条件に含めない。この差異は意図的な設計。
+      const header = `Bearer abc${CTL}`;
+      expect(hasBearerScheme(header)).toBe(true);
+      expect(extractBearerToken(header)).toBeNull();
+    });
+  });
+
+  describe('CONTROL_CHAR_PATTERN', () => {
+    it.each([
+      ['NUL', '\u0000'],
+      ['SOH', '\u0001'],
+      ['US', '\u001F'],
+      ['DEL', '\u007F'],
+    ])('%s にマッチする', (_label, char) => {
+      expect(CONTROL_CHAR_PATTERN.test(char)).toBe(true);
+    });
+
+    it('タブ(U+0009)にもマッチする（\\u0000-\\u001F の範囲内のため）', () => {
+      // extractAuthToken の token 部は [^ \t]+ でキャプチャされるため、
+      // タブが token に混入することはなく、この重複は実害がない。
+      expect(CONTROL_CHAR_PATTERN.test('\t')).toBe(true);
+    });
+
+    it.each([
+      ['通常文字', 'abc'],
+      ['空白', ' '],
+      ['非 ASCII', 'あ'],
+    ])('%s にはマッチしない', (_label, value) => {
+      expect(CONTROL_CHAR_PATTERN.test(value)).toBe(false);
+    });
+  });
+});

--- a/__tests__/unit/auth/cron-secret.test.ts
+++ b/__tests__/unit/auth/cron-secret.test.ts
@@ -1,0 +1,68 @@
+/**
+ * lib/auth/cron-secret.ts の単体テスト。
+ *
+ * 純関数のみで構成されるモジュールのため NextRequest 等のモックは不要。
+ * CRON_TOKEN 優先・CRON_SECRET フォールバック・不正値の fail-closed
+ * （undefined を返す。フォールバックしない）を固定する。
+ */
+
+import { resolveCronSecret } from '@/lib/auth/cron-secret';
+
+// 制御文字はファイルにリテラルで書き込むとバイナリ扱いになるため \uXXXX で表記する
+const CTL = '\u0001';
+
+describe('resolveCronSecret', () => {
+  it('両方有効な場合は CRON_TOKEN を優先する', () => {
+    expect(resolveCronSecret('token-value', 'legacy-value')).toBe(
+      'token-value'
+    );
+  });
+
+  it('CRON_TOKEN のみ有効な場合はその値を返す', () => {
+    expect(resolveCronSecret('token-value', undefined)).toBe('token-value');
+  });
+
+  it('CRON_TOKEN が空白のみの場合は CRON_SECRET へフォールバックする', () => {
+    expect(resolveCronSecret('   ', 'legacy-value')).toBe('legacy-value');
+  });
+
+  it('CRON_TOKEN が空文字列の場合は CRON_SECRET へフォールバックする', () => {
+    expect(resolveCronSecret('', 'legacy-value')).toBe('legacy-value');
+  });
+
+  it.each([
+    ['空白を含む', 'a b'],
+    ['改行を含む', 'abc\n'],
+    ['非 ASCII を含む', 'トークン'],
+    ['制御文字を含む', `abc${CTL}def`],
+  ])(
+    'CRON_TOKEN が不正な非空値（%s）の場合、CRON_SECRET が有効でも undefined を返す（フォールバックしない）',
+    (_label, invalidToken) => {
+      expect(resolveCronSecret(invalidToken, 'legacy-value')).toBeUndefined();
+    }
+  );
+
+  it('CRON_TOKEN が未設定で CRON_SECRET が不正な場合は undefined を返す', () => {
+    expect(resolveCronSecret(undefined, 'a b')).toBeUndefined();
+  });
+
+  it('両方未設定の場合は undefined を返す', () => {
+    expect(resolveCronSecret(undefined, undefined)).toBeUndefined();
+  });
+
+  describe('受理される値の例', () => {
+    it('16進64文字を受理する', () => {
+      const hex64 = 'a'.repeat(64);
+      expect(resolveCronSecret(hex64, undefined)).toBe(hex64);
+    });
+
+    it('base64url的な記号（- と _）を受理する', () => {
+      const value = 'abc-DEF_123';
+      expect(resolveCronSecret(value, undefined)).toBe(value);
+    });
+
+    it('可視 ASCII の両端（! と ~）を受理する', () => {
+      expect(resolveCronSecret('!abc~', undefined)).toBe('!abc~');
+    });
+  });
+});

--- a/app/api/feeds/collect/with-feed-collect-auth.ts
+++ b/app/api/feeds/collect/with-feed-collect-auth.ts
@@ -5,6 +5,7 @@ import {
 } from '@/lib/middleware/with-cron-or-admin-auth';
 import { extractBearerToken } from '@/lib/auth/authorization-header';
 import { compareSecrets } from '@/lib/utils/compare-secrets';
+import { resolveCronSecret } from '@/lib/auth/cron-secret';
 import logger from '@/lib/logger';
 import { env } from '@/lib/config/env';
 
@@ -16,7 +17,7 @@ function checkTokenParam(
   const tokenParam = request.nextUrl.searchParams.get('token');
   if (!tokenParam) return null;
 
-  const cronSecret = env.CRON_TOKEN || env.CRON_SECRET || '';
+  const cronSecret = resolveCronSecret(env.CRON_TOKEN, env.CRON_SECRET) ?? '';
   if (!cronSecret || !compareSecrets(tokenParam, cronSecret)) {
     // ?token= が存在して無効な場合は即401（フォールスルーしない）
     return Promise.resolve(
@@ -59,7 +60,7 @@ export function withFeedCollectTokenAuth(handler: Handler): Handler {
     if (tokenResult) return tokenResult;
 
     // Bearer token チェック（admin session は許可しない）
-    const cronSecret = env.CRON_TOKEN || env.CRON_SECRET;
+    const cronSecret = resolveCronSecret(env.CRON_TOKEN, env.CRON_SECRET);
     if (cronSecret) {
       const bearer = extractBearerToken(request.headers.get('authorization'));
       if (bearer && compareSecrets(bearer, cronSecret)) {

--- a/app/api/feeds/collect/with-feed-collect-auth.ts
+++ b/app/api/feeds/collect/with-feed-collect-auth.ts
@@ -3,6 +3,7 @@ import {
   withCronOrAdminAuth,
   type Handler,
 } from '@/lib/middleware/with-cron-or-admin-auth';
+import { extractBearerToken } from '@/lib/auth/authorization-header';
 import { compareSecrets } from '@/lib/utils/compare-secrets';
 import logger from '@/lib/logger';
 import { env } from '@/lib/config/env';
@@ -60,10 +61,7 @@ export function withFeedCollectTokenAuth(handler: Handler): Handler {
     // Bearer token チェック（admin session は許可しない）
     const cronSecret = env.CRON_TOKEN || env.CRON_SECRET;
     if (cronSecret) {
-      const authHeader = request.headers.get('authorization');
-      const bearer = authHeader?.startsWith('Bearer ')
-        ? authHeader.substring('Bearer '.length)
-        : undefined;
+      const bearer = extractBearerToken(request.headers.get('authorization'));
       if (bearer && compareSecrets(bearer, cronSecret)) {
         return handler(request, context);
       }

--- a/app/api/workers/embedding/with-embedding-worker-auth.ts
+++ b/app/api/workers/embedding/with-embedding-worker-auth.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { type Handler } from '@/lib/middleware/with-cron-or-admin-auth';
 import { extractBearerToken } from '@/lib/auth/authorization-header';
 import { compareSecrets } from '@/lib/utils/compare-secrets';
+import { resolveCronSecret } from '@/lib/auth/cron-secret';
 import { env } from '@/lib/config/env';
 
 /**
@@ -29,7 +30,7 @@ import { env } from '@/lib/config/env';
 export function withEmbeddingWorkerAuth(handler: Handler): Handler {
   return async (request: NextRequest, context?: any) => {
     // 上記 docblock 参照: フォールバックであって「両方有効」ではない
-    const cronSecret = env.CRON_TOKEN || env.CRON_SECRET;
+    const cronSecret = resolveCronSecret(env.CRON_TOKEN, env.CRON_SECRET);
     if (cronSecret) {
       const bearer = extractBearerToken(request.headers.get('authorization'));
       if (bearer && compareSecrets(bearer, cronSecret)) {

--- a/app/api/workers/embedding/with-embedding-worker-auth.ts
+++ b/app/api/workers/embedding/with-embedding-worker-auth.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { type Handler } from '@/lib/middleware/with-cron-or-admin-auth';
+import { extractBearerToken } from '@/lib/auth/authorization-header';
 import { compareSecrets } from '@/lib/utils/compare-secrets';
 import { env } from '@/lib/config/env';
 
@@ -21,18 +22,16 @@ import { env } from '@/lib/config/env';
  * したがって両方が設定されている場合は CRON_TOKEN が優先され、CRON_SECRET の
  * 値では認証できない。これは意図した挙動であり、移行完了後に旧シークレットが
  * 有効なまま残らないようにするための設計。
- * 同じロジックを with-cron-or-admin-auth.ts:38 と
- * app/api/feeds/collect/with-feed-collect-auth.ts:18,61 も採用している。
+ * 同じロジックを lib/middleware/with-cron-or-admin-auth.ts と
+ * app/api/feeds/collect/with-feed-collect-auth.ts も採用している
+ * （行番号は変動するため参照しない）。
  */
 export function withEmbeddingWorkerAuth(handler: Handler): Handler {
   return async (request: NextRequest, context?: any) => {
     // 上記 docblock 参照: フォールバックであって「両方有効」ではない
     const cronSecret = env.CRON_TOKEN || env.CRON_SECRET;
     if (cronSecret) {
-      const authHeader = request.headers.get('authorization');
-      const bearer = authHeader?.startsWith('Bearer ')
-        ? authHeader.substring('Bearer '.length)
-        : undefined;
+      const bearer = extractBearerToken(request.headers.get('authorization'));
       if (bearer && compareSecrets(bearer, cronSecret)) {
         return handler(request, context);
       }

--- a/lib/auth/authorization-header.ts
+++ b/lib/auth/authorization-header.ts
@@ -1,0 +1,77 @@
+/**
+ * Authorization ヘッダのスキーム別パーサー。
+ *
+ * Basic 認証ゲート（lib/auth/basic-auth-gate.ts）と cron 認証ラッパー各所で
+ * パース規則が食い違っていたため、判定を 1 箇所に集約する。
+ *
+ * 受理規則:
+ * - スキーム名は大文字小文字を区別しない（RFC 7235 が case-insensitive と定めている）
+ * - スキームと token の区切りは空白またはタブの 1 文字以上
+ *   （RFC 7235 の `1*SP` より寛容。既存の受理範囲を狭めないための意図的な拡張）
+ * - token は空白・タブを含まない単一トークン。末尾の空白・タブは無視する
+ * - token に制御文字を含む場合は拒否する
+ *
+ * このモジュールは process.env も他の lib/ モジュールも参照しない純関数のみで構成する。
+ * proxy.ts（Node ランタイム）からも API route からも同じ実装を使えるようにするため。
+ */
+
+/**
+ * 制御文字。Authorization ヘッダのいかなる位置でも拒否する。
+ *
+ * basic-auth-gate.ts の parseBasicHeader も base64 デコード後の user/pass 検証に
+ * 使うため export している（定数を複製すると片方だけ変更されうるため）。
+ */
+export const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/;
+
+const BASIC_SCHEME_PATTERN = /^Basic[ \t]+([^ \t]+)[ \t]*$/i;
+const BEARER_SCHEME_PATTERN = /^Bearer[ \t]+([^ \t]+)[ \t]*$/i;
+
+/**
+ * Authorization ヘッダから指定スキームの token を取り出す共通パーサー。
+ * Basic / Bearer に同じ形式・同じ検証を適用するために 1 箇所に集約している。
+ */
+function extractAuthToken(
+  header: string | null,
+  schemePattern: RegExp
+): string | null {
+  if (!header) return null;
+
+  const match = schemePattern.exec(header);
+  if (!match) return null;
+
+  const token = match[1];
+  if (CONTROL_CHAR_PATTERN.test(token)) return null;
+
+  return token;
+}
+
+/**
+ * `Authorization: Bearer <token>` から token を取り出す。
+ * スキーム不一致・形式不正・制御文字混入はいずれも null。
+ */
+export function extractBearerToken(header: string | null): string | null {
+  return extractAuthToken(header, BEARER_SCHEME_PATTERN);
+}
+
+/**
+ * `Authorization: Basic <base64>` から base64 部分を取り出す。
+ *
+ * base64 としての妥当性検証・デコード・`:` 分割・NFC 正規化は行わない。
+ * それらは RFC 7617 固有の処理であり basic-auth-gate.ts の責務とする。
+ */
+export function extractBasicToken(header: string | null): string | null {
+  return extractAuthToken(header, BASIC_SCHEME_PATTERN);
+}
+
+/**
+ * Bearer スキームであることだけを判定する。token は取り出さない。
+ *
+ * extractBearerToken(header) !== null の糖衣ではない点に注意。
+ * 「スキームが Bearer か」だけを知りたい呼び出し元（CSRF 判定）にとって、
+ * token 側の妥当性（制御文字の有無）は判定条件に含めるべきではないため、
+ * 制御文字チェックを経由しない独立した述語としている。
+ */
+export function hasBearerScheme(header: string | null): boolean {
+  if (!header) return false;
+  return BEARER_SCHEME_PATTERN.test(header);
+}

--- a/lib/auth/basic-auth-gate.ts
+++ b/lib/auth/basic-auth-gate.ts
@@ -1,5 +1,10 @@
 import { createHash, createHmac } from 'crypto';
 import type { NextRequest } from 'next/server';
+import {
+  CONTROL_CHAR_PATTERN,
+  extractBasicToken,
+  extractBearerToken,
+} from '@/lib/auth/authorization-header';
 import { compareSecrets } from '@/lib/utils/compare-secrets';
 
 /**
@@ -191,8 +196,6 @@ export function buildGateSetCookie(
 /** 標準 Base64（padding 込み）のみを許容する */
 const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
 
-const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/;
-
 /**
  * Base64 をバイト列として厳密にデコードし、UTF-8 として解釈する。
  *
@@ -219,36 +222,13 @@ interface BasicCredentials {
   pass: string;
 }
 
-const BASIC_SCHEME_PATTERN = /^Basic[ \t]+([^ \t]+)[ \t]*$/i;
-const BEARER_SCHEME_PATTERN = /^Bearer[ \t]+([^ \t]+)[ \t]*$/i;
-
-/**
- * Authorization ヘッダから token を取り出す共通パーサー。
- * Basic / Bearer で同じ形式・同じ検証（scheme は RFC 7235 上 case-insensitive、
- * token は単一、制御文字を含まない）を適用するために 1 箇所に集約している。
- */
-function extractAuthToken(
-  header: string | null,
-  schemePattern: RegExp
-): string | null {
-  if (!header) return null;
-
-  const match = schemePattern.exec(header);
-  if (!match) return null;
-
-  const token = match[1];
-  if (CONTROL_CHAR_PATTERN.test(token)) return null;
-
-  return token;
-}
-
 /**
  * RFC 7617 に従って Authorization: Basic をパースする。
  * - 最初の ':' より後ろが全て password。user-id に ':' は含められない
  * - charset="UTF-8" を通知しているため NFC に正規化する
  */
 function parseBasicHeader(header: string | null): BasicCredentials | null {
-  const token = extractAuthToken(header, BASIC_SCHEME_PATTERN);
+  const token = extractBasicToken(header);
   if (token === null) return null;
 
   const decoded = decodeBase64Strict(token);
@@ -286,7 +266,7 @@ function matchesCronBearer(
 ): boolean {
   if (!cronSecret) return false;
 
-  const token = extractAuthToken(header, BEARER_SCHEME_PATTERN);
+  const token = extractBearerToken(header);
   if (token === null) return false;
 
   return compareSecrets(token, cronSecret);

--- a/lib/auth/cron-secret.ts
+++ b/lib/auth/cron-secret.ts
@@ -1,17 +1,57 @@
 /**
- * cron 認証に使うシークレットの正規化・検証・選択を 1 箇所に集約する。
+ * cron 認証に使うシークレットの正規化・選択を 1 箇所に集約する。
  *
  * CRON_TOKEN は新名称、CRON_SECRET は旧名称であり「両方が同時に有効な独立した
  * 資格情報」ではない（リネーム移行のフォールバック）。CRON_TOKEN が設定されていれば
  * CRON_SECRET は参照しない。
  *
- * 受理規則は lib/config/env.ts の bearerSecret スキーマおよび
- * lib/auth/authorization-header.ts のトークン抽出規則と一致させる。
+ * ## 検証の二層構造
+ *
+ * シークレットの妥当性は 2 つの層で扱う。役割が異なるため両方が必要になる。
+ *
+ * | 層 | 実装 | 役割 | 失敗時の挙動 |
+ * |---|---|---|---|
+ * | 起動時 | lib/config/env.ts の zod スキーマ | 設定ミスを大きく可視化する | 例外。production では env.ts のモジュールロード時に `getEnv()` が走るため**起動自体が失敗する** |
+ * | 認証時 | このモジュール | 選択結果を fail-closed にする | undefined を返し、呼び出し元が 401 を返す |
+ *
+ * production では `proxy.ts` が csrf-protection.ts / auth-cookies.ts を経由して
+ * env.ts を静的 import しているため、不正な CRON_* があれば起動時に落ちる。
+ * したがって認証時の層に到達するのは実質的に開発・テスト環境に限られる。
+ * それでもこの層を fail-closed にしておくのは、`proxy.ts` の `readGateEnv()` が
+ * 生の `process.env` を読む（zod を経由しない）ためであり、多層防御として置いている。
+ *
+ * ここで throw しないのは、`readGateEnv()` から例外を投げると middleware レベルの
+ * 未捕捉例外になり、`proxy.ts` の `gate.kind === 'misconfigured'` → 503 という
+ * 制御された経路を迂回してしまうため。
  */
-const VISIBLE_ASCII_PATTERN = /^[!-~]+$/;
 
+/**
+ * cron シークレットとして受理する文字集合（可視 ASCII、U+0021-U+007E）。
+ *
+ * lib/config/env.ts の zod スキーマ（bearerSecret）と**この定数を共有する**。
+ * 判定規則を 2 箇所に持つと、片方だけ変更されて「env は通すが認証は通らない」
+ * 状態が再発するため。受理範囲の根拠は env.ts 側の docblock を参照。
+ *
+ * 注: lib/auth/authorization-header.ts のトークン抽出規則（`[^ \t]+` + 制御文字拒否）
+ * とは一致しない。パーサーはワイヤから届いた値をどこまで受理するかの規則であり、
+ * 非 ASCII も受理する。こちらは「設定してよい値」のポリシーであり、
+ * HTTP ヘッダとして送出できない値を最初から弾くぶん厳しい。
+ */
+export const CRON_SECRET_PATTERN = /^[!-~]+$/;
+
+/**
+ * 空白のみは未設定として扱う。lib/config/env.ts の sanitizeEnv() と同じ規則。
+ *
+ * この正規化は API 側（sanitizeEnv 済みの env.*）とゲート側（生の process.env）で
+ * 同じシークレットが選ばれることを保証するために必須である。片方だけが空白文字列を
+ * truthy として選ぶと、API が受理するリクエストをゲートが 401 にする。
+ *
+ * トレードオフ: シークレット注入の失敗（テンプレート展開ミス等）で CRON_TOKEN が
+ * 空白のみになった場合、警告なく CRON_SECRET へフォールバックするため
+ * ローテーション失敗に気づけない。それでも sanitizeEnv と規則を揃えることを
+ * 優先している。ここだけ規則を変えると上記の不整合が再発するため。
+ */
 function normalize(value: string | undefined): string | undefined {
-  // lib/config/env.ts の sanitizeEnv() と同じ規則。空白のみは未設定として扱う
   return value !== undefined && value.trim() === '' ? undefined : value;
 }
 
@@ -23,19 +63,9 @@ function normalize(value: string | undefined): string | undefined {
  * CRON_TOKEN に不正な値が設定されている状態で旧 CRON_SECRET へ暗黙に
  * 戻ると、ローテーション失敗に気づけないため。
  *
- * CodeRabbit の提案（PR #649, proxy.ts:41）は不正な非空値で throw する実装を
- * 求めているが、ここでは throw せず undefined を返す。この関数は
- * proxy.ts の readGateEnv() からも呼ばれ、throw すると全リクエストが
- * middleware レベルの未捕捉例外になり、proxy.ts が持つ
- * 「設定不備 → 503」という制御された経路（gate.kind === 'misconfigured'
- * の分岐）を迂回してしまう。
- * 起動時の大きな失敗検知は lib/config/env.ts の zod
- * スキーマ（bearerSecret）が既に担っているため、この関数は認証層での
- * fail-closed（401）に徹する。
- *
- * また、選択されなかった側（legacy が選ばれた場合の token、または
- * その逆）の値は検証しない。未使用の値が不正でも認証を止める必要はなく、
- * 起動時の zod スキーマが別途検出する。
+ * 選択されなかった側の値は検証しない。未使用の値の不正で認証を止める必要はなく、
+ * 起動時の zod スキーマが別途検出する（そちらは未使用側も検証するため、
+ * 不正な値が残っていれば起動時に落ちる）。
  */
 export function resolveCronSecret(
   token: string | undefined,
@@ -43,5 +73,5 @@ export function resolveCronSecret(
 ): string | undefined {
   const selected = normalize(token) ?? normalize(legacy);
   if (selected === undefined) return undefined;
-  return VISIBLE_ASCII_PATTERN.test(selected) ? selected : undefined;
+  return CRON_SECRET_PATTERN.test(selected) ? selected : undefined;
 }

--- a/lib/auth/cron-secret.ts
+++ b/lib/auth/cron-secret.ts
@@ -1,0 +1,47 @@
+/**
+ * cron 認証に使うシークレットの正規化・検証・選択を 1 箇所に集約する。
+ *
+ * CRON_TOKEN は新名称、CRON_SECRET は旧名称であり「両方が同時に有効な独立した
+ * 資格情報」ではない（リネーム移行のフォールバック）。CRON_TOKEN が設定されていれば
+ * CRON_SECRET は参照しない。
+ *
+ * 受理規則は lib/config/env.ts の bearerSecret スキーマおよび
+ * lib/auth/authorization-header.ts のトークン抽出規則と一致させる。
+ */
+const VISIBLE_ASCII_PATTERN = /^[!-~]+$/;
+
+function normalize(value: string | undefined): string | undefined {
+  // lib/config/env.ts の sanitizeEnv() と同じ規則。空白のみは未設定として扱う
+  return value !== undefined && value.trim() === '' ? undefined : value;
+}
+
+/**
+ * CRON_TOKEN を優先し、未設定なら CRON_SECRET へフォールバックして選択する。
+ *
+ * 選択された値が Authorization ヘッダとして送出できない文字を含む場合は
+ * undefined を返す（fail-closed）。**フォールバックはしない**:
+ * CRON_TOKEN に不正な値が設定されている状態で旧 CRON_SECRET へ暗黙に
+ * 戻ると、ローテーション失敗に気づけないため。
+ *
+ * CodeRabbit の提案（PR #649, proxy.ts:41）は不正な非空値で throw する実装を
+ * 求めているが、ここでは throw せず undefined を返す。この関数は
+ * proxy.ts の readGateEnv() からも呼ばれ、throw すると全リクエストが
+ * middleware レベルの未捕捉例外になり、proxy.ts が持つ
+ * 「設定不備 → 503」という制御された経路（gate.kind === 'misconfigured'
+ * の分岐）を迂回してしまう。
+ * 起動時の大きな失敗検知は lib/config/env.ts の zod
+ * スキーマ（bearerSecret）が既に担っているため、この関数は認証層での
+ * fail-closed（401）に徹する。
+ *
+ * また、選択されなかった側（legacy が選ばれた場合の token、または
+ * その逆）の値は検証しない。未使用の値が不正でも認証を止める必要はなく、
+ * 起動時の zod スキーマが別途検出する。
+ */
+export function resolveCronSecret(
+  token: string | undefined,
+  legacy: string | undefined
+): string | undefined {
+  const selected = normalize(token) ?? normalize(legacy);
+  if (selected === undefined) return undefined;
+  return VISIBLE_ASCII_PATTERN.test(selected) ? selected : undefined;
+}

--- a/lib/config/env.ts
+++ b/lib/config/env.ts
@@ -41,6 +41,26 @@ const booleanEnum = z.preprocess(
   z.enum(['true', 'false'])
 );
 
+/**
+ * Authorization: Bearer のトークンとして送出されるシークレット用のスキーマ。
+ *
+ * lib/auth/authorization-header.ts の受理規則と 1 対 1 で対応させる。
+ * 同モジュールは token を `[^ \t]+` で切り出し、制御文字を含む場合は拒否するため、
+ * 空白・タブ・制御文字を含む値は「設定はできるが認証には使えない」状態になる。
+ * これを起動時に検出して fail-closed にする。
+ *
+ * 注: 空白のみ・空文字列の値は sanitizeEnv() が先に undefined へ変換するため
+ * ここには到達しない（＝未設定として扱われ、エラーにはならない）。
+ */
+const bearerSecret = (name: string) =>
+  z
+    .string()
+    .regex(
+      /^[^ \t\u0000-\u001F\u007F]+$/,
+      `${name} に空白文字・タブ・制御文字を含めることはできません`
+    )
+    .optional();
+
 // Environment variable schema
 const envSchema = z
   .object({
@@ -237,8 +257,8 @@ const envSchema = z
     // Security / Middleware
     CURSOR_SECRET: z.string().optional(),
     ALLOW_INSECURE_CURSOR_SECRET: booleanEnum.optional().default('false'),
-    CRON_SECRET: z.string().optional(),
-    CRON_TOKEN: z.string().optional(),
+    CRON_SECRET: bearerSecret('CRON_SECRET'),
+    CRON_TOKEN: bearerSecret('CRON_TOKEN'),
     CSRF_TRUSTED_ORIGINS: z.string().optional(),
     RATE_LIMIT_OVERRIDES: z.string().optional(),
 

--- a/lib/config/env.ts
+++ b/lib/config/env.ts
@@ -4,6 +4,7 @@
  */
 
 import { z } from 'zod';
+import { CRON_SECRET_PATTERN } from '@/lib/auth/cron-secret';
 import logger from '@/lib/logger';
 
 // Preprocess all env vars: empty/whitespace-only strings → undefined
@@ -60,12 +61,16 @@ const booleanEnum = z.preprocess(
  *
  * 注: 空白のみ・空文字列の値は sanitizeEnv() が先に undefined へ変換するため
  * ここには到達しない（＝未設定として扱われ、エラーにはならない）。
+ *
+ * 判定パターンは lib/auth/cron-secret.ts の CRON_SECRET_PATTERN を共有する。
+ * 認証時にシークレットを選択する resolveCronSecret と規則がずれると、
+ * 「env は通すが認証は通らない」状態が再発するため。
  */
 const bearerSecret = (name: string) =>
   z
     .string()
     .regex(
-      /^[\u0021-\u007E]+$/,
+      CRON_SECRET_PATTERN,
       `${name} には可視 ASCII 文字（U+0021-U+007E）のみ使用できます。空白・制御文字・非 ASCII 文字は Authorization ヘッダとして送出できないか、トークンとして復元できません`
     )
     .optional();

--- a/lib/config/env.ts
+++ b/lib/config/env.ts
@@ -44,10 +44,19 @@ const booleanEnum = z.preprocess(
 /**
  * Authorization: Bearer のトークンとして送出されるシークレット用のスキーマ。
  *
- * lib/auth/authorization-header.ts の受理規則と 1 対 1 で対応させる。
- * 同モジュールは token を `[^ \t]+` で切り出し、制御文字を含む場合は拒否するため、
- * 空白・タブ・制御文字を含む値は「設定はできるが認証には使えない」状態になる。
- * これを起動時に検出して fail-closed にする。
+ * 「設定はできるが認証には使えない」値を起動時に弾くのが目的なので、
+ * 実際に Authorization ヘッダへ載せて往復できる文字だけを許可する。
+ * 可視 ASCII（U+0021-U+007E）に限定しており、以下をすべて拒否する。
+ *
+ * - 空白・タブ: lib/auth/authorization-header.ts が token を `[^ \t]+` で
+ *   切り出すため、含まれていると設定値どおりに復元できない
+ * - 制御文字・DEL: 同モジュールが明示的に拒否する。CR/LF はヘッダ分割の温床でもある
+ * - U+00FF を超える文字: HTTP ヘッダ値は ByteString であり、そもそも送出できない
+ *   （`new Headers({ authorization: 'Bearer トークン' })` は TypeError になる）
+ *
+ * U+0080-U+00FF は Headers には載るが RFC 9110 で obs-text として非推奨であり、
+ * 途中の proxy / CDN での取り扱いが保証されないため許可しない。
+ * `openssl rand -hex 32` 等の一般的な生成手段はいずれもこの範囲に収まる。
  *
  * 注: 空白のみ・空文字列の値は sanitizeEnv() が先に undefined へ変換するため
  * ここには到達しない（＝未設定として扱われ、エラーにはならない）。
@@ -56,8 +65,8 @@ const bearerSecret = (name: string) =>
   z
     .string()
     .regex(
-      /^[^ \t\u0000-\u001F\u007F]+$/,
-      `${name} に空白文字・タブ・制御文字を含めることはできません`
+      /^[\u0021-\u007E]+$/,
+      `${name} には可視 ASCII 文字（U+0021-U+007E）のみ使用できます。空白・制御文字・非 ASCII 文字は Authorization ヘッダとして送出できないか、トークンとして復元できません`
     )
     .optional();
 

--- a/lib/middleware/csrf-protection.ts
+++ b/lib/middleware/csrf-protection.ts
@@ -10,6 +10,7 @@ import {
   extendWithSessionContext,
   type SessionContext,
 } from './session-context';
+import { hasBearerScheme } from '@/lib/auth/authorization-header';
 import { env } from '@/lib/config/env';
 
 /**
@@ -192,9 +193,13 @@ export async function validateOrigin(
   }
 
   // 3. Authorization header or no Origin/Referer (server-to-server)
-  // Both cases require valid Auth.js session validation
+  // Both cases require valid Auth.js session validation.
+  //
+  // Bearer の判定は lib/auth/authorization-header.ts に集約している。
+  // ここで見たいのは「スキームが Bearer か」だけで token の妥当性は問わないため、
+  // token を取り出す extractBearerToken ではなく述語 hasBearerScheme を使う。
   const authHeader = request.headers.get('authorization');
-  if (authHeader?.startsWith('Bearer ') || (!origin && !referer)) {
+  if (hasBearerScheme(authHeader) || (!origin && !referer)) {
     try {
       // Use resolveSession to reuse session from context if available
       const session = await resolveSession(context);

--- a/lib/middleware/with-cron-or-admin-auth.ts
+++ b/lib/middleware/with-cron-or-admin-auth.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth/auth';
+import { extractBearerToken } from '@/lib/auth/authorization-header';
 import { compareSecrets } from '@/lib/utils/compare-secrets';
 import { getUserAuthData } from '@/lib/auth/user-auth-cache';
 import logger from '@/lib/logger';
@@ -37,10 +38,7 @@ export function withCronOrAdminAuth(handler: Handler): Handler {
     // 1. Cron Secret認証（Bearer）
     const cronSecret = env.CRON_TOKEN || env.CRON_SECRET;
     if (cronSecret) {
-      const authHeader = request.headers.get('authorization');
-      const token = authHeader?.startsWith('Bearer ')
-        ? authHeader.substring('Bearer '.length)
-        : undefined;
+      const token = extractBearerToken(request.headers.get('authorization'));
 
       if (token && compareSecrets(token, cronSecret)) {
         // Cron実行時はレート制限なしで直接実行

--- a/lib/middleware/with-cron-or-admin-auth.ts
+++ b/lib/middleware/with-cron-or-admin-auth.ts
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth/auth';
 import { extractBearerToken } from '@/lib/auth/authorization-header';
 import { compareSecrets } from '@/lib/utils/compare-secrets';
 import { getUserAuthData } from '@/lib/auth/user-auth-cache';
+import { resolveCronSecret } from '@/lib/auth/cron-secret';
 import logger from '@/lib/logger';
 import { env } from '@/lib/config/env';
 
@@ -36,7 +37,7 @@ export type Handler = (
 export function withCronOrAdminAuth(handler: Handler): Handler {
   return async (request: NextRequest, context?: any) => {
     // 1. Cron Secret認証（Bearer）
-    const cronSecret = env.CRON_TOKEN || env.CRON_SECRET;
+    const cronSecret = resolveCronSecret(env.CRON_TOKEN, env.CRON_SECRET);
     if (cronSecret) {
       const token = extractBearerToken(request.headers.get('authorization'));
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -16,6 +16,19 @@ import { AUTH_COOKIES } from '@/lib/config/auth-cookies';
 
 // Basic 認証ゲートの設定値。lib/ 配下は process.env の直接参照を ESLint で禁止しており、
 // env.ts はモジュールロード時に一度だけ parse するため、ここ（proxy.ts）で都度読んで渡す。
+
+/**
+ * 空白のみの値を未設定として扱う。lib/config/env.ts の sanitizeEnv() と同じ規則。
+ *
+ * API 側は sanitize 済みの env.CRON_TOKEN || env.CRON_SECRET でシークレットを選ぶ。
+ * ここで生の process.env を使うと、例えば CRON_TOKEN='   ' / CRON_SECRET='valid' の
+ * 構成でゲートだけが空白文字列を選び、API が受理するリクエストをゲートが 401 にする。
+ * シークレットの選択規則を API 側と一致させるための正規化。
+ */
+function readOptionalEnv(value: string | undefined): string | undefined {
+  return value !== undefined && value.trim() === '' ? undefined : value;
+}
+
 function readGateEnv(): GateEnv {
   return {
     enabled: process.env.BASIC_AUTH_ENABLED,
@@ -23,7 +36,9 @@ function readGateEnv(): GateEnv {
     pass: process.env.BASIC_AUTH_PASS,
     legacyPass: process.env.BASIC_PASSWORD,
     gateSecret: process.env.BASIC_AUTH_GATE_SECRET,
-    cronSecret: process.env.CRON_TOKEN || process.env.CRON_SECRET,
+    cronSecret:
+      readOptionalEnv(process.env.CRON_TOKEN) ??
+      readOptionalEnv(process.env.CRON_SECRET),
     isProduction: process.env.NODE_ENV === 'production',
   };
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -13,21 +13,10 @@ import {
   requiresCSRFProtection,
 } from '@/lib/middleware/csrf-protection';
 import { AUTH_COOKIES } from '@/lib/config/auth-cookies';
+import { resolveCronSecret } from '@/lib/auth/cron-secret';
 
 // Basic 認証ゲートの設定値。lib/ 配下は process.env の直接参照を ESLint で禁止しており、
 // env.ts はモジュールロード時に一度だけ parse するため、ここ（proxy.ts）で都度読んで渡す。
-
-/**
- * 空白のみの値を未設定として扱う。lib/config/env.ts の sanitizeEnv() と同じ規則。
- *
- * API 側は sanitize 済みの env.CRON_TOKEN || env.CRON_SECRET でシークレットを選ぶ。
- * ここで生の process.env を使うと、例えば CRON_TOKEN='   ' / CRON_SECRET='valid' の
- * 構成でゲートだけが空白文字列を選び、API が受理するリクエストをゲートが 401 にする。
- * シークレットの選択規則を API 側と一致させるための正規化。
- */
-function readOptionalEnv(value: string | undefined): string | undefined {
-  return value !== undefined && value.trim() === '' ? undefined : value;
-}
 
 function readGateEnv(): GateEnv {
   return {
@@ -36,9 +25,10 @@ function readGateEnv(): GateEnv {
     pass: process.env.BASIC_AUTH_PASS,
     legacyPass: process.env.BASIC_PASSWORD,
     gateSecret: process.env.BASIC_AUTH_GATE_SECRET,
-    cronSecret:
-      readOptionalEnv(process.env.CRON_TOKEN) ??
-      readOptionalEnv(process.env.CRON_SECRET),
+    cronSecret: resolveCronSecret(
+      process.env.CRON_TOKEN,
+      process.env.CRON_SECRET
+    ),
     isProduction: process.env.NODE_ENV === 'production',
   };
 }


### PR DESCRIPTION
## 概要

- `Authorization: Bearer` のパース規則が Basic 認証ゲートと cron 認証ラッパー3箇所・CSRF で食い違っていた状態を、共有モジュール `lib/auth/authorization-header.ts` への集約で解消する
- 併せて `CRON_TOKEN` / `CRON_SECRET` に「Authorization ヘッダとして実際に送出でき、トークンとして復元できる」ことを保証する形式検証を追加する
- Issue #647 の4項目のうち **項目3のみ** が対象。他3項目は調査の結果を踏まえて別途扱う（後述）

Refs #647

> [!IMPORTANT]
> **デプロイ前に `CRON_TOKEN` / `CRON_SECRET` の値の確認が必要です。** 空白・改行・非 ASCII を含む値が設定されているスコープはビルドが失敗します。詳細は「デプロイ前の必須確認」を参照してください。

## 背景

PR #646 でゲート側（`lib/auth/basic-auth-gate.ts`）の Authorization パースを scheme case-insensitive・タブ区切り許容に変更したが、API 側3箇所は `startsWith('Bearer ')` の完全一致のまま残った。調査により **双方向の不整合** が存在することが判明している。

| 方向 | 例 | 結果 |
|------|-----|------|
| ゲート受理・API 拒否 | `bearer <token>`、`Bearer\t<token>`、`Bearer  <token>` | ゲートは通過するが API 側で 401 |
| **API 受理・ゲート拒否** | シークレット自体に空白が含まれる場合（`CRON_TOKEN="a b"`） | ゲートで 401 |

後者は調査で新たに発見したもので、共有パーサーの token 部が `[^ \t]+` である以上、**共有化するとこの構成では認証が壊れる**。そのため env 側の形式検証を同時に入れている。

調査・計画の詳細は `.workflow/docs/investigate/investigate_20260815_104450_issue647_basic_auth_gate_followups.md` および `.workflow/docs/plan/plan_20260815_124357_issue647_bearer_shared_parser.md` を参照。

## 実装内容

### 共有パーサー（`lib/auth/authorization-header.ts` 新規）

```ts
export const CONTROL_CHAR_PATTERN: RegExp;
export function extractBearerToken(header: string | null): string | null;
export function extractBasicToken(header: string | null): string | null;
export function hasBearerScheme(header: string | null): boolean;
```

- `process.env` も他の `lib/` モジュールも参照しない純関数のみのリーフモジュール。`proxy.ts`（Node ランタイム）からも API route からも同じ実装を使える
- `extractBasicToken` は base64 の抽出までを担当し、**デコード・`:` 分割・NFC 正規化は `basic-auth-gate.ts` に残す**（RFC 7617 固有の処理であり汎用パースとは責務が異なるため）
- `CONTROL_CHAR_PATTERN` を export しているのは、`parseBasicHeader` が base64 デコード後の user/pass 検証に同じ定数を使い続けるため。定義ごと移設すると制御文字チェックが失われる

### 置換した4箇所

| ファイル | 使用する関数 |
|---|---|
| `lib/middleware/with-cron-or-admin-auth.ts` | `extractBearerToken` |
| `app/api/feeds/collect/with-feed-collect-auth.ts` | `extractBearerToken` |
| `app/api/workers/embedding/with-embedding-worker-auth.ts` | `extractBearerToken` |
| `lib/middleware/csrf-protection.ts` | `hasBearerScheme`（スキームの存在検知のみが目的でトークンを取り出さないため） |

`startsWith('Bearer` の残存は0件。

### `lib/config/env.ts` の形式検証

`CRON_TOKEN` / `CRON_SECRET` を **可視 ASCII（U+0021-U+007E）** に限定する。

「設定はできるが認証には絶対使えない」値を起動時に弾くのが目的なので、実際に Authorization ヘッダへ載せて往復できる文字だけを許可する。

- 空白・タブ: 共有パーサーが token を `[^ \t]+` で切り出すため設定値どおりに復元できない
- 制御文字・DEL: 同モジュールが明示的に拒否。CR/LF はヘッダ分割の温床でもある
- U+00FF を超える文字: HTTP ヘッダ値は ByteString であり **そもそも送出できない**

```
$ node -e "new Headers({authorization: 'Bearer トークン'})"
TypeError: Cannot convert argument to a ByteString because the character at
index 7 has a value of 12488 which is greater than 255.
```

U+0080-U+00FF は `Headers` には載るが RFC 9110 で obs-text として非推奨であり、proxy / CDN での扱いが保証されないため許可しない。`openssl rand -hex 32` 等の一般的な生成手段はこの範囲に収まる。

なお **空白のみ・空文字列の値は `sanitizeEnv()` が先に `undefined` へ変換するため検証エラーにはならない**（未設定扱い）。この挙動もテストで固定している。

### `proxy.ts` のシークレット選択規則の統一

ゲートは生の `process.env.CRON_TOKEN || process.env.CRON_SECRET` を使う一方、API 側は `sanitizeEnv` 済みの `env.*` を使っていた。`CRON_TOKEN='   '` / `CRON_SECRET='valid'` の構成で **ゲートと API が別のシークレットを選ぶ**（＝本 PR が解消しようとしている不整合と同型）。`sanitizeEnv()` と同じ正規化をゲート側にも適用した。

### コメントの訂正

現行の正規表現は **RFC 7235 準拠ではない**（RFC 7235 §2.1 の区切りは `1*SP`、トークンは `token68`）。タブ区切り・複数空白の許容は既存の受理範囲を狭めないための独自拡張である。PR #646 の「RFC 7235 準拠」という記述は不正確だったため、共有モジュールのコメントで正確に記述し直している。

併せて `with-embedding-worker-auth.ts` の docblock にあったクロスファイル行番号参照（`with-cron-or-admin-auth.ts:38` 等）を、行番号に依存しない表記へ変更した。

## この PR の実効範囲（レビュー時の注意）

`CSRF_EXEMPT_PATHS` は `/api/auth` と `/api/health` のみで、cron 系エンドポイントは CSRF 保護の対象である。また `proxy.ts` は `csrfProtection(request)` を context なしで呼ぶため `resolveSession` は必ず `null` を返す。したがって:

| メソッド | 本 PR の効果 |
|---|---|
| **GET** | **あり**。`withFeedCollectTokenAuth`（feeds/collect GET）と `withEmbeddingWorkerAuth`（workers/embedding GET）で実際に挙動が変わる |
| **POST** | **なし**。`withCronOrAdminAuth` の Bearer 分岐は Origin/Referer なしのサーバ間呼び出しからは proxy の CSRF で 403 になり到達しない |

これは本 PR が作った問題ではなく既存仕様で、PR #646 でも「CSRF と cron Bearer の処理順。現行 cron 経路は GET のため実害なし」としてスコープ外に整理済み。**「POST でも直るはず」という前提でレビューしないよう注意**。

同様に `csrf-protection.ts` の変更も proxy 経路では no-op で、一貫性のための変更である。

## テスト結果

test.md は作成していないため、VERIFY フェーズの結果を記載する。

| Step | 結果 | 内容 |
|------|------|------|
| Lint + Type Check | PASS | ESLint exit 0 / 0 errors / 0 warnings、`tsc --noEmit` exit 0 |
| Security Audit | PASS | `npm audit --production --audit-level=high` exit 0（moderate 3件は `valibot` 経由の既存事項で本変更と無関係） |
| Build | PASS | `npm run docker:build` exit 0 |
| Test | PASS | 11ファイル / 350件、すべて exit 0 |
| Diff Review | PASS | デバッグコード・秘密情報・`.gitignore` 対象の混入なし |
| Visual | SKIP | `.tsx` の変更なし |

### テスト内訳

| ファイル | 件数 |
|---------|------|
| `__tests__/unit/auth/authorization-header.test.ts`（新規） | 52 |
| `__tests__/unit/auth/basic-auth-gate.test.ts`（回帰・**期待値無修正**） | 59 |
| `__tests__/lib/config/env.test.ts` | 69 |
| `__tests__/lib/middleware/with-cron-or-admin-auth.test.ts` | 23 |
| `__tests__/api/feeds/collect/with-feed-collect-auth.test.ts`（新規） | 17 |
| `__tests__/lib/middleware/csrf-protection.test.ts` | 30 |
| `__tests__/middleware.node.test.ts` | 35 |
| `__tests__/middleware-maintenance.node.test.ts`（回帰） | 14 |
| `__tests__/api/middleware-order.test.ts`（回帰） | 15 |
| `__tests__/api/workers/embedding.test.ts` + `embedding-scheduler.test.ts` | 36 |

`basic-auth-gate.test.ts` の既存59件が **テスト期待値を1つも変えずに全パス** することで、ゲート側のリファクタが純粋な移設であることを担保している。

`__tests__/api/workers/embedding.test.ts` は `jest.config.node.js` の `testPathIgnorePatterns` に含まれており `/test` 経由では実行されない（同一 `EmbeddingJob` テーブルを使う2ファイルの排他実行が前提の設計）。`JEST_SERIAL_DB=1` + `--runInBand`（`npm run test:node:serial`）で実行して確認した。

### 新規テストの主なカバー範囲

- スキーム名の大文字小文字、タブ区切り、複数空白、末尾空白、複数トークン拒否、制御文字拒否
- `extractBasicToken` の責務境界（base64 として不正な値でも抽出はする）
- `hasBearerScheme` と `extractBearerToken` の判定差（制御文字入りトークンでの挙動差は意図的な設計）
- env 検証の受理／拒否／`sanitizeEnv` による未設定扱いの3系統
- 受理された値が実際に `Headers` へ設定できること
- `proxy.ts` の空白のみ `CRON_TOKEN` フォールバックと小文字 `bearer` の回帰

### レビュー

`security-engineer` / `typescript-reviewer` による設計レビュー（PLAN 時）と、Codex + Devil's Advocate による cross-review（Full Tier、盲検化）を PLAN 時と IMPLEMENT 時の2回実施した。

**IMPLEMENT 時の cross-review で実装の欠陥2件を検出し、いずれも本 PR 内で修正済み**（Codex と DA が独立に同じ欠陥を検出）:

1. **非 ASCII シークレットを受理していた** — 当初は「共有パーサーの受理規則と 1 対 1 対応」で実装したが、パーサーが受理する値の中に **HTTP ヘッダとして送出できない値** が含まれており、検証の目的を果たしていなかった。可視 ASCII 限定へ修正
2. **ゲートと API でシークレットの選択規則が食い違っていた** — `proxy.ts` の `readOptionalEnv()` 追加で修正

その他、PLAN 時のレビューで以下を反映済み: `CONTROL_CHAR_PATTERN` の移設方法の明確化（誤ると既存テスト U14 が回帰）、`hasBearerScheme` の実装指定、受理範囲が狭まるケースの洗い出し、`withFeedCollectTokenAuth` のテストが0件だった点の補完。

## デプロイ前の必須確認

**本 PR には破壊的な設定変更が含まれる。**

Vercel の **Production / Preview / Development の全スコープ**で、`CRON_TOKEN` と `CRON_SECRET` の値が可視 ASCII（U+0021-U+007E）のみで構成されていることを確認すること。

- 該当しない値（空白・タブ・改行・非 ASCII を含む）が設定されている場合、`next build` が page-data collection の段階で失敗する（`lib/config/env.ts` により production ではモジュールロード時に `getEnv()` が走るため）
- 影響は「ビルド失敗」であり、**Production では旧デプロイが稼働し続ける**（安全側）
- ビルドエラーは worker 経由で内側の Zod メッセージが隠れ `Failed to collect page data` としか出ない場合がある。**ビルド失敗時はまず両変数の空白・改行混入を疑うこと**
- **使用していない旧 `CRON_SECRET` の残骸も検証対象になる**点に注意。`CRON_TOKEN` を使う運用なら `CRON_SECRET` は削除するのが確実（`CRON_TOKEN || CRON_SECRET` は「両方有効」ではなくリネーム移行のフォールバックであり、`CRON_TOKEN` が優先される）

値をローテートする場合:

```bash
openssl rand -hex 32 | tr -d '\n'
```

`tr -d '\n'` を挟むのは、`openssl` の出力末尾の改行が値に混入すると検証で弾かれるため。base64 は `?token=` クエリパラメータ認証（`with-feed-collect-auth.ts` の後方互換経路）で URL エンコードが必要になるため hex を推奨する。

### 復旧手順（万一設定ミスでビルドが落ちた場合）

1. **推奨**: シークレットを可視 ASCII の値へローテーションして再デプロイ（根本解決）
2. `218cc483` と `7253698a` の env.ts 部分を revert（ビルドは通るが、空白入りシークレットでは共有パーサーがトークンを抽出できないため cron 認証は壊れたまま）
3. 共有化コミット全体を revert

## Issue #647 の他項目について（本 PR では対応しない）

調査の結果、以下が判明している。詳細は調査レポート参照。

| 項目 | 調査結果 |
|---|---|
| 1. ゲート有効時にルート側で公開キャッシュヘッダを生成しない | **懸念は成立しない**。Next.js 16.2.12 の `send-response.js` は `res` に既存のヘッダを「追加も上書きもせず破棄」する（`Cache-Control` / `CDN-Cache-Control` は多値許可リスト外）。`proxy.ts` の `finalize` が設定する値が最終応答に残る。Vercel プロキシ層の挙動のみ静的検証不能で、本番 curl での実測が残タスク |
| 2. ISR ページの `force-dynamic` の是非 | **完全な no-op のため不要**。`app/articles/[id]/page.tsx` は `searchParams` を await しているため `revalidate = 60` があっても既に動的レンダリングである（本 PR のビルド出力でも `ƒ /articles/[id]` = Dynamic を確認） |
| 4. nanoid の脆弱性対応 | **対応済み**（PR #648 / `nanoid@3.3.18 overridden`） |

`.env.example` への `BASIC_AUTH_GATE_SECRET` 追記漏れ（PR #646 の宿題）も調査で検出しており、こちらは別途対応が必要。

## チェックリスト

- [x] テスト通過（350件、回帰4ファイル含む）
- [x] Lint / 型チェック通過（0 errors / 0 warnings）
- [x] 本番ビルド通過
- [ ] ドキュメント更新済み（`.env.example` は本 PR のスコープ外）
- [ ] 破壊的変更なし（**デプロイ設定に破壊的変更あり**: `CRON_TOKEN` / `CRON_SECRET` に可視 ASCII 以外の文字を含む環境はビルドが失敗する。上記「デプロイ前の必須確認」参照）

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Basic／Bearer認証のAuthorizationヘッダー解析を共通化。
  - Bearerの大文字・小文字、空白、タブ区切りに対応。

- **改善**
  - 認証トークン内の空白・制御文字・不正形式を適切に拒否。
  - 空白のみの認証用環境変数を未設定として扱い、代替シークレットへフォールバック。
  - 認証およびCSRF保護の検証範囲を強化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->