### PR TITLE
fix(ui): モバイルの到達不能・誤遷移と a11y 欠陥を一括修正（UI/UX Phase A）

### DIFF
--- a/__tests__/components/ArticleCard.test.tsx
+++ b/__tests__/components/ArticleCard.test.tsx
@@ -159,24 +159,28 @@ describe('ArticleCard', () => {
       <ArticleCard article={mockArticle} onArticleClick={handleClick} />
     );
 
-    const card = screen.getByTestId('article-card');
-    await user.click(card);
+    // card-with-link: タイトルが実リンク。onArticleClick は副作用フックであり
+    // ナビゲーションの代替ではない（遷移は <a href> としてブラウザが担う）
+    const link = screen.getByTestId('article-title-link');
+    await user.click(link);
 
-    // onArticleClickが呼ばれる（スクロール位置保存等の副作用用）
     expect(handleClick).toHaveBeenCalled();
-    // ナビゲーションも発生する（onArticleClickは副作用フックであり、ナビゲーション代替ではない）
-    expect(mockRouter.push).toHaveBeenCalled();
+    expect(link.getAttribute('href')).toContain('/articles/');
   });
 
-  it('navigates to article detail page when clicked without onArticleClick', async () => {
-    const user = userEvent.setup();
+  it('links to the article detail page, carrying the current list as the return target', () => {
     renderWithProviders(<ArticleCard article={mockArticle} />);
 
-    const card = screen.getByTestId('article-card');
-    await user.click(card);
+    const link = screen.getByTestId('article-title-link');
+    const href = link.getAttribute('href') as string;
 
-    // onArticleClick未指定時はデフォルトのナビゲーションが発生する
-    expect(mockRouter.push).toHaveBeenCalled();
+    expect(link.tagName).toBe('A');
+    expect(href).toContain(`/articles/${mockArticle.id}`);
+    // 戻り先は現在の一覧（`/` 固定ではない）
+    const from = decodeURIComponent(
+      new URL(`http://localhost${href}`).searchParams.get('from') as string
+    );
+    expect(from).toContain('returning=1');
   });
 
   it('displays favorite button', () => {
@@ -391,8 +395,11 @@ describe('ArticleCard', () => {
 
     const titleElement = screen.getByText(/This is an extremely long title/i);
     expect(titleElement).toBeInTheDocument();
-    // タイトルは適切にレンダリングされている
-    expect(titleElement).toHaveClass('font-semibold');
+    // テキストはタイトルリンク内にあり、省略スタイルは見出し側が持つ
+    expect(screen.getByTestId('article-title')).toHaveClass(
+      'font-semibold',
+      'line-clamp-2'
+    );
   });
 
   it('correctly handles missing optional fields', () => {

--- a/__tests__/components/article/favorite-button.test.tsx
+++ b/__tests__/components/article/favorite-button.test.tsx
@@ -1,0 +1,233 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FavoriteButton } from '@/app/components/article/favorite-button';
+
+/**
+ * uncontrolled モードの状態遷移を検証する。
+ *
+ * 背景（PR #652 のレビュー指摘）:
+ * - 同じ記事が 1 画面に複数並ぶ（例: /sources/[id] の「最新記事」と「人気記事TOP5」）
+ *   ため、article-favorite-changed イベントでインスタンス間を同期している
+ * - 楽観更新の失敗時に無条件でロールバックすると、他インスタンスの成功結果や
+ *   サーバーの実状態を巻き戻してしまう
+ */
+
+const mockUseSession = jest.fn(() => ({
+  data: { user: { id: 'user-1' } },
+  isPending: false,
+}));
+jest.mock('@/lib/auth/auth-client', () => ({
+  authClient: {
+    useSession: () => mockUseSession(),
+    signIn: { email: jest.fn(), social: jest.fn() },
+    signOut: jest.fn(),
+    signUp: { email: jest.fn() },
+  },
+}));
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const mockToast = jest.fn();
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+const ARTICLE_ID = 'article-1';
+const ADD_LABEL = 'お気に入りに追加';
+const REMOVE_LABEL = 'お気に入りから削除';
+
+function mockFetchOnce(init: { ok: boolean; status: number }) {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: init.ok,
+    status: init.status,
+    json: async () => ({}),
+  });
+}
+
+describe('FavoriteButton の状態遷移（uncontrolled）', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    mockUseSession.mockReturnValue({
+      data: { user: { id: 'user-1' } },
+      isPending: false,
+    });
+  });
+
+  it('登録に成功すると「削除」ラベルへ変わり、同期イベントを発火する', async () => {
+    const user = userEvent.setup();
+    const events: CustomEvent[] = [];
+    const listener = (e: Event) => events.push(e as CustomEvent);
+    window.addEventListener('article-favorite-changed', listener);
+
+    mockFetchOnce({ ok: true, status: 200 });
+    render(<FavoriteButton articleId={ARTICLE_ID} />);
+
+    await user.click(screen.getByRole('button', { name: ADD_LABEL }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: REMOVE_LABEL })
+      ).toBeInTheDocument();
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].detail).toMatchObject({
+      articleId: ARTICLE_ID,
+      isFavorited: true,
+    });
+
+    window.removeEventListener('article-favorite-changed', listener);
+  });
+
+  it('POST が 409（既に登録済み）でもロールバックしない', async () => {
+    const user = userEvent.setup();
+    mockFetchOnce({ ok: false, status: 409 });
+    render(<FavoriteButton articleId={ARTICLE_ID} />);
+
+    await user.click(screen.getByRole('button', { name: ADD_LABEL }));
+
+    // サーバー上は登録済み＝目的の状態なので、登録済み表示のままにする
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: REMOVE_LABEL })
+      ).toBeInTheDocument();
+    });
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('DELETE が 404（既に未登録）でもロールバックしない', async () => {
+    const user = userEvent.setup();
+    mockFetchOnce({ ok: false, status: 404 });
+    render(<FavoriteButton articleId={ARTICLE_ID} isFavorited />);
+
+    await user.click(screen.getByRole('button', { name: REMOVE_LABEL }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: ADD_LABEL })
+      ).toBeInTheDocument();
+    });
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('サーバーエラー（500）ではロールバックしてエラーを通知する', async () => {
+    const user = userEvent.setup();
+    mockFetchOnce({ ok: false, status: 500 });
+    render(<FavoriteButton articleId={ARTICLE_ID} />);
+
+    await user.click(screen.getByRole('button', { name: ADD_LABEL }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: ADD_LABEL })
+      ).toBeInTheDocument();
+    });
+    expect(mockToast).toHaveBeenCalled();
+  });
+
+  it('ネットワーク例外でもロールバックする', async () => {
+    const user = userEvent.setup();
+    (global.fetch as jest.Mock).mockRejectedValueOnce(
+      new Error('network down')
+    );
+    render(<FavoriteButton articleId={ARTICLE_ID} />);
+
+    await user.click(screen.getByRole('button', { name: ADD_LABEL }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: ADD_LABEL })
+      ).toBeInTheDocument();
+    });
+    expect(mockToast).toHaveBeenCalled();
+  });
+
+  it('他インスタンスの同期イベントを受けて表示を合わせる', async () => {
+    render(<FavoriteButton articleId={ARTICLE_ID} />);
+    expect(screen.getByRole('button', { name: ADD_LABEL })).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('article-favorite-changed', {
+          detail: { articleId: ARTICLE_ID, isFavorited: true },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: REMOVE_LABEL })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('別記事の同期イベントは無視する', async () => {
+    render(<FavoriteButton articleId={ARTICLE_ID} />);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('article-favorite-changed', {
+          detail: { articleId: 'other-article', isFavorited: true },
+        })
+      );
+    });
+
+    expect(screen.getByRole('button', { name: ADD_LABEL })).toBeInTheDocument();
+  });
+
+  it('失敗のロールバックは、後から入った同期イベントを巻き戻さない', async () => {
+    const user = userEvent.setup();
+    // 応答を保留し、その間に別インスタンスの同期イベントを流す
+    let rejectFetch: (reason?: unknown) => void = () => {};
+    (global.fetch as jest.Mock).mockReturnValueOnce(
+      new Promise((_resolve, reject) => {
+        rejectFetch = reject;
+      })
+    );
+
+    render(<FavoriteButton articleId={ARTICLE_ID} />);
+    await user.click(screen.getByRole('button', { name: ADD_LABEL }));
+
+    // 別ボタンが登録に成功した通知（＝これが最新の正）
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('article-favorite-changed', {
+          detail: { articleId: ARTICLE_ID, isFavorited: true },
+        })
+      );
+    });
+
+    // 遅れて自分のリクエストが失敗する
+    await act(async () => {
+      rejectFetch(new Error('late failure'));
+      await Promise.resolve();
+    });
+
+    // 同期イベントの結果（登録済み）が保たれること
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: REMOVE_LABEL })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('未認証ならログインへ誘導し、API を呼ばない', async () => {
+    const user = userEvent.setup();
+    mockUseSession.mockReturnValue({
+      data: null,
+      isPending: false,
+    } as unknown as ReturnType<typeof mockUseSession>);
+
+    render(<FavoriteButton articleId={ARTICLE_ID} />);
+    await user.click(screen.getByRole('button', { name: ADD_LABEL }));
+
+    expect(mockPush).toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/ui-v2/button-v2.test.tsx
+++ b/__tests__/components/ui-v2/button-v2.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react';
+import { ButtonV2 } from '@/components/ui-v2/button-v2';
+
+/**
+ * NOTE: このファイルは意図的に CSS クラス出力を直接アサートする。
+ * プロジェクト標準は data-variant / role / aria-* によるアサートだが、
+ * ButtonV2 の className マージ（twMerge）は「どのクラスが残り、どれが消えるか」
+ * そのものが仕様であり、属性では検証できないための例外。
+ * 背景: investigate G-2（`hidden lg:inline-flex` が効かず死にボタンになっていた）
+ */
+describe('ButtonV2 className merge (twMerge)', () => {
+  it('caller の hidden が base の inline-flex を上書きする', () => {
+    render(<ButtonV2 className="hidden">押す</ButtonV2>);
+    const btn = screen.getByRole('button', { name: '押す' });
+
+    expect(btn.className).toContain('hidden');
+    expect(btn.className).not.toContain('inline-flex');
+  });
+
+  it('hidden lg:inline-flex を渡すと両方が残る（レスポンシブ出し分けが機能する）', () => {
+    render(<ButtonV2 className="hidden lg:inline-flex">フィルター</ButtonV2>);
+    const btn = screen.getByRole('button', { name: 'フィルター' });
+
+    // base の inline-flex（breakpoint なし）は hidden に負けて消える
+    expect(btn.className).not.toMatch(/(^|\s)inline-flex(\s|$)/);
+    expect(btn.className).toContain('hidden');
+    expect(btn.className).toContain('lg:inline-flex');
+  });
+
+  it('caller の高さ指定が size variant の高さを上書きする', () => {
+    render(
+      <ButtonV2 size="sm" className="h-11">
+        タップ
+      </ButtonV2>
+    );
+    const btn = screen.getByRole('button', { name: 'タップ' });
+
+    expect(btn.className).toContain('h-11');
+    // size="sm" の h-8 は消える
+    expect(btn.className).not.toMatch(/(^|\s)h-8(\s|$)/);
+  });
+
+  it('caller の背景色が variant の背景色を上書きする', () => {
+    render(
+      <ButtonV2 variant="primary" className="bg-transparent">
+        透明
+      </ButtonV2>
+    );
+    const btn = screen.getByRole('button', { name: '透明' });
+
+    expect(btn.className).toContain('bg-transparent');
+    expect(btn.className).not.toContain('bg-(--tt-color-primary)');
+  });
+
+  it('衝突しないクラスは base と caller の両方が残る', () => {
+    render(<ButtonV2 className="relative">両立</ButtonV2>);
+    const btn = screen.getByRole('button', { name: '両立' });
+
+    expect(btn.className).toContain('relative');
+    expect(btn.className).toContain('inline-flex');
+    expect(btn.className).toContain('items-center');
+  });
+
+  it('asChild + disabled の cloneElement 経路でも className がマージされる', () => {
+    render(
+      <ButtonV2 asChild disabled className="hidden">
+        <a href="/foo">リンク</a>
+      </ButtonV2>
+    );
+    const link = screen.getByText('リンク');
+
+    expect(link.className).toContain('hidden');
+    expect(link.className).not.toContain('inline-flex');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('asChild + disabled で子要素側の className が親のクラスを上書きする', () => {
+    render(
+      <ButtonV2 asChild disabled size="sm">
+        <a href="/foo" className="h-11">
+          リンク
+        </a>
+      </ButtonV2>
+    );
+    const link = screen.getByText('リンク');
+
+    expect(link.className).toContain('h-11');
+    expect(link.className).not.toMatch(/(^|\s)h-8(\s|$)/);
+  });
+});
+
+describe('ButtonV2 既存挙動の回帰', () => {
+  it('variant を data 属性で公開する', () => {
+    render(<ButtonV2 variant="outline">枠線</ButtonV2>);
+    expect(screen.getByRole('button', { name: '枠線' })).toHaveAttribute(
+      'data-variant',
+      'outline'
+    );
+  });
+
+  it('loading 中は disabled になる', () => {
+    render(<ButtonV2 loading>送信</ButtonV2>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('iconOnly は size を icon 系にマップする', () => {
+    render(
+      <ButtonV2 size="sm" iconOnly aria-label="閉じる">
+        <span>x</span>
+      </ButtonV2>
+    );
+    const btn = screen.getByRole('button', { name: '閉じる' });
+
+    expect(btn.className).toContain('size-8');
+  });
+
+  it('type は既定で button（フォーム誤送信の防止）', () => {
+    render(<ButtonV2>実行</ButtonV2>);
+    expect(screen.getByRole('button', { name: '実行' })).toHaveAttribute(
+      'type',
+      'button'
+    );
+  });
+});

--- a/__tests__/e2e/specs/article-detail.spec.ts
+++ b/__tests__/e2e/specs/article-detail.spec.ts
@@ -34,7 +34,10 @@ test.describe('記事詳細ページ', () => {
       expect(titleText).toBeTruthy();
       
       // 記事本文が表示されることを確認
-      const articleContent = page.locator('article, [class*="content"], [class*="body"]').first();
+      // data-testid を使う: `article` / `[class*="content"]` などのセレクタは
+      // 関連記事の有無（seed データ）や Tailwind のクラス名に依存し、
+      // 環境によって空振りするため
+      const articleContent = page.getByTestId('article-content');
       await expect(articleContent).toBeVisible();
     }
   });

--- a/__tests__/hooks/use-personalization-preferences.test.tsx
+++ b/__tests__/hooks/use-personalization-preferences.test.tsx
@@ -16,6 +16,21 @@ import {
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
+// better-auth の client は ESM のため Jest では実体を読み込ませない。
+// 既定は「認証済み」。未認証の挙動を見るテストだけ個別に上書きする。
+const mockUseSession = jest.fn(() => ({
+  data: { user: { id: 'user-1' } },
+  isPending: false,
+}));
+jest.mock('@/lib/auth/auth-client', () => ({
+  authClient: {
+    useSession: () => mockUseSession(),
+    signIn: { email: jest.fn(), social: jest.fn() },
+    signOut: jest.fn(),
+    signUp: { email: jest.fn() },
+  },
+}));
+
 // Test wrapper with React Query
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -35,6 +50,7 @@ function createWrapper() {
 describe('useInterestCategories', () => {
   beforeEach(() => {
     mockFetch.mockClear();
+    mockUseSession.mockClear();
   });
 
   it('should fetch categories successfully', async () => {
@@ -99,6 +115,7 @@ describe('useInterestCategories', () => {
 describe('useUserPreferences', () => {
   beforeEach(() => {
     mockFetch.mockClear();
+    mockUseSession.mockClear();
   });
 
   it('should fetch user preferences successfully', async () => {
@@ -126,7 +143,39 @@ describe('useUserPreferences', () => {
     expect(mockFetch).toHaveBeenCalledWith('/api/user/preferences/categories?scope=home');
   });
 
-  it('should return default preferences when not authenticated', async () => {
+  it('should not call the API when unauthenticated', async () => {
+    // 未認証では 401 が確定しているためリクエスト自体を送らない
+    mockUseSession.mockReturnValueOnce({ data: null, isPending: false });
+
+    const { result } = renderHook(() => useUserPreferences(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+    // enabled: false のとき isLoading は false（呼び出し側の記事クエリを止めない）
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should not call the API while the session is still pending', async () => {
+    mockUseSession.mockReturnValueOnce({ data: null, isPending: true });
+
+    const { result } = renderHook(() => useUserPreferences(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('should return default preferences when the API returns 401 (expired session)', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 401,
@@ -152,6 +201,7 @@ describe('useUserPreferences', () => {
 describe('useUpdatePreferences', () => {
   beforeEach(() => {
     mockFetch.mockClear();
+    mockUseSession.mockClear();
   });
 
   it('should update preferences successfully', async () => {
@@ -219,6 +269,7 @@ describe('useUpdatePreferences', () => {
 describe('usePersonalizationPreferences', () => {
   beforeEach(() => {
     mockFetch.mockClear();
+    mockUseSession.mockClear();
   });
 
   it('should combine categories and preferences', async () => {

--- a/app/admin/articles/_components/article-detail-dialog.tsx
+++ b/app/admin/articles/_components/article-detail-dialog.tsx
@@ -311,7 +311,7 @@ export function ArticleDetailDialog({
                     <Button
                       variant="outline"
                       size="sm"
-                      className="flex items-center gap-1"
+                      className="items-center gap-1"
                     >
                       {isContentOpen ? '折りたたむ' : '本文を表示'}
                       <ChevronDown

--- a/app/articles/[id]/page.tsx
+++ b/app/articles/[id]/page.tsx
@@ -61,16 +61,14 @@ export default async function ArticlePage({ params, searchParams }: PageProps) {
     // 特定のキーワードから適切なURLへマッピング
     if (fromParam === 'digest') return '/digest';
 
-    try {
-      const decodedUrl = decodeURIComponent(fromParam);
-      // 相対パスまたは同一オリジンのみ許可
-      if (decodedUrl.startsWith('/') && !decodedUrl.startsWith('//')) {
-        return decodedUrl;
-      }
-      return '/';
-    } catch {
-      return '/';
+    // searchParams は Next.js が既に 1 回 decode 済み。
+    // ここで再度 decodeURIComponent すると `search=C%2B%2B` が `search=C++` になり、
+    // 戻り先で URLSearchParams が `+` を空白と解釈してフィルタ条件が壊れる
+    // 相対パスのみ許可（`//` はプロトコル相対 URL なので外部遷移になり得る）
+    if (fromParam.startsWith('/') && !fromParam.startsWith('//')) {
+      return fromParam;
     }
+    return '/';
   };
 
   const returnUrl = getReturnUrl(from);

--- a/app/articles/[id]/page.tsx
+++ b/app/articles/[id]/page.tsx
@@ -236,7 +236,13 @@ export default async function ArticlePage({ params, searchParams }: PageProps) {
                 </div>
               </CardHeader>
 
-              <CardContent className="!-mt-4 space-y-4">
+              {/* data-testid: E2E から本文コンテナを安定して掴めるようにする。
+                  class 名や関連記事の有無に依存するセレクタは seed データ次第で
+                  空振りするため（__tests__/e2e/specs/article-detail.spec.ts） */}
+              <CardContent
+                className="!-mt-4 space-y-4"
+                data-testid="article-content"
+              >
                 {/* Translation notice for translated articles */}
                 {article.translatedTitle && (
                   <div

--- a/app/articles/[id]/page.tsx
+++ b/app/articles/[id]/page.tsx
@@ -32,7 +32,8 @@ interface PageProps {
     id: string;
   }>;
   searchParams: Promise<{
-    from?: string;
+    // Next.js は同名パラメータが複数あると配列を渡す（?from=/a&from=/b）
+    from?: string | string[];
   }>;
 }
 
@@ -55,20 +56,29 @@ export default async function ArticlePage({ params, searchParams }: PageProps) {
   const [{ id }, { from }] = await Promise.all([params, searchParams]);
 
   // セキュリティ: fromパラメータの検証
-  const getReturnUrl = (fromParam: string | undefined): string => {
-    if (!fromParam) return '/';
+  const getReturnUrl = (fromParam: string | string[] | undefined): string => {
+    // 同名パラメータが複数ある場合 Next.js は配列を渡す。文字列以外は破棄する
+    if (typeof fromParam !== 'string' || !fromParam) return '/';
 
     // 特定のキーワードから適切なURLへマッピング
     if (fromParam === 'digest') return '/digest';
 
     // searchParams は Next.js が既に 1 回 decode 済み。
     // ここで再度 decodeURIComponent すると `search=C%2B%2B` が `search=C++` になり、
-    // 戻り先で URLSearchParams が `+` を空白と解釈してフィルタ条件が壊れる
-    // 相対パスのみ許可（`//` はプロトコル相対 URL なので外部遷移になり得る）
-    if (fromParam.startsWith('/') && !fromParam.startsWith('//')) {
-      return fromParam;
+    // 戻り先で URLSearchParams が `+` を空白と解釈してフィルタ条件が壊れる。
+    //
+    // 検証は文字列の前方一致ではなく URL パーサに任せる。`startsWith('/') &&
+    // !startsWith('//')` だけでは `/\evil.example` を通してしまい、WHATWG URL の
+    // 正規化でバックスラッシュが `/` 扱いになる結果 https://evil.example/ への
+    // オープンリダイレクトになる。同一オリジンに解決されたものだけを許可する。
+    try {
+      const base = 'http://internal.invalid';
+      const resolved = new URL(fromParam, base);
+      if (resolved.origin !== base) return '/';
+      return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+    } catch {
+      return '/';
     }
-    return '/';
   };
 
   const returnUrl = getReturnUrl(from);

--- a/app/articles/_components/article-qa-dialog.tsx
+++ b/app/articles/_components/article-qa-dialog.tsx
@@ -55,7 +55,7 @@ export function ArticleQADialog({
         </DialogHeader>
         <div
           ref={scrollContainerRef}
-          className="max-h-[92vh] overflow-y-auto overscroll-contain rounded-[40px] bg-white/70 p-3 sm:p-6"
+          className="max-h-[92vh] overflow-y-auto overscroll-contain rounded-[40px] bg-(--tt-color-surface)/85 p-3 backdrop-blur-sm sm:p-6"
         >
           <ArticleQAClient
             articleId={articleId}

--- a/app/components/article/__tests__/CompactCard.test.tsx
+++ b/app/components/article/__tests__/CompactCard.test.tsx
@@ -9,6 +9,7 @@ import { createMockArticleWithRelations } from '@/test/utils/mock-factories';
 // Next.jsのモック
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
+  usePathname: jest.fn(() => '/'),
   useSearchParams: jest.fn(),
 }));
 
@@ -194,30 +195,26 @@ describe('CompactCard', () => {
     it('既読記事ではタイトルの透明度が変わる', () => {
       render(<CompactCard article={mockArticle} isRead={true} />);
 
-      const title = screen.getByText('Test Article Title');
+      const title = screen.getByTestId('article-title');
       expect(title).toHaveClass('opacity-70');
     });
 
     it('未読記事ではタイトルの透明度は変わらない', () => {
       render(<CompactCard article={mockArticle} isRead={false} />);
 
-      const title = screen.getByText('Test Article Title');
+      const title = screen.getByTestId('article-title');
       expect(title).not.toHaveClass('opacity-70');
     });
   });
 
   describe('インタラクション', () => {
-    it('カードクリック時に記事詳細ページにナビゲートする', async () => {
-      const user = userEvent.setup();
-
+    // card-with-link: div+onClick ではなくタイトルが実リンク。遷移はブラウザが担う
+    it('タイトルが記事詳細への実リンクになっている', () => {
       render(<CompactCard article={mockArticle} />);
 
-      const card = screen.getByTestId('compact-card');
-      await user.click(card);
-
-      expect(mockRouter.push).toHaveBeenCalledWith(
-        expect.stringContaining('/articles/1')
-      );
+      const link = screen.getByTestId('article-title-link');
+      expect(link.tagName).toBe('A');
+      expect(link.getAttribute('href')).toContain('/articles/1');
     });
 
     it('onArticleClickコールバックが提供されている場合実行する', async () => {
@@ -228,38 +225,20 @@ describe('CompactCard', () => {
         <CompactCard article={mockArticle} onArticleClick={handleClick} />
       );
 
-      const card = screen.getByTestId('compact-card');
-      await user.click(card);
+      await user.click(screen.getByTestId('article-title-link'));
 
       expect(handleClick).toHaveBeenCalledWith(mockArticle.id);
     });
 
-    it('キーボード操作（Enter）で記事詳細にナビゲートする', async () => {
-      const user = userEvent.setup();
-
+    it('タイトルリンクがキーボードでフォーカスできる', () => {
       render(<CompactCard article={mockArticle} />);
 
-      const card = screen.getByTestId('compact-card');
-      card.focus();
-      await user.keyboard('{Enter}');
+      const link = screen.getByTestId('article-title-link');
+      link.focus();
 
-      expect(mockRouter.push).toHaveBeenCalledWith(
-        expect.stringContaining('/articles/1')
-      );
-    });
-
-    it('キーボード操作（Space）で記事詳細にナビゲートする', async () => {
-      const user = userEvent.setup();
-
-      render(<CompactCard article={mockArticle} />);
-
-      const card = screen.getByTestId('compact-card');
-      card.focus();
-      await user.keyboard(' ');
-
-      expect(mockRouter.push).toHaveBeenCalledWith(
-        expect.stringContaining('/articles/1')
-      );
+      expect(link).toHaveFocus();
+      // ネイティブ <a href> なので Enter での遷移はブラウザが担保する
+      expect(link).toHaveAttribute('href');
     });
 
     it('タグクリック時にタグフィルターページに遷移する', async () => {
@@ -346,17 +325,18 @@ describe('CompactCard', () => {
       const searchParams = new URLSearchParams('tags=React&sortBy=publishedAt');
       (useSearchParams as jest.Mock).mockReturnValue(searchParams);
 
-      const user = userEvent.setup();
-
       render(<CompactCard article={mockArticle} />);
 
-      const card = screen.getByTestId('compact-card');
-      await user.click(card);
+      const href = screen
+        .getByTestId('article-title-link')
+        .getAttribute('href') as string;
 
-      // URLにfromパラメータが含まれる
-      expect(mockRouter.push).toHaveBeenCalledWith(
-        expect.stringContaining('from=')
+      expect(href).toContain('from=');
+      const from = decodeURIComponent(
+        new URL(`http://localhost${href}`).searchParams.get('from') as string
       );
+      expect(from).toContain('tags=React');
+      expect(from).toContain('returning=1');
     });
   });
 
@@ -368,25 +348,22 @@ describe('CompactCard', () => {
       expect(screen.getByTestId('favorite-button')).toBeInTheDocument();
     });
 
-    it('適切なrole属性を持つ', () => {
+    // href を持たない role/tabIndex ではなく、タイトルを実リンクにして
+    // スクリーンリーダーにリンク先を伝える（card-with-link）
+    it('タイトルがリンクとして公開されている', () => {
       render(<CompactCard article={mockArticle} />);
 
-      const card = screen.getByTestId('compact-card');
-      expect(card).toHaveAttribute('role', 'article');
+      expect(
+        screen.getByRole('link', { name: mockArticle.title })
+      ).toBeInTheDocument();
     });
 
-    it('適切なaria-labelledby属性を持つ', () => {
+    it('タイトルリンクがフォーカス可能である', () => {
       render(<CompactCard article={mockArticle} />);
 
-      const card = screen.getByTestId('compact-card');
-      expect(card).toHaveAttribute('aria-labelledby', 'compact-title-1');
-    });
-
-    it('カードがフォーカス可能である', () => {
-      render(<CompactCard article={mockArticle} />);
-
-      const card = screen.getByTestId('compact-card');
-      expect(card).toHaveAttribute('tabIndex', '0');
+      const link = screen.getByTestId('article-title-link');
+      link.focus();
+      expect(link).toHaveFocus();
     });
 
     it('タグがキーボードで操作可能である', () => {

--- a/app/components/article/card.tsx
+++ b/app/components/article/card.tsx
@@ -186,8 +186,17 @@ export function ArticleCard({
         ) : null}
       </div>
 
-      {/* Action buttons - visible on hover (desktop) or always visible (touch devices) */}
-      <div className="pointer-events-auto absolute right-2 bottom-2 flex items-center gap-1 opacity-100 transition-opacity duration-200 sm:pointer-events-none sm:opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100">
+      {/*
+        Action buttons: single element, layout switches at sm breakpoint.
+        - <sm (mobile): normal-flow footer row below the summary, always visible -> never overlaps content.
+        - >=sm (desktop): absolute overlay bottom-right, revealed on hover OR keyboard focus (group-focus-within).
+      */}
+      <div
+        className={cn(
+          'pointer-events-auto static mt-1 flex min-h-[44px] items-center justify-end gap-1 opacity-100 transition-opacity duration-200 sm:pointer-events-none sm:absolute sm:right-2 sm:bottom-2 sm:mt-0 sm:px-0 sm:opacity-0 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100',
+          hasTopThumbnail && 'px-4'
+        )}
+      >
         {votes > 0 && (
           <BadgeV2
             variant="secondary"

--- a/app/components/article/card.tsx
+++ b/app/components/article/card.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { Calendar, ExternalLink } from 'lucide-react';
 import { CardV2 } from '@/components/ui-v2/card-v2';
 import { BadgeV2 } from '@/components/ui-v2/badge-v2';
@@ -21,10 +22,11 @@ export function ArticleCard({
   isRead: initialIsRead = false,
   isFavorited,
   onToggleFavorite,
+  fetchInitialStatus = false,
   showSource = true,
 }: ArticleCardProps & { isRead?: boolean }) {
   const isRead = useReadStatus(article.id, initialIsRead);
-  const router = useRouter();
+  const pathname = usePathname();
 
   // T1: Thumbnail display with validation and error fallback
   const [thumbnailError, setThumbnailError] = useState(false);
@@ -39,24 +41,15 @@ export function ArticleCard({
     ? getSourceColor(article.source.name)
     : null;
 
-  const handleCardClick = (e: React.MouseEvent) => {
-    if (
-      e.defaultPrevented ||
-      (e.target as HTMLElement).closest('button, a, [role="button"]')
-    ) {
-      return;
-    }
-    if (onArticleClick) {
-      onArticleClick(article.id);
-    }
-
+  // 戻り先は「このカードが置かれている一覧」。`/` 固定にすると /papers や
+  // /favorites/feed から開いた記事の「記事一覧に戻る」がホームへ飛んでしまう
+  const articleHref = useMemo(() => {
     const params = new URLSearchParams(searchParams.toString());
     params.set('returning', '1');
-
-    const returnUrl = `/?${params.toString()}`;
-    const articleUrl = `/articles/${article.id}?from=${encodeURIComponent(returnUrl)}`;
-    router.push(articleUrl);
-  };
+    const query = params.toString();
+    const returnUrl = query ? `${pathname}?${query}` : pathname;
+    return `/articles/${article.id}?from=${encodeURIComponent(returnUrl)}`;
+  }, [article.id, pathname, searchParams]);
 
   const votes = article.userVotes || 0;
 
@@ -69,9 +62,11 @@ export function ArticleCard({
       id={`article-${article.id}`}
       data-testid="article-card"
       data-article-id={article.id}
-      onClick={handleCardClick}
       className={cn(
         'group relative flex h-auto cursor-pointer flex-col sm:min-h-[240px]',
+        // タイトル Link の擬似要素がカード全面を覆うため、フォーカスリングは
+        // コンテナ側で表現する（キーボード操作でどのカードにいるか分かるように）
+        'focus-within:ring-(--tt-color-primary) focus-within:ring-2 focus-within:ring-offset-2',
         hasTopThumbnail ? 'gap-0 pb-4' : 'gap-1.5 px-4 pt-3 pb-4',
         isNew
           ? 'border-t-2 border-t-[var(--tt-color-positive)]'
@@ -111,7 +106,17 @@ export function ArticleCard({
           title={article.translatedTitle || article.title}
           data-testid="article-title"
         >
-          {article.translatedTitle || article.title}
+          {/* card-with-link: タイトルが実リンクで、擬似要素がカード全面の
+              クリック領域になる。div+onClick と違いキーボードで開ける */}
+          <Link
+            href={articleHref}
+            prefetch={false}
+            onClick={() => onArticleClick?.(article.id)}
+            className="after:absolute after:inset-0 after:content-[''] focus:outline-none"
+            data-testid="article-title-link"
+          >
+            {article.translatedTitle || article.title}
+          </Link>
         </h3>
 
         {/* Sub-line: badges + relative time */}
@@ -193,7 +198,7 @@ export function ArticleCard({
       */}
       <div
         className={cn(
-          'pointer-events-auto static mt-1 flex min-h-[44px] items-center justify-end gap-1 opacity-100 transition-opacity duration-200 sm:pointer-events-none sm:absolute sm:right-2 sm:bottom-2 sm:mt-0 sm:px-0 sm:opacity-0 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100',
+          'pointer-events-auto relative z-10 mt-1 flex min-h-[44px] items-center justify-end gap-1 opacity-100 transition-opacity duration-200 sm:pointer-events-none sm:absolute sm:right-2 sm:bottom-2 sm:mt-0 sm:px-0 sm:opacity-0 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100',
           hasTopThumbnail && 'px-4'
         )}
       >
@@ -211,6 +216,7 @@ export function ArticleCard({
           className="bg-background/30 h-9 min-h-[44px] w-9 min-w-[44px]"
           isFavorited={isFavorited}
           onToggleFavorite={onToggleFavorite}
+          fetchInitialStatus={fetchInitialStatus}
         />
         <ButtonV2
           variant="ghost"

--- a/app/components/article/compact-card.tsx
+++ b/app/components/article/compact-card.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useMemo } from 'react';
+import Link from 'next/link';
+import { usePathname, useSearchParams, useRouter } from 'next/navigation';
 import { Calendar, Download, Clock, ExternalLink } from 'lucide-react';
 import { CardV2 } from '@/components/ui-v2/card-v2';
 import { BadgeV2 } from '@/components/ui-v2/badge-v2';
@@ -45,7 +47,8 @@ export function CompactCard({
   onTagClick,
 }: ArticleCardProps & { isRead?: boolean }) {
   const isRead = useReadStatus(article.id, initialIsRead);
-  const router = useRouter();
+  const router = useRouter(); // タグ遷移で使用
+  const pathname = usePathname();
   const searchParams = useSearchParams();
 
   // Note: Use hook to avoid Date.now() during render (React Compiler purity rule)
@@ -57,31 +60,15 @@ export function CompactCard({
   const contentLength = article.contentLength ?? article.content?.length ?? 0;
   const readingTime = getReadingTime(contentLength);
 
-  const navigateToArticle = () => {
-    if (onArticleClick) {
-      onArticleClick(article.id);
-    }
+  // 戻り先は「このカードが置かれている一覧」（`/` 固定だと /papers 等から
+  // 開いた記事の戻るがホームへ飛ぶ）
+  const articleHref = useMemo(() => {
     const params = new URLSearchParams(searchParams.toString());
     params.set('returning', '1');
-    const returnUrl = `/?${params.toString()}`;
-    const articleUrl = `/articles/${article.id}?from=${encodeURIComponent(returnUrl)}`;
-    router.push(articleUrl);
-  };
-
-  const handleCardClick = (e: React.MouseEvent) => {
-    // Ignore clicks on buttons or interactive elements
-    if ((e.target as HTMLElement).closest('button, [role="button"]')) {
-      return;
-    }
-    navigateToArticle();
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      navigateToArticle();
-    }
-  };
+    const query = params.toString();
+    const returnUrl = query ? `${pathname}?${query}` : pathname;
+    return `/articles/${article.id}?from=${encodeURIComponent(returnUrl)}`;
+  }, [article.id, pathname, searchParams]);
 
   const handleTagNavigation = (tagName: string) => {
     if (onTagClick) {
@@ -101,7 +88,7 @@ export function CompactCard({
     const remainingCount = article.tags.length - 1;
 
     return (
-      <div className="flex min-w-0 items-center gap-1">
+      <div className="relative z-10 flex min-w-0 items-center gap-1">
         <BadgeV2
           variant="outline"
           tabIndex={0}
@@ -134,17 +121,13 @@ export function CompactCard({
   return (
     <CardV2
       variant="hover"
-      tabIndex={0}
-      role="article"
-      aria-labelledby={`compact-title-${article.id}`}
       id={`article-${article.id}`}
       data-testid="compact-card"
       data-article-id={article.id}
-      onClick={handleCardClick}
-      onKeyDown={handleKeyDown}
       className={cn(
         'group relative flex min-h-[140px] cursor-pointer flex-col gap-1 p-3',
-        'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+        // フォーカスリングはタイトル Link を包むコンテナ側で表現する
+        'focus-within:ring-2 focus-within:ring-(--tt-color-primary) focus-within:ring-offset-2',
         isNew
           ? 'border-t-2 border-t-[var(--tt-color-positive)]'
           : sourceColor?.borderLeft
@@ -220,14 +203,23 @@ export function CompactCard({
         )}
         data-testid="article-title"
       >
-        {article.translatedTitle || article.title}
+        <Link
+          href={articleHref}
+          prefetch={false}
+          onClick={() => onArticleClick?.(article.id)}
+          className="after:absolute after:inset-0 after:content-[''] focus:outline-none"
+          data-testid="article-title-link"
+        >
+          {article.translatedTitle || article.title}
+        </Link>
       </h3>
 
       {/* Tags */}
       {renderTags()}
 
       {/* Footer: ArticleCardと同じ構造 - 左=FavoriteButton、右=読了時間+元記事ボタン */}
-      <div className="mt-auto flex items-center justify-between pt-1">
+      {/* 擬似要素のクリック領域より上に載せる（付け漏れるとボタン操作が記事遷移に化ける） */}
+      <div className="relative z-10 mt-auto flex items-center justify-between pt-1">
         <FavoriteButton
           articleId={article.id}
           isFavorited={isFavorited}

--- a/app/components/article/favorite-button.tsx
+++ b/app/components/article/favorite-button.tsx
@@ -181,7 +181,10 @@ export function FavoriteButton({
       // スタンドアロン使用の場合は直接APIを呼び出す
       // 楽観的更新
       const newState = !isFavorited;
-      stateGenerationRef.current += 1;
+      // この楽観更新の世代を控える。失敗時のロールバックは「まだ自分が最新」の
+      // ときだけ行う。別ボタンの成功イベントで既に更新済みなら巻き戻さない
+      const optimisticGeneration = stateGenerationRef.current + 1;
+      stateGenerationRef.current = optimisticGeneration;
       setUncontrolledFavorited(newState);
 
       try {
@@ -200,11 +203,14 @@ export function FavoriteButton({
             })
           );
         } else {
-          // エラー時は元に戻す
-          setUncontrolledFavorited(!newState);
           throw new Error('Failed to toggle favorite');
         }
       } catch (error) {
+        // HTTP エラーとネットワーク例外の双方でロールバックする（旧実装は
+        // 例外時に楽観更新が残っていた）。ただし自分の更新が最新のときだけ
+        if (stateGenerationRef.current === optimisticGeneration) {
+          setUncontrolledFavorited(!newState);
+        }
         console.error('Failed to toggle favorite:', error);
         toast({
           title: 'エラー',

--- a/app/components/article/favorite-button.tsx
+++ b/app/components/article/favorite-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui-v2/button-v2';
 import { Heart } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -47,6 +47,9 @@ export function FavoriteButton({
   const [isLoadingInitial, setIsLoadingInitial] = useState(
     fetchInitialStatus && !isControlled
   );
+  // 初期 GET の世代。トグルや他インスタンスからの同期が入った後に古い GET が
+  // 返ってきても、その結果で状態を巻き戻さないための番兵
+  const stateGenerationRef = useRef(0);
 
   const isFavorited = isControlled ? initialFavorited : uncontrolledFavorited;
 
@@ -66,6 +69,7 @@ export function FavoriteButton({
     }
 
     const abortController = new AbortController();
+    const generationAtRequest = stateGenerationRef.current;
 
     const fetchStatus = async () => {
       try {
@@ -76,7 +80,10 @@ export function FavoriteButton({
         });
         if (response.ok) {
           const data = await response.json();
-          setUncontrolledFavorited(data.isFavorited);
+          // GET 発行後にトグル or 同期イベントが起きていたら、その結果を優先する
+          if (generationAtRequest === stateGenerationRef.current) {
+            setUncontrolledFavorited(data.isFavorited);
+          }
         }
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
@@ -124,6 +131,7 @@ export function FavoriteButton({
         event as CustomEvent<{ articleId: string; isFavorited: boolean }>
       ).detail;
       if (!detail || detail.articleId !== articleId) return;
+      stateGenerationRef.current += 1;
       setUncontrolledFavorited(detail.isFavorited);
     };
 
@@ -173,6 +181,7 @@ export function FavoriteButton({
       // スタンドアロン使用の場合は直接APIを呼び出す
       // 楽観的更新
       const newState = !isFavorited;
+      stateGenerationRef.current += 1;
       setUncontrolledFavorited(newState);
 
       try {

--- a/app/components/article/favorite-button.tsx
+++ b/app/components/article/favorite-button.tsx
@@ -112,6 +112,29 @@ export function FavoriteButton({
     setUncontrolledFavorited(initialFavorited);
   }, [initialFavorited, fetchInitialStatus, onToggleFavorite]);
 
+  // 同じ記事が 1 画面に複数並ぶケース（例: /sources/[id] の「最新記事」と
+  // 「人気記事TOP5」）で、片方をトグルしてももう片方の表示が変わらない問題を防ぐ。
+  // トグル成功時に発火する article-favorite-changed を購読して状態を揃える。
+  // controlled モードは親が state を持つため対象外。
+  useEffect(() => {
+    if (onToggleFavorite) return;
+
+    const handleFavoriteChanged = (event: Event) => {
+      const detail = (
+        event as CustomEvent<{ articleId: string; isFavorited: boolean }>
+      ).detail;
+      if (!detail || detail.articleId !== articleId) return;
+      setUncontrolledFavorited(detail.isFavorited);
+    };
+
+    window.addEventListener('article-favorite-changed', handleFavoriteChanged);
+    return () =>
+      window.removeEventListener(
+        'article-favorite-changed',
+        handleFavoriteChanged
+      );
+  }, [articleId, onToggleFavorite]);
+
   const handleClick = async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();

--- a/app/components/article/favorite-button.tsx
+++ b/app/components/article/favorite-button.tsx
@@ -191,7 +191,14 @@ export function FavoriteButton({
         const response = await fetch(`/api/favorites/${articleId}`, {
           method: newState ? 'POST' : 'DELETE',
         });
-        if (response.ok) {
+        // 409 = 既に登録済み / 404 = 既に未登録。どちらもサーバーの状態は
+        // newState と一致しているので、成功と同じ扱いにする（ロールバックすると
+        // 実状態と UI が食い違う）
+        const alreadyInDesiredState =
+          (newState && response.status === 409) ||
+          (!newState && response.status === 404);
+
+        if (response.ok || alreadyInDesiredState) {
           // API成功時にイベント発火（React Queryキャッシュ同期用）
           window.dispatchEvent(
             new CustomEvent('article-favorite-changed', {
@@ -203,7 +210,9 @@ export function FavoriteButton({
             })
           );
         } else {
-          throw new Error('Failed to toggle favorite');
+          throw new Error(
+            `Failed to toggle favorite (HTTP ${response.status})`
+          );
         }
       } catch (error) {
         // HTTP エラーとネットワーク例外の双方でロールバックする（旧実装は
@@ -244,6 +253,7 @@ export function FavoriteButton({
         data-testid="favorite-button"
       >
         <Heart
+          aria-hidden="true"
           className={cn(
             'h-4 w-4 transition-colors',
             isFavorited && 'fill-[var(--tt-color-negative)]',
@@ -273,8 +283,14 @@ export function FavoriteButton({
         className
       )}
       data-testid="favorite-button"
+      // showText が false のときはハートアイコンだけになり、支援技術に
+      // 目的が伝わらない（axe の button-name 違反）。compact モードと同じく
+      // 常にアクセシブル名を持たせる
+      aria-label={isFavorited ? 'お気に入りから削除' : 'お気に入りに追加'}
+      aria-pressed={isFavorited}
     >
       <Heart
+        aria-hidden="true"
         className={cn(
           'h-4 w-4 transition-colors',
           outline

--- a/app/components/article/list-item.tsx
+++ b/app/components/article/list-item.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
+import { useState, useEffect, useMemo } from 'react';
+import Link from 'next/link';
+import { usePathname, useSearchParams, useRouter } from 'next/navigation';
 import { Clock, TrendingUp, ExternalLink, Eye } from 'lucide-react';
 import { BadgeV2 } from '@/components/ui-v2/badge-v2';
 import { ButtonV2 } from '@/components/ui-v2/button-v2';
@@ -21,7 +22,8 @@ export function ArticleListItem({
   onToggleFavorite,
 }: ArticleListItemProps) {
   const isRead = useReadStatus(article.id, initialIsRead);
-  const router = useRouter();
+  const router = useRouter(); // タグ遷移で使用
+  const pathname = usePathname();
 
   // Note: Date.now() called in useEffect to avoid purity violations during render
   const isNew = useIsNewArticle(article.publishedAt, 24) ?? false;
@@ -37,52 +39,31 @@ export function ArticleListItem({
   const searchParams = useSearchParams();
   const sourceColor = getSourceColor(article.source?.name || 'Unknown');
 
-  const handleClick = useCallback(
-    (_e: React.MouseEvent | React.KeyboardEvent) => {
-      if (onArticleClick) {
-        onArticleClick(article.id);
-      }
-
-      const params = new URLSearchParams(searchParams.toString());
-      params.set('returning', '1');
-
-      const returnUrl = `/?${params.toString()}`;
-      const articleUrl = `/articles/${article.id}?from=${encodeURIComponent(returnUrl)}`;
-
-      router.push(articleUrl);
-    },
-    [article.id, onArticleClick, searchParams, router]
-  );
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.target !== e.currentTarget) return;
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        handleClick(e);
-      }
-    },
-    [handleClick]
-  );
+  // 戻り先は「このカードが置かれている一覧」（`/` 固定だと /papers 等から
+  // 開いた記事の戻るがホームへ飛ぶ）
+  const articleHref = useMemo(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('returning', '1');
+    const query = params.toString();
+    const returnUrl = query ? `${pathname}?${query}` : pathname;
+    return `/articles/${article.id}?from=${encodeURIComponent(returnUrl)}`;
+  }, [article.id, pathname, searchParams]);
 
   return (
     <div
       id={`article-${article.id}`}
       data-article-id={article.id}
-      role="link"
-      tabIndex={0}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      aria-label={article.translatedTitle || article.title}
       className={cn(
-        'group flex cursor-pointer items-center justify-between gap-4 rounded-lg p-3',
+        // href を持たない role="link" は SR にリンク先を伝えられないため撤去し、
+        // タイトルを実リンクにする card-with-link へ移行。relative は擬似要素の基準
+        'group relative flex cursor-pointer items-center justify-between gap-4 rounded-lg p-3',
         'bg-(--tt-color-surface)',
         'transition-all duration-200',
         'hover:bg-(--tt-color-surface-hover)',
         'border border-(--tt-color-border)',
         'hover:border-(--tt-color-border-hover)',
         'hover:shadow-sm',
-        'focus-visible:ring-2 focus-visible:ring-(--tt-color-primary) focus-visible:outline-none',
+        'focus-within:ring-2 focus-within:ring-(--tt-color-primary)',
         sourceColor.hover
       )}
     >
@@ -107,7 +88,15 @@ export function ArticleListItem({
               className="text-foreground line-clamp-1 text-sm font-medium group-hover:text-(--tt-color-primary)"
               title={article.translatedTitle || article.title}
             >
-              {article.translatedTitle || article.title}
+              <Link
+                href={articleHref}
+                prefetch={false}
+                onClick={() => onArticleClick?.(article.id)}
+                className="after:absolute after:inset-0 after:content-[''] focus:outline-none"
+                data-testid="article-title-link"
+              >
+                {article.translatedTitle || article.title}
+              </Link>
             </h3>
           </div>
           {article.summary && (
@@ -121,7 +110,7 @@ export function ArticleListItem({
         </div>
 
         {article.tags && article.tags.length > 0 && (
-          <div className="mt-1 hidden flex-wrap gap-1 sm:flex">
+          <div className="relative z-10 mt-1 hidden flex-wrap gap-1 sm:flex">
             {article.tags.slice(0, 3).map((tag) => (
               <BadgeV2
                 key={tag.id}
@@ -164,11 +153,13 @@ export function ArticleListItem({
         <div className="text-muted-foreground flex flex-col gap-0.5 text-xs">
           <div className="hidden flex-col gap-0.5 sm:flex">
             <span className="flex items-center gap-1">
-              <span>📅</span>
+              <span aria-hidden="true">📅</span>
+              <span className="sr-only">公開日:</span>
               <span>{formatDateWithTime(article.publishedAt)}</span>
             </span>
             <span className="flex items-center gap-1">
-              <span>📥</span>
+              <span aria-hidden="true">📥</span>
+              <span className="sr-only">収集日:</span>
               <span>{formatDateWithTime(article.createdAt)}</span>
             </span>
           </div>
@@ -180,7 +171,8 @@ export function ArticleListItem({
           </span>
         </div>
 
-        <div className="hidden items-center gap-1 group-focus-within:flex group-hover:flex">
+        {/* 擬似要素のクリック領域より上に載せる（付け漏れると操作が記事遷移に化ける） */}
+        <div className="relative z-10 hidden items-center gap-1 group-focus-within:flex group-hover:flex">
           <FavoriteButton
             articleId={article.id}
             compact

--- a/app/components/article/related-articles.tsx
+++ b/app/components/article/related-articles.tsx
@@ -213,7 +213,7 @@ export function RelatedArticles({
           </Button>
         </div>
       </CardHeader>
-      <CardContent className="scrollbar-thin max-h-[600px] space-y-2 overflow-y-auto">
+      <CardContent className="max-h-[600px] scrollbar-thin space-y-2 overflow-y-auto">
         {displayArticles.map((article) => (
           <RelatedArticleItem key={article.id} article={article} />
         ))}
@@ -221,7 +221,7 @@ export function RelatedArticles({
         {hasMore && (
           <Button
             variant="ghost"
-            className="mt-2 flex w-full items-center gap-2"
+            className="mt-2 w-full items-center gap-2"
             onClick={() => setExpanded(!expanded)}
           >
             {expanded ? (

--- a/app/components/common/date-range-filter.tsx
+++ b/app/components/common/date-range-filter.tsx
@@ -20,6 +20,10 @@ import {
 } from '@/components/ui/select';
 import { useMediaQuery } from '@/app/hooks/use-media-query';
 import { DATE_RANGE_OPTIONS, getDateRangeLabel } from '@/app/lib/date-utils';
+import {
+  buildFilterUrl,
+  clearTransientFilterParams,
+} from '@/lib/utils/url/filter-params';
 
 interface DateRangeFilterProps {
   className?: string;
@@ -110,7 +114,8 @@ export function DateRangeFilter({ className = '' }: DateRangeFilterProps) {
     params.delete('dateRange');
     params.delete('dateFrom');
     params.delete('dateTo');
-    params.delete('page');
+    // ページと /reader の選択中記事をリセット
+    clearTransientFilterParams(params);
 
     // Set new params
     for (const [key, value] of Object.entries(updates)) {
@@ -119,10 +124,8 @@ export function DateRangeFilter({ className = '' }: DateRangeFilterProps) {
       }
     }
 
-    const queryString = params.toString();
     // パスを固定すると /reader で日付を選んだ瞬間にホームへ離脱する
-    const newUrl = queryString ? `${pathname}?${queryString}` : pathname;
-    router.push(newUrl);
+    router.push(buildFilterUrl(pathname, params));
   }
 
   async function saveFilterPreference(prefs: {

--- a/app/components/common/date-range-filter.tsx
+++ b/app/components/common/date-range-filter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Calendar as CalendarIcon } from 'lucide-react';
 import type { DateRange } from 'react-day-picker';
 import { Button } from '@/components/ui-v2/button-v2';
@@ -60,6 +60,7 @@ function getDateBounds() {
 
 export function DateRangeFilter({ className = '' }: DateRangeFilterProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const isMobile = useMediaQuery('(max-width: 768px)');
 
@@ -119,7 +120,8 @@ export function DateRangeFilter({ className = '' }: DateRangeFilterProps) {
     }
 
     const queryString = params.toString();
-    const newUrl = queryString ? `/?${queryString}` : '/';
+    // パスを固定すると /reader で日付を選んだ瞬間にホームへ離脱する
+    const newUrl = queryString ? `${pathname}?${queryString}` : pathname;
     router.push(newUrl);
   }
 

--- a/app/components/common/filter-reset-button.tsx
+++ b/app/components/common/filter-reset-button.tsx
@@ -11,6 +11,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { toast } from '@/hooks/use-toast';
 
 export function FilterResetButton() {
   const router = useRouter();
@@ -18,29 +19,47 @@ export function FilterResetButton() {
   const [isResetting, setIsResetting] = useState(false);
 
   const handleReset = async () => {
+    if (isResetting) return;
     setIsResetting(true);
 
+    // 2 本の DELETE は独立しているため、片方だけ成功する部分失敗があり得る。
+    // その場合でも一部の Cookie は既に消えているので、成否にかかわらず
+    // UI とサーバー状態を再同期する（旧実装は throw して再同期を飛ばしていた）
+    let failed = false;
     try {
-      // Clear all filter-related cookies (parallel)
       const responses = await Promise.all([
         fetch('/api/filter-preferences', { method: 'DELETE' }),
         fetch('/api/source-filter', { method: 'DELETE' }),
       ]);
-      if (responses.some((r) => !r.ok)) {
-        throw new Error('Filter reset API failed');
+      failed = responses.some((r) => !r.ok);
+      if (failed) {
+        console.error(
+          '[FilterResetButton] filter reset API returned non-OK:',
+          responses.map((r) => r.status)
+        );
       }
-
-      // Clear view mode cookie (if exists)
-      document.cookie =
-        'article-view-mode=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
-
-      await queryClient.invalidateQueries();
-      router.replace('/');
     } catch (err) {
       console.error('Filter reset failed:', err);
-      alert('フィルターのリセットに失敗しました');
+      failed = true;
+    }
+
+    // Clear view mode cookie (if exists) — API の成否に依存しない
+    document.cookie =
+      'article-view-mode=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+
+    try {
+      await queryClient.invalidateQueries();
+      router.replace('/');
     } finally {
       setIsResetting(false);
+    }
+
+    if (failed) {
+      toast({
+        title: 'フィルターのリセットに一部失敗しました',
+        description: '残った条件がある場合は時間をおいて再度お試しください。',
+        variant: 'destructive',
+      });
     }
   };
 

--- a/app/components/common/filter-reset-button.tsx
+++ b/app/components/common/filter-reset-button.tsx
@@ -25,22 +25,22 @@ export function FilterResetButton() {
     // 2 本の DELETE は独立しているため、片方だけ成功する部分失敗があり得る。
     // その場合でも一部の Cookie は既に消えているので、成否にかかわらず
     // UI とサーバー状態を再同期する（旧実装は throw して再同期を飛ばしていた）
-    let failed = false;
-    try {
-      const responses = await Promise.all([
-        fetch('/api/filter-preferences', { method: 'DELETE' }),
-        fetch('/api/source-filter', { method: 'DELETE' }),
-      ]);
-      failed = responses.some((r) => !r.ok);
-      if (failed) {
-        console.error(
-          '[FilterResetButton] filter reset API returned non-OK:',
-          responses.map((r) => r.status)
-        );
-      }
-    } catch (err) {
-      console.error('Filter reset failed:', err);
-      failed = true;
+    // Promise.all は片方が reject した時点で先へ進んでしまい、もう一方の DELETE が
+    // 完了する前に再同期してしまう。allSettled で両方の決着を待つ
+    const results = await Promise.allSettled([
+      fetch('/api/filter-preferences', { method: 'DELETE' }),
+      fetch('/api/source-filter', { method: 'DELETE' }),
+    ]);
+    const failed = results.some(
+      (r) => r.status === 'rejected' || !r.value.ok
+    );
+    if (failed) {
+      console.error(
+        '[FilterResetButton] filter reset did not fully succeed:',
+        results.map((r) =>
+          r.status === 'rejected' ? `rejected: ${r.reason}` : r.value.status
+        )
+      );
     }
 
     // Clear view mode cookie (if exists) — API の成否に依存しない

--- a/app/components/common/hooks/useSourceFilter.ts
+++ b/app/components/common/hooks/useSourceFilter.ts
@@ -14,6 +14,10 @@ import { useCompanyFilter } from '@/lib/hooks/use-company-filter';
 import type { CompanySource } from '@/lib/providers/company-source';
 import type { GroupedSources } from '@/lib/types/source-grouping';
 import { getPrimaryCategoryByGroupId } from '@/lib/compatibility/category-group-mapping';
+import {
+  buildFilterUrl,
+  clearTransientFilterParams,
+} from '@/lib/utils/url/filter-params';
 
 interface UseSourceFilterParams {
   sources: Array<{ id: string; name: string }>;
@@ -276,7 +280,8 @@ export function useSourceFilter({
     // Remove old params
     params.delete('sourceId');
     params.delete('sources');
-    params.delete('page'); // ページパラメータも削除
+    // ページと /reader の選択中記事をリセット
+    clearTransientFilterParams(params);
 
     if (sourceIds.length === 0) {
       // 明示的に「何も選択しない」状態を示す
@@ -289,13 +294,8 @@ export function useSourceFilter({
       params.set('sources', sourceIds.join(','));
     }
 
-    // URLを構築（パラメータがない場合は "/" のみ）
-    const newURL = params.toString()
-      ? `${pathname}?${params.toString()}`
-      : pathname;
-
     // URL更新（Next.jsが自動的に競合を制御）
-    router.push(newURL);
+    router.push(buildFilterUrl(pathname, params));
 
     // Cookie更新は150msデバウンス
     lastQueuedSourcesRef.current = sourceIds;

--- a/app/components/common/mark-all-read-button.tsx
+++ b/app/components/common/mark-all-read-button.tsx
@@ -94,7 +94,7 @@ export function MarkAllReadButton({
         size="sm"
         onClick={handleMarkAllRead}
         disabled={disabled || isMarking || unreadCount === 0}
-        className="relative flex items-center gap-2"
+        className="relative items-center gap-2"
         title="全ての未読記事を既読にする"
       >
         <CheckCheck className="h-4 w-4" />

--- a/app/components/common/mobile-search-toggle.tsx
+++ b/app/components/common/mobile-search-toggle.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useId, useRef, useState } from 'react';
+import { Search, X } from 'lucide-react';
+import { ButtonV2 } from '@/components/ui-v2/button-v2';
+import { SearchBox } from '@/app/components/common/search-box';
+
+/**
+ * モバイル (<lg) 用のキーワード検索入口。
+ * lg以上では常時表示のSearchBoxがあるため非表示にし、
+ * モバイルではこのトグルボタンからツールバー直下に全幅のSearchBoxを段階的開示する。
+ */
+export function MobileSearchToggle() {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // 展開時、検索入力へフォーカスを移す
+  useEffect(() => {
+    if (!open) return;
+    const input = panelRef.current?.querySelector<HTMLInputElement>('input');
+    input?.focus();
+  }, [open]);
+
+  return (
+    <>
+      <ButtonV2
+        type="button"
+        variant="outline"
+        size="sm"
+        iconOnly
+        onClick={() => setOpen((prev) => !prev)}
+        className="h-9 min-h-[44px] w-9 min-w-[44px] lg:hidden"
+        aria-label={open ? '検索を閉じる' : '検索を開く'}
+        aria-expanded={open}
+        aria-controls={panelId}
+        data-testid="mobile-search-toggle"
+      >
+        {open ? <X className="h-4 w-4" /> : <Search className="h-4 w-4" />}
+      </ButtonV2>
+      {open && (
+        <div
+          id={panelId}
+          ref={panelRef}
+          className="w-full lg:hidden"
+          data-testid="mobile-search-panel"
+        >
+          <SearchBox fullWidth />
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/components/common/mobile-search-toggle.tsx
+++ b/app/components/common/mobile-search-toggle.tsx
@@ -42,7 +42,9 @@ export function MobileSearchToggle() {
         <div
           id={panelId}
           ref={panelRef}
-          className="w-full lg:hidden"
+          // basis-full: 親が flex-wrap のとき自分だけで 1 行を占有し、
+          // 右カラム内の狭い領域に閉じ込められないようにする
+          className="w-full basis-full lg:hidden"
           data-testid="mobile-search-panel"
         >
           <SearchBox fullWidth />

--- a/app/components/common/search-box.tsx
+++ b/app/components/common/search-box.tsx
@@ -50,6 +50,8 @@ export function SearchBox({ fullWidth = false }: SearchBoxProps = {}) {
         params.delete('search');
         params.delete('page');
       }
+      // フィルタ変更時は選択中記事（reader用）をクリアする
+      params.delete('article');
 
       // 現在のパスを維持してURLパラメータを更新
       const nextUrl = params.toString()
@@ -91,6 +93,8 @@ export function SearchBox({ fullWidth = false }: SearchBoxProps = {}) {
     const params = new URLSearchParams(searchParams.toString());
     params.delete('search');
     params.delete('page');
+    // フィルタ変更時は選択中記事（reader用）をクリアする
+    params.delete('article');
 
     // 現在のパスを維持してURLパラメータを更新
     const nextUrl = params.toString()

--- a/app/components/common/search-box.tsx
+++ b/app/components/common/search-box.tsx
@@ -6,8 +6,14 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui-v2/button-v2';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import { useDebounce } from '@/hooks/use-debounce';
+import { cn } from '@/lib/utils';
 
-export function SearchBox() {
+interface SearchBoxProps {
+  /** trueの場合、親要素の幅いっぱいに広がる（モバイル検索パネル用） */
+  fullWidth?: boolean;
+}
+
+export function SearchBox({ fullWidth = false }: SearchBoxProps = {}) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
@@ -105,7 +111,9 @@ export function SearchBox() {
   };
 
   return (
-    <div className="flex flex-col" style={{ width: '24rem' }}>
+    <div
+      className={cn('flex flex-col', fullWidth ? 'w-full' : 'w-96 max-w-full')}
+    >
       <div className="relative">
         <Search className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 transform text-[var(--tt-color-text-muted)]" />
         <Input
@@ -131,6 +139,7 @@ export function SearchBox() {
             onClick={handleClear}
             className="absolute top-1/2 right-1 h-6 w-6 -translate-y-1/2 transform p-0"
             data-testid="search-clear"
+            aria-label="検索をクリア"
           >
             <X className="h-3 w-3" />
           </Button>

--- a/app/components/common/server-pagination.tsx
+++ b/app/components/common/server-pagination.tsx
@@ -8,11 +8,15 @@ interface ServerPaginationProps {
   searchParams: Record<string, string | undefined>;
 }
 
-export function ServerPagination({ currentPage, totalPages, searchParams }: ServerPaginationProps) {
+export function ServerPagination({
+  currentPage,
+  totalPages,
+  searchParams,
+}: ServerPaginationProps) {
   const getPageNumbers = () => {
     const pages: (number | string)[] = [];
     const showPages = 5; // Number of page buttons to show
-    
+
     if (totalPages <= showPages) {
       // Show all pages if total is less than showPages
       for (let i = 1; i <= totalPages; i++) {
@@ -21,27 +25,27 @@ export function ServerPagination({ currentPage, totalPages, searchParams }: Serv
     } else {
       // Always show first page
       pages.push(1);
-      
+
       if (currentPage > 3) {
         pages.push('...');
       }
-      
+
       // Show pages around current page
       const start = Math.max(2, currentPage - 1);
       const end = Math.min(totalPages - 1, currentPage + 1);
-      
+
       for (let i = start; i <= end; i++) {
         pages.push(i);
       }
-      
+
       if (currentPage < totalPages - 2) {
         pages.push('...');
       }
-      
+
       // Always show last page
       pages.push(totalPages);
     }
-    
+
     return pages;
   };
 
@@ -61,13 +65,16 @@ export function ServerPagination({ currentPage, totalPages, searchParams }: Serv
   }
 
   return (
-    <nav className="flex items-center justify-center space-x-2" data-testid="pagination-container">
+    <nav
+      className="flex items-center justify-center space-x-2"
+      data-testid="pagination-container"
+    >
       <Button
         variant="outline"
         size="sm"
         disabled={currentPage === 1}
         asChild={currentPage !== 1}
-        className="flex items-center gap-1 whitespace-nowrap"
+        className="items-center gap-1 whitespace-nowrap"
         data-testid="pagination-prev"
       >
         {currentPage === 1 ? (
@@ -76,25 +83,32 @@ export function ServerPagination({ currentPage, totalPages, searchParams }: Serv
             前へ
           </span>
         ) : (
-          <Link href={buildPageUrl(currentPage - 1)} className="flex items-center gap-1">
+          <Link
+            href={buildPageUrl(currentPage - 1)}
+            className="flex items-center gap-1"
+          >
             <ChevronLeft className="h-4 w-4" />
             前へ
           </Link>
         )}
       </Button>
-      
+
       <div className="flex items-center space-x-1">
         {getPageNumbers().map((page, index) => (
           <div key={index}>
             {page === '...' ? (
-              <span className="px-3 text-muted-foreground">...</span>
+              <span className="text-muted-foreground px-3">...</span>
             ) : (
               <Button
                 variant={currentPage === page ? 'default' : 'outline'}
                 size="sm"
                 className="min-w-[40px]"
                 asChild={currentPage !== page}
-                data-testid={currentPage === page ? 'pagination-current' : `pagination-button-${page}`}
+                data-testid={
+                  currentPage === page
+                    ? 'pagination-current'
+                    : `pagination-button-${page}`
+                }
               >
                 {currentPage === page ? (
                   <span>{page}</span>
@@ -106,13 +120,13 @@ export function ServerPagination({ currentPage, totalPages, searchParams }: Serv
           </div>
         ))}
       </div>
-      
+
       <Button
         variant="outline"
         size="sm"
         disabled={currentPage === totalPages}
         asChild={currentPage !== totalPages}
-        className="flex items-center gap-1 whitespace-nowrap"
+        className="items-center gap-1 whitespace-nowrap"
         data-testid="pagination-next"
       >
         {currentPage === totalPages ? (
@@ -121,7 +135,10 @@ export function ServerPagination({ currentPage, totalPages, searchParams }: Serv
             <ChevronRight className="h-4 w-4" />
           </span>
         ) : (
-          <Link href={buildPageUrl(currentPage + 1)} className="flex items-center gap-1">
+          <Link
+            href={buildPageUrl(currentPage + 1)}
+            className="flex items-center gap-1"
+          >
             次へ
             <ChevronRight className="h-4 w-4" />
           </Link>

--- a/app/components/common/sort-buttons.tsx
+++ b/app/components/common/sort-buttons.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/ui-v2/button-v2';
 import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 import { useState, useEffect } from 'react';
+import { clearTransientFilterParams } from '@/lib/utils/url/filter-params';
 
 interface SortButtonsProps {
   initialSortBy?: string;
@@ -34,8 +35,8 @@ export function SortButtons({ initialSortBy }: SortButtonsProps) {
 
     const params = new URLSearchParams(searchParams.toString());
     params.set('sortBy', newSortBy);
-    params.delete('page'); // Reset to first page
-    params.delete('article'); // フィルタ変更時は選択中記事（reader用）をクリアする
+    // ページと /reader の選択中記事をリセット
+    clearTransientFilterParams(params);
 
     // 現在のパスを維持してURLパラメータを更新
     router.push(`${pathname}?${params.toString()}`);

--- a/app/components/common/sort-buttons.tsx
+++ b/app/components/common/sort-buttons.tsx
@@ -35,6 +35,7 @@ export function SortButtons({ initialSortBy }: SortButtonsProps) {
     const params = new URLSearchParams(searchParams.toString());
     params.set('sortBy', newSortBy);
     params.delete('page'); // Reset to first page
+    params.delete('article'); // フィルタ変更時は選択中記事（reader用）をクリアする
 
     // 現在のパスを維持してURLパラメータを更新
     router.push(`${pathname}?${params.toString()}`);

--- a/app/components/common/tag-filter-dropdown.tsx
+++ b/app/components/common/tag-filter-dropdown.tsx
@@ -102,6 +102,7 @@ export function TagFilterDropdown({ tags }: TagFilterDropdownProps) {
                   params.delete('tags');
                   params.delete('tagMode');
                   params.delete('page');
+                  params.delete('article'); // フィルタ変更時は選択中記事（reader用）をクリアする
                   const qs = params.toString();
                   router.replace(qs ? `${pathname}?${qs}` : pathname);
                 }}

--- a/app/components/common/tag-filter-dropdown.tsx
+++ b/app/components/common/tag-filter-dropdown.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { TagFilter } from './tag-filter';
 import { cn } from '@/lib/utils';
+import { clearTransientFilterParams } from '@/lib/utils/url/filter-params';
 
 interface TagFilterDropdownProps {
   tags: Array<{
@@ -101,8 +102,7 @@ export function TagFilterDropdown({ tags }: TagFilterDropdownProps) {
                   const params = new URLSearchParams(searchParams.toString());
                   params.delete('tags');
                   params.delete('tagMode');
-                  params.delete('page');
-                  params.delete('article'); // フィルタ変更時は選択中記事（reader用）をクリアする
+                  clearTransientFilterParams(params);
                   const qs = params.toString();
                   router.replace(qs ? `${pathname}?${qs}` : pathname);
                 }}

--- a/app/components/common/tag-filter.tsx
+++ b/app/components/common/tag-filter.tsx
@@ -26,6 +26,10 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import { useDebounce } from '@/lib/hooks/use-debounce';
+import {
+  buildFilterUrl,
+  clearTransientFilterParams,
+} from '@/lib/utils/url/filter-params';
 
 interface TagFilterProps {
   tags: Array<{
@@ -182,12 +186,11 @@ export function TagFilter({ tags: initialTags }: TagFilterProps) {
       params.delete('tagMode');
     }
 
-    // ページ番号をリセット
-    params.delete('page');
+    // ページ番号と /reader の選択中記事をリセット
+    clearTransientFilterParams(params);
 
     // パスを固定すると /reader や /papers でタグを選んだ瞬間にホームへ離脱する
-    const qs = params.toString();
-    router.push(qs ? `${pathname}?${qs}` : pathname);
+    router.push(buildFilterUrl(pathname, params));
   };
 
   // タグの選択/選択解除

--- a/app/components/common/tag-filter.tsx
+++ b/app/components/common/tag-filter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Badge } from '@/components/ui-v2/badge-v2';
 import { Button } from '@/components/ui-v2/button-v2';
 import { Input } from '@/components/ui/input';
@@ -38,6 +38,7 @@ interface TagFilterProps {
 
 export function TagFilter({ tags: initialTags }: TagFilterProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -184,7 +185,9 @@ export function TagFilter({ tags: initialTags }: TagFilterProps) {
     // ページ番号をリセット
     params.delete('page');
 
-    router.push(`/?${params.toString()}`);
+    // パスを固定すると /reader や /papers でタグを選んだ瞬間にホームへ離脱する
+    const qs = params.toString();
+    router.push(qs ? `${pathname}?${qs}` : pathname);
   };
 
   // タグの選択/選択解除

--- a/app/components/common/unread-filter.tsx
+++ b/app/components/common/unread-filter.tsx
@@ -8,13 +8,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { cn } from '@/lib/utils';
 
 type ReadFilterMode = 'all' | 'unread' | 'read';
 
 export function UnreadFilter() {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const currentMode =
     (searchParams.get('readFilter') as ReadFilterMode) || 'all';
@@ -32,7 +33,9 @@ export function UnreadFilter() {
     // ページをリセット
     params.delete('page');
 
-    router.push(`/?${params.toString()}`);
+    // 現在のパスを維持する（他の一覧画面から使われても離脱しないように）
+    const qs = params.toString();
+    router.push(qs ? `${pathname}?${qs}` : pathname);
   };
 
   const getIcon = (mode: ReadFilterMode) => {

--- a/app/components/common/unread-filter.tsx
+++ b/app/components/common/unread-filter.tsx
@@ -10,6 +10,10 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { cn } from '@/lib/utils';
+import {
+  buildFilterUrl,
+  clearTransientFilterParams,
+} from '@/lib/utils/url/filter-params';
 
 type ReadFilterMode = 'all' | 'unread' | 'read';
 
@@ -30,12 +34,11 @@ export function UnreadFilter() {
       params.set('readFilter', mode);
     }
 
-    // ページをリセット
-    params.delete('page');
+    // ページと /reader の選択中記事をリセット
+    clearTransientFilterParams(params);
 
     // 現在のパスを維持する（他の一覧画面から使われても離脱しないように）
-    const qs = params.toString();
-    router.push(qs ? `${pathname}?${qs}` : pathname);
+    router.push(buildFilterUrl(pathname, params));
   };
 
   const getIcon = (mode: ReadFilterMode) => {

--- a/app/components/common/view-mode-toggle.tsx
+++ b/app/components/common/view-mode-toggle.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Grid3x3, Grid2x2, List } from 'lucide-react';
 import { Button } from '@/components/ui-v2/button-v2';
 import type { ViewModeToggleProps } from '@/types/components';
@@ -12,8 +14,17 @@ import {
 import { toast } from '@/hooks/use-toast';
 
 export function ViewModeToggle({ currentMode }: ViewModeToggleProps) {
+  const router = useRouter();
+  const [isUpdating, setIsUpdating] = useState(false);
+  // 連打時に古い応答で状態が巻き戻らないよう、最新リクエストだけを採用する
+  const requestSeqRef = useRef(0);
+
   const handleModeChange = async (mode: ViewModeToggleProps['currentMode']) => {
-    // サーバーに送信してCookieを更新
+    if (isUpdating) return;
+
+    const seq = ++requestSeqRef.current;
+    setIsUpdating(true);
+
     try {
       const response = await fetch('/api/view-mode', {
         method: 'POST',
@@ -23,10 +34,13 @@ export function ViewModeToggle({ currentMode }: ViewModeToggleProps) {
       if (!response.ok) {
         throw new Error(`View mode update failed: HTTP ${response.status}`);
       }
-      // ページをリロードして新しい表示モードを適用
-      window.location.reload();
+      if (seq !== requestSeqRef.current) return;
+      // Server Component を再取得して Cookie の表示モードを反映する。
+      // フルリロードと違い、読み込み済みの記事とスクロール位置は保持される
+      router.refresh();
     } catch (error) {
-      // POST 失敗時は reload せず、開発者が原因を追跡できるようログだけ残す
+      if (seq !== requestSeqRef.current) return;
+      // POST 失敗時は再取得せず、開発者が原因を追跡できるようログだけ残す
       console.error(
         `[ViewModeToggle] failed to update view mode (mode=${mode}):`,
         error
@@ -37,6 +51,8 @@ export function ViewModeToggle({ currentMode }: ViewModeToggleProps) {
         description: '時間をおいて再度お試しください。',
         variant: 'destructive',
       });
+    } finally {
+      if (seq === requestSeqRef.current) setIsUpdating(false);
     }
   };
 
@@ -56,6 +72,7 @@ export function ViewModeToggle({ currentMode }: ViewModeToggleProps) {
               variant={currentMode === 'card' ? 'default' : 'outline'}
               size="sm"
               onClick={() => handleModeChange('card')}
+              disabled={isUpdating}
               className="h-7 w-7 p-0"
             >
               <Grid3x3 className="h-4 w-4" />
@@ -75,6 +92,7 @@ export function ViewModeToggle({ currentMode }: ViewModeToggleProps) {
               variant={currentMode === 'compact' ? 'default' : 'outline'}
               size="sm"
               onClick={() => handleModeChange('compact')}
+              disabled={isUpdating}
               className="h-7 w-7 p-0"
             >
               <Grid2x2 className="h-4 w-4" />
@@ -94,6 +112,7 @@ export function ViewModeToggle({ currentMode }: ViewModeToggleProps) {
               variant={currentMode === 'list' ? 'default' : 'outline'}
               size="sm"
               onClick={() => handleModeChange('list')}
+              disabled={isUpdating}
               className="h-7 w-7 p-0"
             >
               <List className="h-4 w-4" />

--- a/app/components/layout/__tests__/header.test.tsx
+++ b/app/components/layout/__tests__/header.test.tsx
@@ -15,6 +15,17 @@ jest.mock('@/lib/constants', () => ({
   SITE_NAME: 'TechTrend',
 }));
 
+// better-auth の client は ESM のため、Jest では実体を読み込ませずモックする
+// （Issue #585 で Header が AI 検索リンクの表示判定に useSession を使うようになった）
+jest.mock('@/lib/auth/auth-client', () => ({
+  authClient: {
+    useSession: jest.fn().mockReturnValue({ data: null, isPending: false }),
+    signIn: { email: jest.fn(), social: jest.fn() },
+    signOut: jest.fn(),
+    signUp: { email: jest.fn() },
+  },
+}));
+
 // コンポーネントのモック
 jest.mock('@/components/theme-toggle', () => ({
   ThemeToggle: () => <button data-testid="theme-toggle">Theme Toggle</button>,
@@ -222,23 +233,25 @@ describe('Header', () => {
     });
   });
 
+  // ヘッダーのデスクトップ切替は lg。ツールバー（検索・タグ等）が lg 基準のため、
+  // md にすると 768〜1023px でナビだけデスクトップ表示になりヘッダーが溢れる
   describe('レスポンシブ表示', () => {
-    it('デスクトップナビはmd以上で表示される', () => {
+    it('デスクトップナビはlg以上で表示される', () => {
       render(<Header />);
 
       const desktopNav = screen.getByTestId('desktop-nav');
-      expect(desktopNav).toHaveClass('hidden md:flex');
+      expect(desktopNav).toHaveClass('hidden lg:flex');
     });
 
-    it('モバイルメニューボタンはmd未満で表示される', () => {
+    it('モバイルメニューボタンはlg未満で表示される', () => {
       render(<Header />);
 
       const mobileMenuToggle =
         screen.getByTestId('mobile-menu-toggle').parentElement;
-      expect(mobileMenuToggle).toHaveClass('md:hidden');
+      expect(mobileMenuToggle).toHaveClass('lg:hidden');
     });
 
-    it('モバイルナビはmd未満でのみ表示される', async () => {
+    it('モバイルナビはlg未満でのみ表示される', async () => {
       const user = userEvent.setup();
       render(<Header />);
 
@@ -246,7 +259,7 @@ describe('Header', () => {
       await user.click(toggleButton);
 
       const mobileNav = screen.getByTestId('mobile-nav');
-      expect(mobileNav).toHaveClass('md:hidden');
+      expect(mobileNav).toHaveClass('lg:hidden');
     });
   });
 

--- a/app/components/layout/header.tsx
+++ b/app/components/layout/header.tsx
@@ -13,6 +13,8 @@ import {
   BookOpen,
   Newspaper,
   FileText,
+  Sparkles,
+  UserPlus,
 } from 'lucide-react';
 import { Button } from '@/components/ui-v2/button-v2';
 import { useState } from 'react';
@@ -22,14 +24,19 @@ import { ThemeToggle } from '@/components/theme-toggle';
 import { UserMenu } from '@/components/auth/UserMenu';
 import { cn } from '@/lib/utils';
 import { NavDropdown } from '@/app/components/layout/nav-dropdown';
+import { authClient } from '@/lib/auth/auth-client';
+import { features } from '@/config/features';
+
+const MOBILE_NAV_ID = 'mobile-nav-panel';
 
 export function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const pathname = usePathname();
+  const { data: session, isPending } = authClient.useSession();
 
   // ナビゲーション項目の定義
   // prefetch: false は認証必須ページに設定（Server Component auth() redirect がprefetch時に走るのを防止）
-  const primaryNav = [
+  const primaryNavBase = [
     { href: '/', label: 'ホーム', icon: Home },
     { href: '/reader', label: 'リーダー', icon: BookOpen },
     {
@@ -39,8 +46,24 @@ export function Header() {
       prefetch: false as const,
     },
     { href: '/popular', label: '人気', icon: TrendingUp },
+  ];
+
+  // Issue #585: AI検索はフラグ有効 + 認証済みユーザーのみ表示（isPending中はチラつき防止のため非表示）
+  const showAiSearch = features.aiSearch && !isPending && !!session?.user;
+  const aiSearchNavItem = {
+    href: '/search/agent',
+    label: 'AI検索',
+    icon: Sparkles,
+    prefetch: false as const,
+  };
+
+  const primaryNav = [
+    ...primaryNavBase,
+    ...(showAiSearch ? [aiSearchNavItem] : []),
     { href: '/trends', label: 'トレンド', icon: BarChart3 },
   ];
+
+  const showSignupLink = !isPending && !session;
 
   const secondaryNav = [
     { href: '/history', label: '閲覧履歴', icon: LineChart },
@@ -54,21 +77,21 @@ export function Header() {
 
   return (
     <header className="bg-background/95 supports-[backdrop-filter]:bg-background/60 sticky top-0 z-50 w-full border-b backdrop-blur">
-      <div className="w-full px-6">
-        <div className="flex h-10 items-center justify-between">
+      <div className="w-full px-4 lg:px-6">
+        <div className="flex h-12 items-center justify-between lg:h-10">
           {/* Logo and Site Name */}
           <Link
             href="/"
-            className="flex items-center space-x-2"
+            className="flex min-w-0 items-center space-x-2"
             data-testid="header-logo"
           >
-            <Rss className="text-primary h-5 w-5" />
-            <span className="text-lg font-bold">{SITE_NAME}</span>
+            <Rss className="text-primary h-5 w-5 shrink-0" />
+            <span className="truncate text-lg font-bold">{SITE_NAME}</span>
           </Link>
 
           {/* Desktop Navigation */}
           <nav
-            className="hidden items-center space-x-3 md:flex"
+            className="hidden items-center space-x-3 lg:flex"
             data-testid="desktop-nav"
           >
             {/* 主要ナビゲーション */}
@@ -84,7 +107,7 @@ export function Header() {
                   aria-current={isActive ? 'page' : undefined}
                   data-testid={`nav-link-${item.label.toLowerCase()}`}
                   className={cn(
-                    'inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-all duration-200',
+                    'inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all duration-200',
                     'focus-visible:ring-primary focus-visible:ring-2 focus-visible:outline-none',
                     isActive
                       ? 'bg-primary text-primary-foreground shadow-sm'
@@ -102,19 +125,25 @@ export function Header() {
           </nav>
 
           {/* Desktop Actions */}
-          <div className="hidden items-center space-x-4 md:flex">
+          <div className="hidden items-center space-x-4 lg:flex">
             <ThemeToggle />
             <UserMenu />
           </div>
 
           {/* Mobile Actions */}
-          <div className="flex items-center gap-2 md:hidden">
+          <div className="flex items-center gap-2 lg:hidden">
             <ThemeToggle />
-            <UserMenu />
+            <UserMenu compact />
             <Button
               variant="ghost"
               size="sm"
+              className="h-11 w-11"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              aria-label={
+                mobileMenuOpen ? 'メニューを閉じる' : 'メニューを開く'
+              }
+              aria-expanded={mobileMenuOpen}
+              aria-controls={MOBILE_NAV_ID}
               data-testid="mobile-menu-toggle"
             >
               {mobileMenuOpen ? (
@@ -128,7 +157,11 @@ export function Header() {
 
         {/* Mobile Navigation */}
         {mobileMenuOpen && (
-          <nav className="border-t py-4 md:hidden" data-testid="mobile-nav">
+          <nav
+            id={MOBILE_NAV_ID}
+            className="border-t py-4 lg:hidden"
+            data-testid="mobile-nav"
+          >
             <div className="flex flex-col space-y-2">
               {/* 主要ナビゲーション */}
               {primaryNav.map((item) => {
@@ -187,6 +220,25 @@ export function Header() {
                   </Link>
                 );
               })}
+
+              {showSignupLink && (
+                <>
+                  <div className="bg-border my-2 h-px" />
+                  <Link
+                    href="/auth/signup"
+                    data-testid="mobile-nav-link-signup"
+                    className={cn(
+                      'inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-200',
+                      'focus-visible:ring-primary focus-visible:ring-2 focus-visible:outline-none',
+                      'hover:bg-secondary/50'
+                    )}
+                    onClick={() => setMobileMenuOpen(false)}
+                  >
+                    <UserPlus className="h-4 w-4" />
+                    <span>新規登録</span>
+                  </Link>
+                </>
+              )}
             </div>
           </nav>
         )}

--- a/app/components/layout/nav-dropdown.tsx
+++ b/app/components/layout/nav-dropdown.tsx
@@ -29,7 +29,7 @@ export function NavDropdown({ items }: NavDropdownProps) {
     <DropdownMenu>
       <DropdownMenuTrigger
         className={cn(
-          'inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-all duration-200',
+          'inline-flex shrink-0 items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all duration-200',
           'focus-visible:ring-primary focus-visible:ring-2 focus-visible:outline-none',
           hasActiveItem
             ? 'bg-primary text-primary-foreground shadow-sm'

--- a/app/components/popular/PopularArticles.tsx
+++ b/app/components/popular/PopularArticles.tsx
@@ -3,7 +3,12 @@
 import { useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui-v2/card-v2';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui-v2/card-v2';
 import { Button } from '@/components/ui-v2/button-v2';
 import { Badge } from '@/components/ui-v2/badge-v2';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -342,7 +347,7 @@ export function PopularArticles({
                     variant="ghost"
                     size="sm"
                     asChild
-                    className="flex h-11 w-11 items-center justify-center p-0"
+                    className="h-11 w-11 items-center justify-center p-0"
                   >
                     <a
                       href={article.url}

--- a/app/components/popular/share-button.tsx
+++ b/app/components/popular/share-button.tsx
@@ -84,7 +84,7 @@ export function ShareButton({ url, title, className }: ShareButtonProps) {
       disabled={isSharing}
       aria-label="記事を共有"
       className={cn(
-        'flex h-11 w-11 items-center justify-center p-0',
+        'h-11 w-11 items-center justify-center p-0',
         'focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2',
         className
       )}

--- a/app/components/tags/TagCloud.tsx
+++ b/app/components/tags/TagCloud.tsx
@@ -51,10 +51,14 @@ export function getTagColor(
   return cn(baseClasses, 'text-primary/60 hover:text-primary/40');
 }
 
-// Pre-compute skeleton widths at module level to avoid Math.random() during render
-const SKELETON_WIDTHS = Array.from({ length: 20 }, () =>
-  Math.floor(Math.random() * 100 + 50)
-);
+// スケルトンの幅は固定値。モジュールレベルでも Math.random() を使うと
+// サーバーとクライアントで別の値になり hydration mismatch を起こすため
+// （タグクラウド表示時に毎回 React の hydration エラーが出ていた）。
+// 見た目のばらつきだけが目的なので、決め打ちの並びで十分。
+const SKELETON_WIDTHS = [
+  118, 72, 145, 96, 61, 132, 84, 108, 57, 121, 90, 149, 66, 103, 137, 78, 112,
+  54, 126, 88,
+];
 
 interface TagCloudProps {
   className?: string;

--- a/app/components/tags/TagCloud.tsx
+++ b/app/components/tags/TagCloud.tsx
@@ -183,6 +183,8 @@ export function TagCloud({
               size="sm"
               onClick={() => refetch()}
               disabled={isFetching}
+              aria-label="タグクラウドを再取得"
+              title="再取得"
             >
               <RefreshCw
                 className={cn('h-4 w-4', isFetching && 'animate-spin')}

--- a/app/components/tags/__tests__/TagCloud.test.tsx
+++ b/app/components/tags/__tests__/TagCloud.test.tsx
@@ -166,7 +166,10 @@ describe('TagCloud', () => {
       });
 
       // リフレッシュボタンをクリック
-      const refreshButton = screen.getByRole('button', { name: '' }); // RefreshCw icon
+      // アイコンのみのボタンには aria-label を付与済み（axe の button-name 対策）
+      const refreshButton = screen.getByRole('button', {
+        name: 'タグクラウドを再取得',
+      });
       await user.click(refreshButton);
 
       await waitFor(() => {
@@ -466,7 +469,10 @@ describe('TagCloud', () => {
       );
 
       // 初期ローディング中
-      const refreshButton = screen.getByRole('button', { name: '' }); // RefreshCw icon
+      // アイコンのみのボタンには aria-label を付与済み（axe の button-name 対策）
+      const refreshButton = screen.getByRole('button', {
+        name: 'タグクラウドを再取得',
+      });
       expect(refreshButton).toBeDisabled();
 
       // ローディング完了後

--- a/app/components/trends/TrendSubNav.tsx
+++ b/app/components/trends/TrendSubNav.tsx
@@ -28,9 +28,12 @@ export function TrendSubNav() {
   };
 
   return (
+    // role="tablist"/"tab" は付けない: 中身は別ページへのリンクで、tabpanel も
+    // 矢印キーによる roving tabindex も存在しないため、tabs として告知すると
+    // スクリーンリーダー利用者の期待と食い違う。ナビ + aria-current が正しい。
+    // モバイルでは横スクロールさせ、ラベルの途中改行（縦書き状の崩れ）を防ぐ。
     <nav
-      className="bg-muted/50 flex items-center gap-1 rounded-lg p-1"
-      role="tablist"
+      className="bg-muted/50 flex [scrollbar-width:none] items-center gap-1 overflow-x-auto rounded-lg p-1 [&::-webkit-scrollbar]:hidden"
       aria-label="トレンドナビゲーション"
     >
       {trendNavItems.map((item) => {
@@ -41,11 +44,9 @@ export function TrendSubNav() {
           <Link
             key={item.href}
             href={item.href}
-            role="tab"
-            aria-selected={active}
             aria-current={active ? 'page' : undefined}
             className={cn(
-              'inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-all duration-200',
+              'inline-flex shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all duration-200',
               'focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
               active
                 ? 'bg-background text-foreground shadow-sm'

--- a/app/favorites/feed/_components/favorite-feed-content.tsx
+++ b/app/favorites/feed/_components/favorite-feed-content.tsx
@@ -312,7 +312,12 @@ export function FavoriteFeedContent() {
 
           <div className="space-y-4">
             {sortedArticles.map((article) => (
-              <ArticleCard key={article.id} article={article} />
+              <ArticleCard
+                key={article.id}
+                article={article}
+                // この画面は API がお気に入り状態を返さないため、カード側で取得する
+                fetchInitialStatus
+              />
             ))}
           </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -454,8 +454,32 @@ html.no-transitions *::after {
   }
 }
 
-/* Reduced motion support */
+/* Reduced motion support
+ *
+ * 個別クラスの列挙をやめ、全体を抑制してローディング表示だけを例外にする方式。
+ * 列挙方式は独自アニメーション（.chat-message-bubble / .chat-button-pulse /
+ * .animate-fade-in や Tailwind の animate-ping / animate-pulse、Radix の
+ * data-[state] アニメ）が増えるたびに漏れ、実質メンテ不能だったため。
+ */
 @media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  /* 進行中であることを伝える表示は動きを残す（止めると停止と区別できない） */
+  .animate-spin,
+  [data-loading='true'] .animate-spin,
+  .animate-pulse-loading {
+    animation-duration: 1s !important;
+    animation-iteration-count: infinite !important;
+  }
+
+  /* 入場アニメーションは最終状態で固定する（途中で止まって不可視になるのを防ぐ） */
   .fade-in-content,
   .animate-in,
   .animate-shimmer,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -166,7 +166,7 @@ export default async function RootLayout({
               <main
                 id="main-content"
                 tabIndex={-1}
-                className="flex-1 overflow-y-auto focus:outline-none"
+                className="flex-1 overflow-y-auto"
               >
                 {children}
               </main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -144,6 +144,14 @@ export default async function RootLayout({
       {/* 重要: overflow-hiddenは追加しないこと。トップページ以外でスクロール不可になる */}
       <body className="flex h-full flex-col overflow-hidden antialiased">
         <NoTransitions />
+        {/* キーボード利用者がヘッダーのナビ全体を Tab で通過せずに本文へ移動できるようにする */}
+        <a
+          href="#main-content"
+          data-testid="skip-to-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-100 focus:rounded-md focus:bg-(--tt-color-primary) focus:px-4 focus:py-2 focus:text-(--tt-color-on-primary) focus:shadow-lg focus:ring-2 focus:ring-(--tt-color-primary) focus:ring-offset-2 focus:outline-none"
+        >
+          本文へスキップ
+        </a>
         <AuthProvider>
           <ThemeProvider
             attribute="class"
@@ -154,7 +162,14 @@ export default async function RootLayout({
             <QueryProvider>
               {/* <OnboardingProvider> */}
               <Header />
-              <main className="flex-1 overflow-y-auto">{children}</main>
+              {/* tabIndex={-1}: スキップリンクの遷移先として確実にフォーカスを受け取るため */}
+              <main
+                id="main-content"
+                tabIndex={-1}
+                className="flex-1 overflow-y-auto focus:outline-none"
+              >
+                {children}
+              </main>
               <ScrollToTopButton />
               <ToastProvider />
               <WebVitalsReporter />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,5 @@
 import { Suspense } from 'react';
 import { cookies } from 'next/headers';
-import Link from 'next/link';
-import { Sparkles } from 'lucide-react';
 import { Filters } from '@/app/components/common/filters';
 import { MobileFilters } from '@/app/components/common/mobile-filters';
 import { MobileSearchToggle } from '@/app/components/common/mobile-search-toggle';
@@ -10,7 +8,6 @@ import { TagFilterDropdown } from '@/app/components/common/tag-filter-dropdown';
 import { ViewModeToggle } from '@/app/components/common/view-mode-toggle';
 import { SortButtons } from '@/app/components/common/sort-buttons';
 import { getSession } from '@/lib/auth/get-session';
-import { features } from '@/config/features';
 import { HomeClientInfinite } from '@/app/components/home/home-client-infinite';
 import { LoadingSpinner } from '@/app/components/common/loading-spinner';
 import { PersonalizationToggle } from '@/app/components/personalization';
@@ -162,16 +159,10 @@ export default async function Home({ searchParams }: PageProps) {
             <div className="hidden lg:block">
               <SearchBox />
             </div>
-            {features.aiSearch && session?.user && (
-              <Link
-                href="/search/agent"
-                className="hidden items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium whitespace-nowrap text-[var(--tt-color-info)] transition-colors hover:bg-[var(--tt-color-info-bg)] lg:flex"
-                title="AI検索"
-              >
-                <Sparkles className="h-4 w-4 flex-shrink-0" />
-                <span>AI検索</span>
-              </Link>
-            )}
+            {/* AI 検索リンクはヘッダーの primaryNav へ移設した（Issue #585）。
+                ここに残すとホーム上で同じリンクが 2 つ並び、支援技術にも
+                重複して読み上げられるため削除。デスクトップ限定だった導線も
+                ヘッダー経由で全ページ・全幅から到達できるようになっている */}
             <div className="hidden lg:block">
               <TagFilterDropdown tags={tags} />
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { Sparkles } from 'lucide-react';
 import { Filters } from '@/app/components/common/filters';
 import { MobileFilters } from '@/app/components/common/mobile-filters';
+import { MobileSearchToggle } from '@/app/components/common/mobile-search-toggle';
 import { SearchBox } from '@/app/components/common/search-box';
 import { TagFilterDropdown } from '@/app/components/common/tag-filter-dropdown';
 import { ViewModeToggle } from '@/app/components/common/view-mode-toggle';
@@ -157,6 +158,7 @@ export default async function Home({ searchParams }: PageProps) {
               initialSourceIds={initialSourceIds}
               initialIsAuthenticated={!!session?.user}
             />
+            <MobileSearchToggle />
             <div className="hidden lg:block">
               <SearchBox />
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -198,7 +198,8 @@ export default async function Home({ searchParams }: PageProps) {
             <FilterSidebarOverlay />
 
             {/* Article list - 常にフルワイド */}
-            <main className="flex h-full flex-col">
+            {/* RootLayout が <main> を持つため section にする（ランドマーク重複の解消） */}
+            <section aria-label="記事一覧" className="flex h-full flex-col">
               <Suspense
                 fallback={
                   <LoadingSpinner message="記事を読み込んでいます..." />
@@ -215,7 +216,7 @@ export default async function Home({ searchParams }: PageProps) {
                   excludeSources={ARXIV_SOURCE_ID}
                 />
               </Suspense>
-            </main>
+            </section>
           </div>
         </div>
       </div>

--- a/app/papers/page.tsx
+++ b/app/papers/page.tsx
@@ -58,7 +58,7 @@ export default async function PapersPage({ searchParams }: PageProps) {
                 </div>
               </div>
 
-              <div className="ml-4 flex flex-wrap items-center gap-2">
+              <div className="flex w-full basis-full flex-wrap items-center gap-2 lg:ml-4 lg:w-auto lg:basis-auto">
                 <MobileSearchToggle />
                 <div className="hidden lg:block">
                   <SearchBox />

--- a/app/papers/page.tsx
+++ b/app/papers/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import { cookies } from 'next/headers';
 import { FileText } from 'lucide-react';
+import { MobileSearchToggle } from '@/app/components/common/mobile-search-toggle';
 import { SearchBox } from '@/app/components/common/search-box';
 import { ViewModeToggle } from '@/app/components/common/view-mode-toggle';
 import { SortButtons } from '@/app/components/common/sort-buttons';
@@ -55,7 +56,8 @@ export default async function PapersPage({ searchParams }: PageProps) {
                 </div>
               </div>
 
-              <div className="ml-4 flex items-center gap-2">
+              <div className="ml-4 flex flex-wrap items-center gap-2">
+                <MobileSearchToggle />
                 <div className="hidden lg:block">
                   <SearchBox />
                 </div>

--- a/app/papers/page.tsx
+++ b/app/papers/page.tsx
@@ -49,7 +49,8 @@ export default async function PapersPage({ searchParams }: PageProps) {
         <section aria-label="論文一覧" className="flex-1 lg:flex lg:flex-col">
           {/* ツールバー */}
           <div className="flex-shrink-0 border-b border-[var(--tt-color-border)] bg-[var(--tt-color-surface-muted)] px-4 py-2 lg:px-6">
-            <div className="flex items-center justify-between">
+            {/* 検索パネル展開時に全幅の行として折り返せるよう flex-wrap にする */}
+            <div className="flex flex-wrap items-center justify-between gap-y-2">
               <div className="flex flex-shrink-0 items-center gap-2">
                 <div className="flex items-center gap-2 text-[var(--tt-color-info)]">
                   <FileText className="h-5 w-5" />

--- a/app/papers/page.tsx
+++ b/app/papers/page.tsx
@@ -45,7 +45,8 @@ export default async function PapersPage({ searchParams }: PageProps) {
       {/* メインエリア - サイドバーなし */}
       <div className="flex-1 lg:flex lg:overflow-hidden">
         {/* コンテンツエリア */}
-        <main className="flex-1 lg:flex lg:flex-col">
+        {/* RootLayout が <main> を持つため section にする（ランドマーク重複の解消） */}
+        <section aria-label="論文一覧" className="flex-1 lg:flex lg:flex-col">
           {/* ツールバー */}
           <div className="flex-shrink-0 border-b border-[var(--tt-color-border)] bg-[var(--tt-color-surface-muted)] px-4 py-2 lg:px-6">
             <div className="flex items-center justify-between">
@@ -80,7 +81,7 @@ export default async function PapersPage({ searchParams }: PageProps) {
               initialSortBy={initialSortBy}
             />
           </Suspense>
-        </main>
+        </section>
       </div>
     </div>
   );

--- a/app/reader/article-detail.tsx
+++ b/app/reader/article-detail.tsx
@@ -22,9 +22,64 @@ interface ArticleDetailProps {
   hasNext?: boolean;
   onPrev?: () => void;
   onNext?: () => void;
+  /** モバイル専用: リスト表示へ戻る（sticky bar の「← 記事リスト」） */
+  onBack?: () => void;
 }
 
 const MAX_VISIBLE_TAGS = 5;
+
+/** モバイル専用 sticky header: 「← 記事リスト」+ Prev/Next */
+function MobileDetailBar({
+  hasPrev,
+  hasNext,
+  onPrev,
+  onNext,
+  onBack,
+}: Pick<
+  ArticleDetailProps,
+  'hasPrev' | 'hasNext' | 'onPrev' | 'onNext' | 'onBack'
+>) {
+  return (
+    <div
+      className="flex shrink-0 items-center justify-between gap-2 border-b border-[var(--tt-color-border)] bg-[var(--tt-color-surface)] px-3 py-2 md:hidden"
+      data-testid="reader-mobile-detail-bar"
+    >
+      <button
+        type="button"
+        onClick={() => onBack?.()}
+        className="inline-flex cursor-pointer items-center gap-1 rounded-full px-2 py-1.5 text-sm font-medium text-[var(--tt-color-text)] transition-colors duration-150 hover:bg-[var(--tt-color-surface-hover)] motion-reduce:transition-none"
+        data-testid="reader-back-to-list"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        記事リスト
+      </button>
+      {(hasPrev || hasNext) && (
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => onPrev?.()}
+            disabled={!hasPrev}
+            aria-label="前の記事"
+            className="inline-flex cursor-pointer items-center justify-center rounded-full p-1.5 text-[var(--tt-color-text)] transition-colors duration-150 hover:bg-[var(--tt-color-surface-hover)] disabled:cursor-default disabled:opacity-30 motion-reduce:transition-none"
+            data-testid="reader-mobile-prev"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onNext?.()}
+            disabled={!hasNext}
+            aria-label="次の記事"
+            className="inline-flex cursor-pointer items-center justify-center rounded-full p-1.5 text-[var(--tt-color-text)] transition-colors duration-150 hover:bg-[var(--tt-color-surface-hover)] disabled:cursor-default disabled:opacity-30 motion-reduce:transition-none"
+            data-testid="reader-mobile-next"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function ReaderArticleDetail({
   article,
@@ -34,22 +89,29 @@ export function ReaderArticleDetail({
   hasNext,
   onPrev,
   onNext,
+  onBack,
 }: ArticleDetailProps) {
   if (error) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
-        <AlertCircle className="h-8 w-8 text-[var(--tt-color-negative)]" />
-        <p className="text-sm text-[var(--tt-color-text-muted)]">{error}</p>
+      <div className="flex h-full flex-col overflow-hidden">
+        <MobileDetailBar onBack={onBack} />
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 overflow-y-auto text-center">
+          <AlertCircle className="h-8 w-8 text-[var(--tt-color-negative)]" />
+          <p className="text-sm text-[var(--tt-color-text-muted)]">{error}</p>
+        </div>
       </div>
     );
   }
 
   if (!article && !isLoading) {
     return (
-      <div className="flex h-full items-center justify-center text-[var(--tt-color-text-muted)]">
-        <div className="text-center">
-          <Newspaper className="mx-auto mb-3 h-12 w-12 opacity-40" />
-          <p className="text-sm">記事を選択してください</p>
+      <div className="flex h-full flex-col overflow-hidden">
+        <MobileDetailBar onBack={onBack} />
+        <div className="flex flex-1 items-center justify-center overflow-y-auto text-[var(--tt-color-text-muted)]">
+          <div className="text-center">
+            <Newspaper className="mx-auto mb-3 h-12 w-12 opacity-40" />
+            <p className="text-sm">記事を選択してください</p>
+          </div>
         </div>
       </div>
     );
@@ -57,8 +119,11 @@ export function ReaderArticleDetail({
 
   if (isLoading) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <Loader2 className="h-6 w-6 animate-spin text-[var(--tt-color-positive)] motion-reduce:animate-none" />
+      <div className="flex h-full flex-col overflow-hidden">
+        <MobileDetailBar onBack={onBack} />
+        <div className="flex flex-1 items-center justify-center overflow-y-auto">
+          <Loader2 className="h-6 w-6 animate-spin text-[var(--tt-color-positive)] motion-reduce:animate-none" />
+        </div>
       </div>
     );
   }
@@ -87,126 +152,136 @@ export function ReaderArticleDetail({
   const dateStr = formatDate(article.publishedAt);
 
   return (
-    <div className="h-full overflow-y-auto bg-[var(--tt-color-surface)]">
-      <div className="w-full px-5 py-8">
-        {/* Prev / Next navigation */}
-        {(hasPrev || hasNext) && (
-          <div className="mb-4 flex items-center justify-between">
-            <button
-              type="button"
-              onClick={() => onPrev?.()}
-              disabled={!hasPrev}
-              className="inline-flex cursor-pointer items-center gap-1 rounded-full bg-[var(--tt-color-surface-hover)] px-4 py-2 text-sm font-medium text-[var(--tt-color-text)] transition-colors duration-150 hover:bg-[var(--tt-color-surface-hover)] hover:text-[var(--tt-color-text)] disabled:cursor-default disabled:opacity-30 motion-reduce:transition-none"
-            >
-              <ChevronLeft className="h-4 w-4" />
-              前の記事
-            </button>
-            <button
-              type="button"
-              onClick={() => onNext?.()}
-              disabled={!hasNext}
-              className="inline-flex cursor-pointer items-center gap-1 rounded-full bg-[var(--tt-color-surface-hover)] px-4 py-2 text-sm font-medium text-[var(--tt-color-text)] transition-colors duration-150 hover:bg-[var(--tt-color-surface-hover)] hover:text-[var(--tt-color-text)] disabled:cursor-default disabled:opacity-30 motion-reduce:transition-none"
-            >
-              次の記事
-              <ChevronRight className="h-4 w-4" />
-            </button>
-          </div>
-        )}
-
-        {/* Card */}
-        <div className="rounded-2xl bg-[var(--tt-color-surface)] px-10 py-8 shadow-sm ring-1 ring-[var(--tt-color-border)]">
-          {/* Meta: source badge + date */}
-          <div className="flex items-center gap-3">
-            {article.source?.name && (
-              <span className="rounded-full bg-[var(--tt-color-positive-bg)] px-3 py-0.5 text-xs font-bold tracking-wide text-[var(--tt-color-positive)] uppercase">
-                {article.source.name}
-              </span>
-            )}
-            {dateStr && (
-              <span className="rounded-full border border-[var(--tt-color-border)] px-3 py-0.5 text-xs text-[var(--tt-color-text-muted)]">
-                {dateStr}
-              </span>
-            )}
-            <FavoriteButton
-              articleId={article.id}
-              showText
-              fetchInitialStatus
-              outline
-              size="sm"
-              className="ml-auto rounded-full border border-[var(--tt-color-border)] px-3 py-1 text-xs font-medium text-[var(--tt-color-text-muted)] shadow-none"
-            />
-            {safeUrl && (
-              <a
-                href={safeUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 rounded-full border border-[var(--tt-color-border)] px-3 py-1 text-xs font-medium text-[var(--tt-color-text-muted)] transition-colors duration-150 hover:bg-[var(--tt-color-surface-muted)] motion-reduce:transition-none"
+    <div className="flex h-full flex-col overflow-hidden bg-[var(--tt-color-surface)]">
+      <MobileDetailBar
+        hasPrev={hasPrev}
+        hasNext={hasNext}
+        onPrev={onPrev}
+        onNext={onNext}
+        onBack={onBack}
+      />
+      <div className="flex-1 overflow-y-auto">
+        <div className="w-full px-5 py-8">
+          {/* Prev / Next navigation (デスクトップのみ。モバイルはsticky headerに集約) */}
+          {(hasPrev || hasNext) && (
+            <div className="mb-4 hidden items-center justify-between md:flex">
+              <button
+                type="button"
+                onClick={() => onPrev?.()}
+                disabled={!hasPrev}
+                className="inline-flex cursor-pointer items-center gap-1 rounded-full bg-[var(--tt-color-surface-hover)] px-4 py-2 text-sm font-medium text-[var(--tt-color-text)] transition-colors duration-150 hover:bg-[var(--tt-color-surface-hover)] hover:text-[var(--tt-color-text)] disabled:cursor-default disabled:opacity-30 motion-reduce:transition-none"
               >
-                <ExternalLink className="h-3 w-3" />
-                元記事を読む
-              </a>
-            )}
-          </div>
-
-          {/* Title */}
-          <h1
-            className="mt-5 text-2xl leading-tight font-bold tracking-tight text-[var(--tt-color-text)]"
-            aria-live="polite"
-          >
-            {displayTitle}
-          </h1>
-
-          {/* Tags */}
-          {article.tags && article.tags.length > 0 && (
-            <div className="mt-3 flex flex-wrap gap-1.5">
-              {article.tags.slice(0, MAX_VISIBLE_TAGS).map((tag) => (
-                <span
-                  key={tag.id}
-                  className="rounded-full bg-[var(--tt-color-surface-muted)] px-2 py-0.5 text-[11px] text-[var(--tt-color-text-muted)]"
-                >
-                  #{tag.name}
-                </span>
-              ))}
+                <ChevronLeft className="h-4 w-4" />
+                前の記事
+              </button>
+              <button
+                type="button"
+                onClick={() => onNext?.()}
+                disabled={!hasNext}
+                className="inline-flex cursor-pointer items-center gap-1 rounded-full bg-[var(--tt-color-surface-hover)] px-4 py-2 text-sm font-medium text-[var(--tt-color-text)] transition-colors duration-150 hover:bg-[var(--tt-color-surface-hover)] hover:text-[var(--tt-color-text)] disabled:cursor-default disabled:opacity-30 motion-reduce:transition-none"
+              >
+                次の記事
+                <ChevronRight className="h-4 w-4" />
+              </button>
             </div>
           )}
 
-          {/* Divider */}
-          <hr className="mt-5 border-[var(--tt-color-border)]" />
-
-          {/* Summary */}
-          {article.summary && (
-            <p className="mt-6 text-[15px] leading-[1.9] text-[var(--tt-color-text)]">
-              {article.summary}
-            </p>
-          )}
-
-          {/* Detailed sections */}
-          {sections.length > 0 && (
-            <div className="mt-8 space-y-5">
-              {sections.map((section, i) => (
-                <div
-                  key={`section-${section.title ?? ''}-${i}`}
-                  className="border-l-[3px] border-[var(--tt-color-positive-border)] py-1 pl-5"
+          {/* Card */}
+          <div className="rounded-2xl bg-[var(--tt-color-surface)] px-4 py-6 shadow-sm ring-1 ring-[var(--tt-color-border)] sm:px-10 sm:py-8">
+            {/* Meta: source badge + date
+                375px では 4 要素が 1 行に収まらずお気に入りが画面外に出ていたため折り返す */}
+            <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+              {article.source?.name && (
+                <span className="rounded-full bg-[var(--tt-color-positive-bg)] px-3 py-0.5 text-xs font-bold tracking-wide text-[var(--tt-color-positive)] uppercase">
+                  {article.source.name}
+                </span>
+              )}
+              {dateStr && (
+                <span className="rounded-full border border-[var(--tt-color-border)] px-3 py-0.5 text-xs text-[var(--tt-color-text-muted)]">
+                  {dateStr}
+                </span>
+              )}
+              <FavoriteButton
+                articleId={article.id}
+                showText
+                fetchInitialStatus
+                outline
+                size="sm"
+                className="rounded-full border border-[var(--tt-color-border)] px-3 py-1 text-xs font-medium text-[var(--tt-color-text-muted)] shadow-none sm:ml-auto"
+              />
+              {safeUrl && (
+                <a
+                  href={safeUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 rounded-full border border-[var(--tt-color-border)] px-3 py-1 text-xs font-medium text-[var(--tt-color-text-muted)] transition-colors duration-150 hover:bg-[var(--tt-color-surface-muted)] motion-reduce:transition-none"
                 >
-                  <div className="flex items-start gap-2">
-                    <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[var(--tt-color-positive)]" />
-                    <p className="text-sm font-semibold text-[var(--tt-color-text)]">
-                      {section.title}
+                  <ExternalLink className="h-3 w-3" />
+                  元記事を読む
+                </a>
+              )}
+            </div>
+
+            {/* Title */}
+            <h1
+              className="mt-5 text-2xl leading-tight font-bold tracking-tight text-[var(--tt-color-text)]"
+              aria-live="polite"
+            >
+              {displayTitle}
+            </h1>
+
+            {/* Tags */}
+            {article.tags && article.tags.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {article.tags.slice(0, MAX_VISIBLE_TAGS).map((tag) => (
+                  <span
+                    key={tag.id}
+                    className="rounded-full bg-[var(--tt-color-surface-muted)] px-2 py-0.5 text-[11px] text-[var(--tt-color-text-muted)]"
+                  >
+                    #{tag.name}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Divider */}
+            <hr className="mt-5 border-[var(--tt-color-border)]" />
+
+            {/* Summary */}
+            {article.summary && (
+              <p className="mt-6 text-[15px] leading-[1.9] text-[var(--tt-color-text)]">
+                {article.summary}
+              </p>
+            )}
+
+            {/* Detailed sections */}
+            {sections.length > 0 && (
+              <div className="mt-8 space-y-5">
+                {sections.map((section, i) => (
+                  <div
+                    key={`section-${section.title ?? ''}-${i}`}
+                    className="border-l-[3px] border-[var(--tt-color-positive-border)] py-1 pl-5"
+                  >
+                    <div className="flex items-start gap-2">
+                      <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[var(--tt-color-positive)]" />
+                      <p className="text-sm font-semibold text-[var(--tt-color-text)]">
+                        {section.title}
+                      </p>
+                    </div>
+                    <p className="mt-2 pl-6 text-sm leading-[1.8] text-[var(--tt-color-text)]">
+                      {section.content}
                     </p>
                   </div>
-                  <p className="mt-2 pl-6 text-sm leading-[1.8] text-[var(--tt-color-text)]">
-                    {section.content}
-                  </p>
-                </div>
-              ))}
-            </div>
-          )}
+                ))}
+              </div>
+            )}
 
-          {!article.summary && sections.length === 0 && (
-            <p className="mt-6 text-sm text-[var(--tt-color-text-muted)] italic">
-              要約はありません
-            </p>
-          )}
+            {!article.summary && sections.length === 0 && (
+              <p className="mt-6 text-sm text-[var(--tt-color-text-muted)] italic">
+                要約はありません
+              </p>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/app/reader/reader-client.tsx
+++ b/app/reader/reader-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 import {
   useInfiniteQuery,
@@ -13,6 +13,8 @@ import { MobileSearchToggle } from '@/app/components/common/mobile-search-toggle
 import { SearchBox } from '@/app/components/common/search-box';
 import { TagFilterDropdown } from '@/app/components/common/tag-filter-dropdown';
 import { SortButtons } from '@/app/components/common/sort-buttons';
+import { useMediaQuery } from '@/app/hooks/use-media-query';
+import { cn } from '@/lib/utils';
 import { ReaderArticleList } from './article-list';
 import { ReaderArticleDetail } from './article-detail';
 import type {
@@ -20,6 +22,9 @@ import type {
   ArticleListResponse,
   ArticleDetailResponse,
 } from './types';
+
+/** md: Tailwindブレークポイント (768px) と揃える */
+const DESKTOP_MEDIA_QUERY = '(min-width: 768px)';
 
 const READER_ARTICLES_PER_PAGE = 20;
 
@@ -108,8 +113,13 @@ export function ReaderClient({ tags }: ReaderClientProps) {
     return params;
   }, [searchParams]);
 
-  // key forces remount (and selectedId reset) when filters change
-  const filterKey = searchParams.toString();
+  // key forces remount (and selectedId reset) when filters change.
+  // `article` は含めない（記事選択のたびに Inner が再マウントされ、選択状態や
+  // 読み込み済みページが失われてしまうため。filterParams から再構成する）。
+  const filterKey = useMemo(
+    () => new URLSearchParams(filterParams).toString(),
+    [filterParams]
+  );
 
   return (
     <ReaderClientInner
@@ -127,7 +137,53 @@ function ReaderClientInner({
   tags: ReaderClientProps['tags'];
   filterParams: Record<string, string>;
 }) {
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+  const articleParam = searchParams.get('article');
+
+  // md未満はモバイル。SSR時はfalse（初期レンダーはリスト表示側に倒れる）。
+  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY);
+  const isDesktopRef = useRef(isDesktop);
+  useEffect(() => {
+    isDesktopRef.current = isDesktop;
+  }, [isDesktop]);
+
+  // 選択中記事をURLの `article` パラメータへ native History API で反映する。
+  // router.push/replace を使わないのは、/reader が force-dynamic のため
+  // Next Router 経由の遷移は毎回サーバー(sources/tags/session取得)への
+  // RSCリクエストを発生させてしまうから。
+  const selectArticle = useCallback(
+    (id: string, opts?: { replace?: boolean }) => {
+      if (typeof window === 'undefined') return;
+      const replace = opts?.replace ?? isDesktopRef.current;
+      const params = new URLSearchParams(window.location.search);
+      params.set('article', id);
+      const url = `${window.location.pathname}?${params.toString()}`;
+      // data引数には null を渡す（history.state をそのまま渡すと Next.js の
+      // 内部フラグ __NA が付いた状態になり、パッチされた pushState/replaceState が
+      // 「Next.js内部からの呼び出し」と誤認して useSearchParams への同期処理を
+      // スキップしてしまうため。null なら Next.js が現在の内部treeを自動でコピーする）
+      if (replace) {
+        window.history.replaceState(null, '', url);
+      } else {
+        window.history.pushState(null, '', url);
+      }
+    },
+    []
+  );
+
+  // モバイルの「← 記事リスト」: articleパラメータを外してリスト表示に戻す。
+  // history.back() だとdeep link直遷移時に戻り先が存在せずアプリ外に出て
+  // しまうことがあるため、常にpushStateでarticleを外す方式にしている。
+  const backToList = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    params.delete('article');
+    const qs = params.toString();
+    const url = qs
+      ? `${window.location.pathname}?${qs}`
+      : window.location.pathname;
+    window.history.pushState(null, '', url);
+  }, []);
 
   // Infinite query for article list
   const {
@@ -155,8 +211,9 @@ function ReaderClientInner({
     [listData]
   );
 
-  // Auto-select first article
-  const effectiveSelectedId = selectedId ?? articles[0]?.id ?? null;
+  // Auto-select first article (articleParam未指定時のデフォルト表示用。
+  // URLは更新しない＝モバイルのペイン切り替えはarticleParamの有無のみで判定する)
+  const effectiveSelectedId = articleParam ?? articles[0]?.id ?? null;
 
   // Detail query (keep previous article visible while loading next)
   const {
@@ -177,9 +234,15 @@ function ReaderClientInner({
   const currentIndex = effectiveSelectedId
     ? articles.findIndex((a: ReaderListArticle) => a.id === effectiveSelectedId)
     : -1;
+  const isSelectedLoaded = currentIndex >= 0;
   const hasPrev = currentIndex > 0;
+  // hasNext: 読み込み済みリスト内に次の記事があるか（handleNext/keyboardの分岐に使用）
   const hasNext = currentIndex >= 0 && currentIndex < articles.length - 1;
+  // canGoNextUi: Nextボタンの有効/無効（UI表示用）。
+  // 未ロード記事へのdeep link時（currentIndex === -1）はhasNextPageに関わらず無効化する
+  const canGoNextUi = isSelectedLoaded && (hasNext || !!hasNextPage);
 
+  // 次ページ取得後の続き選択。Prev/Nextやキーボード連続操作の延長のため常にreplace。
   const fetchNextAndSelect = useCallback(
     (idx: number) => {
       if (!hasNextPage || isFetchingNextPage) return;
@@ -189,7 +252,7 @@ function ReaderClientInner({
             const newArticles = result.data.pages.flatMap((p) => p.data.items);
             const nextArticle = newArticles[idx + 1];
             if (nextArticle) {
-              setSelectedId(nextArticle.id);
+              selectArticle(nextArticle.id, { replace: true });
             }
           }
         })
@@ -197,20 +260,21 @@ function ReaderClientInner({
           // Error handled by useInfiniteQuery's error state
         });
     },
-    [hasNextPage, isFetchingNextPage, fetchNextPage]
+    [hasNextPage, isFetchingNextPage, fetchNextPage, selectArticle]
   );
 
   const handlePrev = useCallback(() => {
-    if (hasPrev) setSelectedId(articles[currentIndex - 1].id);
-  }, [hasPrev, articles, currentIndex]);
+    if (hasPrev)
+      selectArticle(articles[currentIndex - 1].id, { replace: true });
+  }, [hasPrev, articles, currentIndex, selectArticle]);
 
   const handleNext = useCallback(() => {
     if (hasNext) {
-      setSelectedId(articles[currentIndex + 1].id);
+      selectArticle(articles[currentIndex + 1].id, { replace: true });
     } else {
       fetchNextAndSelect(currentIndex);
     }
-  }, [hasNext, articles, currentIndex, fetchNextAndSelect]);
+  }, [hasNext, articles, currentIndex, fetchNextAndSelect, selectArticle]);
 
   const handleLoadMore = useCallback(() => {
     fetchNextPage().catch(() => {
@@ -218,11 +282,16 @@ function ReaderClientInner({
     });
   }, [fetchNextPage]);
 
-  const handleSelectArticle = useCallback((articleId: string) => {
-    setSelectedId(articleId);
-  }, []);
+  // リストからの選択: モバイルはpush（ブラウザバックでリストへ戻れる）、
+  // デスクトップはreplace（履歴を汚さない）
+  const handleSelectArticle = useCallback(
+    (articleId: string) => {
+      selectArticle(articleId);
+    },
+    [selectArticle]
+  );
 
-  // Keyboard navigation
+  // Keyboard navigation（ArrowUp/Down連続操作もPrev/Next同様に常にreplace）
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (!effectiveSelectedId || articles.length === 0) return;
@@ -232,16 +301,16 @@ function ReaderClientInner({
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         if (idx < articles.length - 1) {
-          setSelectedId(articles[idx + 1].id);
+          selectArticle(articles[idx + 1].id, { replace: true });
         } else {
           fetchNextAndSelect(idx);
         }
       } else if (e.key === 'ArrowUp' && idx > 0) {
         e.preventDefault();
-        setSelectedId(articles[idx - 1].id);
+        selectArticle(articles[idx - 1].id, { replace: true });
       }
     },
-    [effectiveSelectedId, articles, fetchNextAndSelect]
+    [effectiveSelectedId, articles, fetchNextAndSelect, selectArticle]
   );
 
   return (
@@ -256,11 +325,14 @@ function ReaderClientInner({
         <TagFilterDropdown tags={tags} />
         <SortButtons />
       </div>
-      {/* Two-panel layout */}
+      {/* Two-panel layout: md未満は article パラメータの有無で1ペイン切替、md以上は常に2ペイン */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left panel: Article list */}
         <div
-          className="w-[380px] shrink-0 overflow-y-auto border-r border-[var(--tt-color-border)] bg-[var(--tt-color-surface-muted)]"
+          className={cn(
+            'shrink-0 overflow-y-auto border-r border-[var(--tt-color-border)] bg-[var(--tt-color-surface-muted)] md:w-[320px] lg:w-[380px]',
+            articleParam ? 'hidden md:block' : 'block w-full'
+          )}
           role="region"
           aria-label="記事リスト"
         >
@@ -279,7 +351,10 @@ function ReaderClientInner({
         </div>
         {/* Right panel: Article detail */}
         <div
-          className="flex-1 overflow-y-auto"
+          className={cn(
+            'flex-1 overflow-hidden',
+            articleParam ? 'block' : 'hidden md:block'
+          )}
           role="region"
           aria-label="記事詳細"
         >
@@ -288,9 +363,10 @@ function ReaderClientInner({
             isLoading={!detailData && isFetchingDetail}
             error={detailError instanceof Error ? detailError.message : null}
             hasPrev={hasPrev}
-            hasNext={hasNext || !!hasNextPage}
+            hasNext={canGoNextUi}
             onPrev={handlePrev}
             onNext={handleNext}
+            onBack={backToList}
           />
         </div>
       </div>

--- a/app/reader/reader-client.tsx
+++ b/app/reader/reader-client.tsx
@@ -98,6 +98,7 @@ export function ReaderClient({ tags }: ReaderClientProps) {
     const dateFrom = searchParams.get('dateFrom');
     const dateTo = searchParams.get('dateTo');
     const dateRange = searchParams.get('dateRange');
+    const category = searchParams.get('category');
 
     if (sortBy) params.sortBy = sortBy;
     if (sortOrder) params.sortOrder = sortOrder;
@@ -109,6 +110,9 @@ export function ReaderClient({ tags }: ReaderClientProps) {
     if (dateFrom) params.dateFrom = dateFrom;
     if (dateTo) params.dateTo = dateTo;
     if (dateRange) params.dateRange = dateRange;
+    // category を拾わないと、フィルタパネルでカテゴリを選んでも URL だけ変わって
+    // 一覧が変化しない（API 側は category を受け付ける）
+    if (category) params.category = category;
 
     return params;
   }, [searchParams]);

--- a/app/reader/reader-client.tsx
+++ b/app/reader/reader-client.tsx
@@ -9,6 +9,7 @@ import {
 } from '@tanstack/react-query';
 import { ARXIV_SOURCE_ID } from '@/lib/constants/source-categories';
 import { FilterSidebarToggle } from '@/app/components/home/filter-sidebar';
+import { MobileSearchToggle } from '@/app/components/common/mobile-search-toggle';
 import { SearchBox } from '@/app/components/common/search-box';
 import { TagFilterDropdown } from '@/app/components/common/tag-filter-dropdown';
 import { SortButtons } from '@/app/components/common/sort-buttons';
@@ -248,7 +249,10 @@ function ReaderClientInner({
       {/* Toolbar */}
       <div className="flex flex-shrink-0 flex-wrap items-center gap-2 border-b border-[var(--tt-color-border)] px-4 py-2">
         <FilterSidebarToggle />
-        <SearchBox />
+        <MobileSearchToggle />
+        <div className="hidden lg:block">
+          <SearchBox />
+        </div>
         <TagFilterDropdown tags={tags} />
         <SortButtons />
       </div>

--- a/app/sources/[id]/page.tsx
+++ b/app/sources/[id]/page.tsx
@@ -242,7 +242,12 @@ export default async function SourceDetailPage({
                 </Card>
               ) : (
                 recentArticles.map((article) => (
-                  <ArticleCard key={article.id} article={article} />
+                  <ArticleCard
+                    key={article.id}
+                    article={article}
+                    // Server Component からは状態を渡せないためカード側で取得する
+                    fetchInitialStatus
+                  />
                 ))
               )}
             </div>
@@ -262,7 +267,7 @@ export default async function SourceDetailPage({
                       {index + 1}
                     </div>
                     <div className="flex-1">
-                      <ArticleCard article={article} />
+                      <ArticleCard article={article} fetchInitialStatus />
                     </div>
                   </div>
                 ))}

--- a/app/trends/diff/_components/diff-sections.tsx
+++ b/app/trends/diff/_components/diff-sections.tsx
@@ -34,15 +34,17 @@ export function DiffMainContent({
   onHoverLeave,
 }: DiffMainContentProps) {
   return (
-    <main className="container mx-auto max-w-6xl space-y-8 px-4 py-6">
-      {/* Stats Bar */}
-      <div className="bg-background flex items-center justify-center gap-6 rounded-lg border px-4 py-3 shadow-sm">
+    // RootLayout（app/layout.tsx）が既に <main> を持つため、ここは div。
+    // ページに <main> が 2 つあるとランドマークナビゲーションが破綻する
+    <div className="container mx-auto max-w-6xl space-y-8 px-4 py-6">
+      {/* Stats Bar: モバイルは 2 列グリッド（横一列だと 375px で溢れて「下火」が切れる） */}
+      <div className="bg-background grid grid-cols-2 gap-3 rounded-lg border px-4 py-3 shadow-sm sm:flex sm:items-center sm:justify-center sm:gap-6">
         <div className="flex items-center gap-2">
           <Sparkles className="h-4 w-4 text-[var(--tt-color-warning)]" />
           <span className="text-sm font-semibold">{grouped.new.length}</span>
           <span className="text-muted-foreground text-xs">新規</span>
         </div>
-        <div className="bg-border h-4 w-px" />
+        <div className="bg-border hidden h-4 w-px sm:block" />
         <div className="flex items-center gap-2">
           <TrendingUp className="h-4 w-4 text-[var(--tt-color-info)]" />
           <span className="text-sm font-semibold">
@@ -50,7 +52,7 @@ export function DiffMainContent({
           </span>
           <span className="text-muted-foreground text-xs">急上昇</span>
         </div>
-        <div className="bg-border h-4 w-px" />
+        <div className="bg-border hidden h-4 w-px sm:block" />
         <div className="flex items-center gap-2">
           <Minus className="h-4 w-4 text-[var(--tt-color-text-muted)]" />
           <span className="text-sm font-semibold">
@@ -58,7 +60,7 @@ export function DiffMainContent({
           </span>
           <span className="text-muted-foreground text-xs">継続</span>
         </div>
-        <div className="bg-border h-4 w-px" />
+        <div className="bg-border hidden h-4 w-px sm:block" />
         <div className="flex items-center gap-2">
           <TrendingDown className="h-4 w-4 text-[var(--tt-color-text-muted)]" />
           <span className="text-sm font-semibold">
@@ -179,6 +181,6 @@ export function DiffMainContent({
           </div>
         </section>
       )}
-    </main>
+    </div>
   );
 }

--- a/app/trends/diff/_components/topic-card.tsx
+++ b/app/trends/diff/_components/topic-card.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useMemo } from 'react';
+import { useId, useMemo, useState } from 'react';
 import { Sparkles, Zap, ArrowUpRight, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ArticleInfo, ChangeWithCategory } from './diff-utils';
@@ -34,6 +34,11 @@ export function HotTopicChip({
     [articles, change.relatedArticleIds]
   );
   const isHovered = hoveredTopic === topicKey;
+  // hover だけが展開手段だと、キーボード利用者とタッチ端末から関連記事に到達できない。
+  // 明示的な開閉ボタンを併設し、hover はマウス利用者向けの補助として残す。
+  const [isExpanded, setIsExpanded] = useState(false);
+  const relatedPanelId = useId();
+  const showRelated = (isHovered || isExpanded) && relatedArticles.length > 0;
 
   return (
     <div
@@ -88,9 +93,24 @@ export function HotTopicChip({
           {change.description}
         </p>
 
-        {/* Related articles on hover */}
-        {isHovered && relatedArticles.length > 0 && (
-          <div className="animate-in fade-in mt-2 space-y-1 border-t border-current/10 pt-2 duration-150">
+        {/* Related articles: hover か開閉ボタンで展開 */}
+        {relatedArticles.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            aria-expanded={showRelated}
+            aria-controls={relatedPanelId}
+            data-testid="topic-related-toggle"
+            className="text-muted-foreground hover:text-foreground focus-visible:ring-primary mt-2 inline-flex items-center gap-1 rounded text-xs underline-offset-2 hover:underline focus-visible:ring-2 focus-visible:outline-none"
+          >
+            関連記事 {relatedArticles.length} 件
+          </button>
+        )}
+        {showRelated && (
+          <div
+            id={relatedPanelId}
+            className="animate-in fade-in mt-2 space-y-1 border-t border-current/10 pt-2 duration-150"
+          >
             {relatedArticles.map((article) => (
               <Link
                 key={article.id}
@@ -109,7 +129,8 @@ export function HotTopicChip({
       <Link
         href={`/?tags=${encodeURIComponent(change.topic)}&tagMode=OR`}
         className={cn(
-          'absolute top-2 right-2 rounded p-1 opacity-0 transition-opacity group-hover:opacity-100',
+          // focus-visible を足さないとキーボード到達時に不可視のままになる
+          'absolute top-2 right-2 rounded p-1 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100',
           isNew
             ? 'text-[var(--tt-color-warning)] hover:bg-[var(--tt-color-warning-bg)]'
             : 'text-[var(--tt-color-info)] hover:bg-[var(--tt-color-info-bg)]'

--- a/app/trends/diff/_components/topic-card.tsx
+++ b/app/trends/diff/_components/topic-card.tsx
@@ -37,8 +37,14 @@ export function HotTopicChip({
   // hover だけが展開手段だと、キーボード利用者とタッチ端末から関連記事に到達できない。
   // 明示的な開閉ボタンを併設し、hover はマウス利用者向けの補助として残す。
   const [isExpanded, setIsExpanded] = useState(false);
+  // hover で開いたパネルをボタンで閉じられるようにする。ポインタが乗っている間は
+  // isHovered が true のままなので、この「今回の hover では閉じた」フラグがないと
+  // ボタンを押しても閉じられず aria-expanded も true のままになる
+  const [hoverDismissed, setHoverDismissed] = useState(false);
   const relatedPanelId = useId();
-  const showRelated = (isHovered || isExpanded) && relatedArticles.length > 0;
+  const showRelated =
+    relatedArticles.length > 0 &&
+    (isExpanded || (isHovered && !hoverDismissed));
 
   return (
     <div
@@ -50,7 +56,10 @@ export function HotTopicChip({
           : 'border-l-4 border-l-[var(--tt-color-info)] hover:border-[var(--tt-color-info-border)]',
         'hover:-translate-y-0.5 hover:shadow-md'
       )}
-      onMouseEnter={() => onMouseEnter(topicKey)}
+      onMouseEnter={() => {
+        setHoverDismissed(false);
+        onMouseEnter(topicKey);
+      }}
       onMouseLeave={onMouseLeave}
     >
       <div className="p-4">
@@ -97,7 +106,15 @@ export function HotTopicChip({
         {relatedArticles.length > 0 && (
           <button
             type="button"
-            onClick={() => setIsExpanded((prev) => !prev)}
+            onClick={() => {
+              if (showRelated) {
+                setIsExpanded(false);
+                setHoverDismissed(true);
+                return;
+              }
+              setHoverDismissed(false);
+              setIsExpanded(true);
+            }}
             aria-expanded={showRelated}
             aria-controls={relatedPanelId}
             data-testid="topic-related-toggle"

--- a/app/trends/diff/_components/topic-card.tsx
+++ b/app/trends/diff/_components/topic-card.tsx
@@ -128,6 +128,7 @@ export function HotTopicChip({
       {/* Quick action */}
       <Link
         href={`/?tags=${encodeURIComponent(change.topic)}&tagMode=OR`}
+        aria-label={`${change.topic} の記事を一覧で見る`}
         className={cn(
           // focus-visible を足さないとキーボード到達時に不可視のままになる
           'absolute top-2 right-2 rounded p-1 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100',

--- a/components/auth/UserMenu.tsx
+++ b/components/auth/UserMenu.tsx
@@ -27,7 +27,12 @@ import {
   LineChart,
 } from 'lucide-react';
 
-export function UserMenu() {
+interface UserMenuProps {
+  /** true の場合、未認証時は「ログイン」ボタンのみ表示する（モバイルヘッダー等の省スペース用途） */
+  compact?: boolean;
+}
+
+export function UserMenu({ compact = false }: UserMenuProps = {}) {
   const { data: session, isPending } = authClient.useSession();
   const [isSigningOut, setIsSigningOut] = useState(false);
 
@@ -52,6 +57,16 @@ export function UserMenu() {
   }
 
   if (!session) {
+    if (compact) {
+      return (
+        <div className="flex items-center">
+          <Button variant="ghost" asChild>
+            <Link href="/auth/login">ログイン</Link>
+          </Button>
+        </div>
+      );
+    }
+
     return (
       <div className="flex items-center gap-2">
         <Button variant="ghost" asChild>

--- a/components/filters/CategoryFilter.tsx
+++ b/components/filters/CategoryFilter.tsx
@@ -12,6 +12,10 @@ import {
 import { Badge } from '@/components/ui-v2/badge-v2';
 import { Layers, Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import {
+  buildFilterUrl,
+  clearTransientFilterParams,
+} from '@/lib/utils/url/filter-params';
 
 interface Category {
   value: string | null;
@@ -76,12 +80,11 @@ export default function CategoryFilter() {
         params.set('category', value);
       }
 
-      // Reset to page 1 when changing category
-      params.delete('page');
+      // Reset to page 1 when changing category (+ /reader の選択中記事を解除)
+      clearTransientFilterParams(params);
 
       // パスを固定すると /reader でカテゴリを選んだ瞬間にホームへ離脱する
-      const qs = params.toString();
-      router.push(qs ? `${pathname}?${qs}` : pathname);
+      router.push(buildFilterUrl(pathname, params));
     });
   };
 

--- a/components/filters/CategoryFilter.tsx
+++ b/components/filters/CategoryFilter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useTransition, useCallback } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   Select,
   SelectContent,
@@ -26,6 +26,7 @@ interface CategoryStats {
 
 export default function CategoryFilter() {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const [categories, setCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
@@ -78,7 +79,9 @@ export default function CategoryFilter() {
       // Reset to page 1 when changing category
       params.delete('page');
 
-      router.push(`/?${params.toString()}`);
+      // パスを固定すると /reader でカテゴリを選んだ瞬間にホームへ離脱する
+      const qs = params.toString();
+      router.push(qs ? `${pathname}?${qs}` : pathname);
     });
   };
 

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -19,7 +19,7 @@ export function ThemeToggle() {
       <Button
         variant="ghost"
         size="icon"
-        className="h-9 w-9"
+        className="h-11 w-11 lg:h-9 lg:w-9"
         aria-label="テーマ切り替え"
         disabled
         aria-busy="true"
@@ -35,7 +35,7 @@ export function ThemeToggle() {
     <Button
       variant="ghost"
       size="icon"
-      className="h-9 w-9"
+      className="h-11 w-11 lg:h-9 lg:w-9"
       onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
       aria-label={
         theme === 'dark' ? 'ライトモードに切り替え' : 'ダークモードに切り替え'

--- a/components/ui-v2/button-v2.tsx
+++ b/components/ui-v2/button-v2.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Slot } from 'radix-ui';
 import { Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 const PRIMARY_STYLE =
   'bg-(--tt-color-primary) text-(--tt-color-on-primary) hover:bg-(--tt-color-primary-hover) shadow-sm hover:shadow-md';
@@ -105,11 +106,13 @@ function ButtonV2({
   const Comp = asChild ? Slot.Root : 'button';
   const resolvedSize = iconOnly ? (ICON_SIZE_MAP[size!] ?? 'icon') : size;
 
-  const buttonClassName = buttonV2Variants({
-    variant,
-    size: resolvedSize,
-    className,
-  });
+  // cn() = twMerge(clsx()): caller className must win over cva base classes.
+  // Passing className into cva would only concatenate, letting base `inline-flex`
+  // survive a caller's `hidden` (see plan FD-0 / investigate G-2).
+  const buttonClassName = cn(
+    buttonV2Variants({ variant, size: resolvedSize }),
+    className
+  );
 
   const disabledProps = asChild
     ? {
@@ -138,9 +141,7 @@ function ButtonV2({
       'data-disabled': 'true',
       'aria-disabled': true,
       tabIndex: -1,
-      className: [buttonClassName, children.props.className]
-        .filter(Boolean)
-        .join(' '),
+      className: cn(buttonClassName, children.props.className),
       onClick: (e: React.MouseEvent) => {
         e.preventDefault();
         e.stopPropagation();

--- a/lib/hooks/use-personalization-preferences.ts
+++ b/lib/hooks/use-personalization-preferences.ts
@@ -8,6 +8,7 @@
 'use client';
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { authClient } from '@/lib/auth/auth-client';
 import type {
   UserCategoryPreferences,
   UpdateCategoryPreferencesRequest,
@@ -146,9 +147,19 @@ export function useInterestCategories() {
  * Hook for fetching user's category preferences
  */
 export function useUserPreferences(scope: PreferenceScope = 'home') {
+  const { data: session, isPending: isSessionPending } =
+    authClient.useSession();
+
   return useQuery({
     queryKey: PERSONALIZATION_QUERY_KEYS.preferences(scope),
     queryFn: () => fetchPreferences(scope),
+    // 未認証では 401 が確定しているため呼ばない（ゲストのホーム表示で毎回
+    // /api/user/preferences/categories が 401 を返していた）。
+    // セッション判定中も待ってから有効化する。
+    // NOTE: React Query v5 の isLoading は `isPending && isFetching` なので、
+    // enabled: false のとき isLoading は false になる。呼び出し側の
+    // `enabled: !isLoadingPreferences`（home-client-infinite）は止まらない。
+    enabled: !isSessionPending && !!session?.user,
     staleTime: 1000 * 60 * 5, // 5 minutes
     gcTime: 1000 * 60 * 30, // 30 minutes
     retry: false, // fail gracefully for guest users or temporary API issues
@@ -208,9 +219,16 @@ export function useUpdatePreferences(scope: PreferenceScope = 'home') {
  * Combined hook for personalization preferences management
  */
 export function usePersonalizationPreferences(scope: PreferenceScope = 'home') {
+  const { isPending: isSessionPending } = authClient.useSession();
   const categoriesQuery = useInterestCategories();
   const preferencesQuery = useUserPreferences(scope);
   const updateMutation = useUpdatePreferences(scope);
+
+  // セッション判定中は preferences クエリが enabled: false のため isLoading が
+  // false になる。そのまま公開すると認証済みユーザーで記事クエリが先に走り、
+  // 直後に設定が解決して再フェッチ（＝空状態のフラッシュ、Issue #569 の再発）に
+  // なるため、セッション判定中もローディング扱いにする。
+  const isLoadingPreferences = isSessionPending || preferencesQuery.isLoading;
 
   const categories = categoriesQuery.data ?? EMPTY_CATEGORIES;
   const preferences = preferencesQuery.data ?? DEFAULT_PREFERENCES;
@@ -235,8 +253,8 @@ export function usePersonalizationPreferences(scope: PreferenceScope = 'home') {
 
     // Loading states
     isLoadingCategories: categoriesQuery.isLoading,
-    isLoadingPreferences: preferencesQuery.isLoading,
-    isLoading: categoriesQuery.isLoading || preferencesQuery.isLoading,
+    isLoadingPreferences,
+    isLoading: categoriesQuery.isLoading || isLoadingPreferences,
 
     // Error states
     categoriesError: categoriesQuery.error,

--- a/lib/hooks/use-personalization-preferences.ts
+++ b/lib/hooks/use-personalization-preferences.ts
@@ -31,8 +31,10 @@ const DEFAULT_PREFERENCES: UserCategoryPreferences = {
 // =============================================================================
 
 export const PERSONALIZATION_QUERY_KEYS = {
-  preferences: (scope: PreferenceScope = 'home') =>
-    ['personalization-preferences', scope] as const,
+  // userId をキーに含める: 含めないとセッション失効や同一 SPA 内でのユーザー
+  // 切り替え後に、前のユーザーの設定がキャッシュから返ってしまう
+  preferences: (scope: PreferenceScope = 'home', userId?: string | null) =>
+    ['personalization-preferences', scope, userId ?? 'anonymous'] as const,
   categories: ['interest-categories'] as const,
 };
 
@@ -151,7 +153,7 @@ export function useUserPreferences(scope: PreferenceScope = 'home') {
     authClient.useSession();
 
   return useQuery({
-    queryKey: PERSONALIZATION_QUERY_KEYS.preferences(scope),
+    queryKey: PERSONALIZATION_QUERY_KEYS.preferences(scope, session?.user?.id),
     queryFn: () => fetchPreferences(scope),
     // 未認証では 401 が確定しているため呼ばない（ゲストのホーム表示で毎回
     // /api/user/preferences/categories が 401 を返していた）。
@@ -170,6 +172,7 @@ export function useUserPreferences(scope: PreferenceScope = 'home') {
  * Hook for updating user's category preferences
  */
 export function useUpdatePreferences(scope: PreferenceScope = 'home') {
+  const { data: session } = authClient.useSession();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -182,7 +185,7 @@ export function useUpdatePreferences(scope: PreferenceScope = 'home') {
 
       // Update cache after successful mutation
       queryClient.setQueryData<UserCategoryPreferences>(
-        PERSONALIZATION_QUERY_KEYS.preferences(scope),
+        PERSONALIZATION_QUERY_KEYS.preferences(scope, session?.user?.id),
         (old) => ({
           ...old,
           selectedCategories,

--- a/lib/utils/url/filter-params.ts
+++ b/lib/utils/url/filter-params.ts
@@ -1,0 +1,28 @@
+/**
+ * 一覧フィルタの URL 更新で共通して落とすパラメータ。
+ *
+ * - `page`: 条件が変わったら 1 ページ目に戻す
+ * - `article`: /reader の選択中記事。残すとフィルタ結果に存在しない記事の詳細が
+ *   表示されたままになり、モバイルでは一覧へ戻れなくなる（詳細ペインの表示条件が
+ *   `article` の有無のため）
+ *
+ * フィルタ部品ごとに delete を書くと必ず抜けが出るため、この関数を経由させる。
+ */
+export function clearTransientFilterParams(params: URLSearchParams): void {
+  params.delete('page');
+  params.delete('article');
+}
+
+/**
+ * 現在のパスを保ったままクエリ文字列を組み立てる。
+ *
+ * フィルタ部品が遷移先を `/?...` と決め打ちすると、/reader や /papers で
+ * フィルタを操作した瞬間にホームへ離脱する。
+ */
+export function buildFilterUrl(
+  pathname: string,
+  params: URLSearchParams
+): string {
+  const queryString = params.toString();
+  return queryString ? `${pathname}?${queryString}` : pathname;
+}

--- a/types/components.ts
+++ b/types/components.ts
@@ -17,6 +17,12 @@ export interface ArticleCardProps {
   onArticleClick?: (articleId?: string) => void;
   isFavorited?: boolean;
   onToggleFavorite?: () => void;
+  /**
+   * お気に入り状態を各カードが自分で API から取得する（ISR / Server Component の
+   * ページ用）。isFavorited を渡せない画面で未指定のままだと常に「未登録」表示に
+   * なるため、そうした画面ではこれを true にする。
+   */
+  fetchInitialStatus?: boolean;
 }
 
 // 記事リスト


### PR DESCRIPTION
## 概要

- UI/UX 監査（`/investigate`）で確定した「到達できない・操作できない・誤遷移する」バグと a11y 欠陥を一括修正した Phase A
- **モバイルでナビゲーション・検索・リーダーが実質使えなかった状態**を解消（375px でヘッダーが 419px に溢れハンバーガーが画面外、検索窓が消失、`/reader` は本文が画面外）
- 2026-04 の総合監査で起票され、**実装されないまま COMPLETED でクローズされていた** Issue #580 #581 #582 #583 #585 の DoD を満たす
- 見せ方の強化・読了後導線・カード共通化（Phase B〜E）は非スコープ

## 背景

`/investigate` で公開 26 画面を監査し、コード読解 + スクリーンショット 29 枚で以下を確認した（調査レポート: `.workflow/docs/investigate/investigate_20260815_194751_ui_ux_audit.md`）。

| 症状 | 原因 |
|---|---|
| 375px・未ログインでハンバーガーが画面外（実測 `scrollWidth=419`） | ロゴ + テーマ + ログイン/新規登録 + ハンバーガーが `px-6` の 40px 行に収まらない |
| 768〜1023px でナビラベルが縦書き状に折り返す | ヘッダーは `md:`、ツールバーは `lg:` とブレークポイントが不一致 |
| モバイルでキーワード検索に到達不能 | `SearchBox` が `hidden lg:block`、モバイルフィルター Sheet にも検索入力なし |
| `/reader` がモバイルで使えない | 2 ペインがブレークポイントなしで横並び、左ペイン `w-[380px]` 固定で右ペインが画面外 |
| モバイルに押しても何も起きない「フィルター」ボタンが 2 つ | ButtonV2 が cva に className を渡すだけで twMerge せず、呼び出し側の `hidden` が base の `inline-flex` に負けていた |
| `/papers` 等から開いた記事の「戻る」がホームへ飛ぶ | 共有カード 3 種が戻り先を `/` に固定 |
| デフォルトの card ビューだけキーボードで記事を開けない | `div + onClick` で `tabIndex`/`role`/`onKeyDown` なし（list は `href` を持たない `role="link"`） |

## 実装内容

計画書: `.workflow/docs/plan/plan_20260815_212004_ui_ux_fixes_phase_a.md`（FD-0〜FD-15）

### 基盤（先行）
- **`ButtonV2` の className を `cn()`（twMerge）で結合**（通常経路 + `asChild` の cloneElement 経路）。85 ファイルに影響するため単独コミットに分離し、呼び出し側で単独 `flex` を渡していた 6 箇所は base の `inline-flex` を維持するよう削除

### モバイル対応
- ヘッダー: モバイル `h-12`/`px-4`（デスクトップは `lg:h-10 lg:px-6` で従来維持）、`UserMenu` に `compact` を追加して未認証時は「ログイン」1 ボタン（「新規登録」はメニュー内へ）、`md:` → `lg:` に統一、ハンバーガー/テーマ切替を 44×44 に
- `MobileSearchToggle` を新設し `/`・`/papers`・`/reader` に配置。`SearchBox` のインライン固定幅（`24rem`）を撤去し `w-96 max-w-full` / `fullWidth` prop に
- `ArticleCard`: モバイルはアクションを要約下の通常フロー行へ（要約末尾との重なりを構造的に解消）、`sm` 以上は `group-focus-within` を追加して Tab 到達時に可視化
- `/reader`: `?article=` の有無で 1 ペイン切替。URL 更新は **native History API**（`router.push` だと `force-dynamic` の同ページが毎回 RSC 再取得になるため。実測で記事 5 件連続選択でも RSC リクエスト 0 件）。外側の `key` は `filterParams` から再構成して `article` を除外し、選択のたびの再マウントを防止
- `/trends/diff`: 統計バーをモバイル 2 列に、サブナビを横スクロール化

### 導線・状態
- 共有カード 3 種の戻り先を `usePathname()` ベースに変更（`/papers?returning=1` に正しく戻る）
- 記事詳細の `from` から**二重 decode を撤去**（`search=C%2B%2B` が `C++` → 空白に化けてフィルタが壊れていた）
- フィルタ 8 経路の遷移先パス固定と `article` 残留を共通ヘルパー `lib/utils/url/filter-params.ts` に集約。`/reader` でタグ・日付・カテゴリを選ぶとホームへ離脱していた既存バグも解消
- `ViewModeToggle` を `router.refresh()` 化（読み込み済み記事とスクロール位置を維持）+ 連打制御。`FilterResetButton` は `Promise.allSettled` で部分失敗時も UI を再同期
- `FavoriteButton` に同期イベント購読と世代管理を追加（同一記事が複数並ぶ画面での不整合・遅延応答による巻き戻しを防止）。あわせて `ArticleCard` に `fetchInitialStatus` を追加し、お気に入り状態を渡せない `/favorites/feed`・`/sources/[id]` へ配線（常に「未登録」と表示されていた問題を解消）

### アクセシビリティ
- 記事カード 3 種を **card-with-link** パターンへ（タイトルを `<Link>`、擬似要素でカード全面をクリック領域に、内包ボタンは `relative z-10`）。`role="link"` の誤用を解消（#580）
- ハンバーガーに `aria-label`/`aria-expanded`/`aria-controls`（#581）、日付絵文字に `aria-hidden`（#582）、QA ダイアログをダークモード対応（#583）、AI 検索リンクを primaryNav とモバイルメニューに追加（#585）
- スキップリンク追加、`<main>` の二重ネストを解消（RootLayout の 1 つに）
- reduced-motion を個別クラス列挙から全体抑制 + ローディング例外へ（`animate-ping` 等の漏れを解消）
- `TrendSubNav` の tabs ARIA 誤用を撤去、`topic-card` の hover 専用 UI に開閉ボタンを追加、アイコンのみのリンク/ボタンにアクセシブル名を付与

### その他の修正
- 未認証時に毎回 401 を返していた `/api/user/preferences/categories` の呼び出しを hook 層で抑止（query key にユーザー ID を含めキャッシュも分離）
- `TagCloud` のモジュールレベル `Math.random()` による hydration mismatch を解消

## テスト結果

VERIFY フェーズ（全 Step PASSED）:

| Step | 結果 |
|---|---|
| Lint + Type Check | `eslint` exit=0（**0 errors / 0 warnings**）、`tsc --noEmit` exit=0 |
| Security Audit | `npm audit --audit-level=high` exit=0（high/critical なし） |
| Build | `npm run docker:build` exit=0、全 33 ルート生成完了 |
| Test | 変更影響範囲 **10 suites / 185 tests PASS**、DOM 全体 **49 suites / 613 tests PASS** |
| E2E | card 依存 3 spec（`scroll-restoration` 3 / `tag-search` 1 / `scroll-restoration-button` 2）＝ **6 tests PASS** |
| Diff Review | デバッグコード・秘密情報・ignore 対象の混入なし |
| Visual | 375px / 1920px で全対象ページの水平溢れなし、デスクトップ回帰なし |

Playwright による実測（未認証・dev サーバー）:
- **375 / 414 / 768 / 820 / 1024 / 1280 / 1920 すべてで `scrollWidth === viewport`**、ハンバーガー 44×44 が画面内
- `/reader` 375px でリスト → 詳細 → ブラウザバックが機能、記事 5 件連続選択で RSC リクエスト 0 件
- `/papers` → 記事 → 戻るで `/papers?returning=1` に復帰、`note=a%2Bb` が `a+b` のまま保持
- card / compact / list の 3 モードでお気に入りクリックが記事詳細への誤遷移にならない
- 未認証ホームで preferences API 呼び出し 0 件・4xx/5xx 0 件

## レビュー

- **設計レビュー**（frontend-architect）: Critical 2 / Warning 4 → 全件反映（reader の `key` 衝突、PR 依存関係、stretched-link の z-index 付け漏れ等）
- **cross-review Full Tier**（Codex + Devil's Advocate、盲検並列）: Critical 2 / Warning 15 → 対応 10 件・対応不要 3 件（理由を実装レポートに記録）
  - 両者が独立に指摘した **`from` のバックスラッシュによるオープンリダイレクト**（`?from=%2F%5Cevil.example` が `https://evil.example/` になる）を URL パーサでの同一オリジン検証に変更して修正
  - フィルタ経路の `article` 残留も両者が指摘し、共通ヘルパーで全 8 経路を集約

## 既知の制約・申し送り

- **VRT ベースライン未更新**: `visual-regression.spec.ts` は Docker（`CI=true`）でスキップされる。意図的に見た目を変えているため、ローカル（`CI` 未設定）での `--update-snapshots` が別途必要
- **E2E は card 依存 3 spec のみ実行**。全件（`docker:e2e:fast`）と全ブラウザは未実行
- **認証済み画面は未検証**（AI 検索リンクの表示、`/digest`・`/favorites`・`/history` 等）。ログインできる環境での確認を推奨
- 計画外だが `/reader` の目的達成に必須のため、フィルタ部品のパス固定修正を本 PR に含めた（実装レポートに逸脱として記録）

## チェックリスト

- [x] テスト通過（DOM 613 / E2E 6 / Build / Lint / Type Check）
- [x] ドキュメント更新済み（`.workflow/docs/` の investigate / plan / implement。※ `.workflow/` は gitignore 対象のため PR には含まれない）
- [x] 破壊的変更なし（DB / API / 外部依存の変更なし）

## 関連 Issue

以下は 2026-04 の総合監査（#576）で起票され COMPLETED でクローズされていたが、コードには反映されていなかった。本 PR で実際に実装した（既にクローズ済みのため `Closes` ではなく参照として記載）。

- #580 ArticleCard にキーボード操作対応を追加
- #581 Header モバイル Menu ボタンに aria-label / aria-expanded 追加
- #582 ArticleListItem 絵文字アイコンに aria-hidden 追加
- #583 ArticleQADialog ダークモード対応（デザイントークン化）
- #585 AI 検索リンクを Header primaryNav に追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - モバイルで検索欄を開閉し、入力欄へすぐ移動できるようになりました。
  - リーダー画面にモバイル向けの戻る操作と前後記事ナビゲーションを追加しました。
  - AI検索リンクの表示条件を見直しました。
  - 記事カードのお気に入り状態が複数箇所で同期されます。

- **改善**
  - 記事タイトルを明確なリンクとして操作できるようにしました。
  - フィルターや並べ替え時に不要な選択状態を自動解除します。
  - キーボード操作、スクリーンリーダー、画面幅への対応を強化しました。
  - reduced motion設定時のアニメーションを抑制しました。

- **不具合修正**
  - フィルターリセットの部分的な失敗時も画面状態を適切に更新します。
  - お気に入りの初期取得結果が直前の操作を上書きする問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->